### PR TITLE
Adding ceph tests

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -63,6 +63,7 @@ async def validate_all(model, log_dir):
             cpu_arch not in ['s390x', 'arm64', 'aarch64']):
         await validate_encryption_at_rest(model)
     await validate_dns_provider(model)
+    await validate_ceph(model)
 
 
 @log_calls
@@ -293,32 +294,54 @@ async def verify_deleted(unit, entity_type, name, extra_args=''):
     return True
 
 
-# note that name_list is a list of entities(pods, services, etc) being searched
-# and that partial matches work. If you have a pod with random characters at the
-# end due to being in a deploymnet, you can add just the name of the deployment
-# and it will still match
-async def verify_ready(unit, entity_type, name_list, extra_args=''):
-    cmd = "/snap/bin/kubectl {} --output json get {}".format(extra_args, entity_type)
+async def find_entities(unit, entity_type, name_list, extra_args=''):
+    cmd = "/snap/bin/kubectl {} --output json get {}"
+    cmd = cmd.format(extra_args, entity_type)
     output = await unit.run(cmd)
     if output.results['Code'] != '0':
         # error resource type not found most likely. This can happen when the api server is
         # restarting. As such, don't assume this means ready.
         return False
     out_list = json.loads(output.results['Stdout'])
-
+    matches = []
     for name in name_list:
         # find all entries that match this
-        matches = [n for n in out_list['items'] if name in n['metadata']['name']]
+        [matches.append(n) for n in out_list['items']
+         if name in n['metadata']['name']]
+    return matches
 
-        # now verify they are ALL ready, it isn't cool if just one is ready now
-        ready = [n for n in matches if n['kind'] == 'DaemonSet' or
-                 n['status']['phase'] == 'Running' or
-                 n['status']['phase'] == 'Active']
-        if len(ready) != len(matches):
-            return False
+
+# note that name_list is a list of entities(pods, services, etc) being searched
+# and that partial matches work. If you have a pod with random characters at
+# the end due to being in a deploymnet, you can add just the name of the
+# deployment and it will still match
+async def verify_ready(unit, entity_type, name_list, extra_args=''):
+    matches = await find_entities(unit, entity_type, name_list, extra_args)
+    if not matches:
+        return False
+
+    # now verify they are ALL ready, it isn't cool if just one is ready now
+    ready = [n for n in matches if n['kind'] == 'DaemonSet' or
+             n['status']['phase'] == 'Running' or
+             n['status']['phase'] == 'Active']
+    if len(ready) != len(matches):
+        return False
 
     # made it here then all the matches are ready
     return True
+
+
+# note that name_list is a list of entities(pods, services, etc) being searched
+# and that partial matches work. If you have a pod with random characters at
+# the end due to being in a deploymnet, you can add just the name of the
+# deployment and it will still match
+async def verify_completed(unit, entity_type, name_list, extra_args=''):
+    matches = await find_entities(unit, entity_type, name_list, extra_args)
+    if not matches or len(matches) == 0:
+        return False
+
+    # now verify they are ALL completed - note that is in the phase 'Succeeded'
+    return all([n['status']['phase'] == 'Succeeded' for n in matches])
 
 
 @log_calls_async
@@ -1528,6 +1551,148 @@ async def validate_dns_provider(model):
 
     # Cleanup
     await cleanup()
