### PR TITLE
Add new calico-upgrade resource for Calico 3.6

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -6,6 +6,8 @@
 'cs:~containers/calico':
   calico-amd64.tar.gz: calico
   calico-arm64.tar.gz: calico-arm64
+  calico-upgrade-amd64.tar.gz: calico-upgrade
+  calico-upgrade-arm64.tar.gz: calico-upgrade-arm64
 'cs:~containers/flannel':
   flannel-amd64.tar.gz: flannel-amd64
   flannel-arm64.tar.gz: flannel-arm64


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/layer-calico/pull/32