+
+
+@log_calls_async
+async def validate_ceph(model):
+    async def test_storage_class(model, sc_name):
+        master = model.applications['kubernetes-master'].units[0]
+        # write a string to a file on the pvc
+        pod_definition = """
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {0}-pvc
+  annotations:
+   volume.beta.kubernetes.io/storage-class: {0}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: {0}-write-test
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: {0}-pvc
+      readOnly: false
+  containers:
+    - name: {0}-write-test
+      image: ubuntu
+      command: ["/bin/bash", "-c", "echo 'JUJU TEST' > /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never
+""".format(sc_name)
+        cmd = '/snap/bin/kubectl create -f - << EOF{}EOF'.format(pod_definition)
+        log('Ceph: {} writing test'.format(sc_name))
+        output = await master.run(cmd)
+        assert output.status == 'completed'
+
+        # wait for completion
+        await retry_async_with_timeout(verify_completed,
+                                       (master, 'po', ['{}-write-test'.format(sc_name)]),
+                                       timeout_msg="Unable to create write pod for ceph test")
+
+        # read that string from ceph pvc
+        pod_definition = """
+kind: Pod
+apiVersion: v1
+metadata:
+  name: {0}-read-test
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: {0}-pvc
+      readOnly: false
+  containers:
+    - name: {0}-read-test
+      image: ubuntu
+      command: ["/bin/bash", "-c", "cat /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never
+""".format(sc_name)
+        cmd = '/snap/bin/kubectl create -f - << EOF{}EOF'.format(pod_definition)
+        log('Ceph: {} reading test'.format(sc_name))
+        output = await master.run(cmd)
+        assert output.status == 'completed'
+
+        # wait for completion
+        await retry_async_with_timeout(verify_completed,
+                                       (master, 'po', ['{}-read-test'.format(sc_name)]),
+                                       timeout_msg="Unable to create write pod for ceph test")
+
+        output = await master.run('/snap/bin/kubectl logs {}-read-test'.format(sc_name))
+        assert output.status == 'completed'
+        log('output = {}'.format(output.data['results']['Stdout']))
+        assert 'JUJU TEST' in output.data['results']['Stdout']
+
+        log('Ceph: {} cleanup'.format(sc_name))
+        pods = '{0}-read-test {0}-write-test'.format(sc_name)
+        pvcs = '{}-pvc'.format(sc_name)
+        output = await master.run('/snap/bin/kubectl delete po {}'.format(pods))
+        assert output.status == 'completed'
+        output = await master.run('/snap/bin/kubectl delete pvc {}'.format(pvcs))
+        assert output.status == 'completed'
+
+        await retry_async_with_timeout(verify_deleted,
+                                       (master, 'po', pods),
+                                       timeout_msg="Unable to remove the ceph test pods")
+        await retry_async_with_timeout(verify_deleted,
+                                       (master, 'pvc', pvcs),
+                                       timeout_msg="Unable to remove the ceph test pvc")
+
+    try:
+        # setup
+        log('deploying ceph mon')
+        await model.deploy('ceph-mon', num_units=3)
+        cs = {
+               'osd-devices': {'size': 8 * 1024, 'pool': 'ebs', 'count': 1},
+               'osd-journals': {'size': 8 * 1024, 'pool': 'ebs', 'count': 1}
+             }
+        log('deploying ceph osd')
+        await model.deploy('ceph-osd', storage=cs, num_units=3)
+
+        log('adding relations')
+        await model.add_relation('ceph-mon', 'ceph-osd')
+        await model.add_relation('ceph-mon:admin', 'kubernetes-master')
+        await model.add_relation('ceph-mon:client', 'kubernetes-master')
+        log('waiting...')
+        await asyncify(_juju_wait)()
+
+        # until bug https://bugs.launchpad.net/charm-kubernetes-master/+bug/1824035 fixed
+        action = await model.applications['ceph-mon'].units[0].run_action('create-pool', name='ext4-pool')
+        await action.wait()
+        assert action.status == 'completed'
+
+        log('waiting for csi to settle')
+        unit = model.applications['kubernetes-master'].units[0]
+        await retry_async_with_timeout(verify_ready,
+                                       (unit, 'po', ['csi-rbdplugin']),
+                                       timeout_msg="CSI pods not ready!")
+        # create pod that writes to a pv from ceph
+        await test_storage_class(model, 'ceph-xfs')
+        await test_storage_class(model, 'ceph-ext4')
+        # cleanup
+        (done1, pending1) = await asyncio.wait({
+            model.applications['ceph-mon'].destroy(),
+            model.applications['ceph-osd'].destroy(),
+        })
+        # read and ignore any exception so that it doesn't get raised
+        # when the task is GC'd
+        done1.exception()
+    finally:
+        await asyncify(_juju_wait)()
 
 
 class MicrobotError(Exception):


### PR DESCRIPTION
Test does the following:
 * deploys ceph beside k8s
 * waits for settle

 * creates a pvc backed by xfs
 * creates a pod that writes to that pv
 * creates a pod that reads that pv
 * verifies the contents match

 * creates a pvc backed by ext4
 * creates a pod that writes to that pv
 * creates a pod that reads that pv
 * verifies the contents match

