### PR TITLE
Add calico-upgrade resources for canal

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -1,6 +1,8 @@
 'cs:~containers/canal':
   calico-amd64.tar.gz: calico
   calico-arm64.tar.gz: calico-arm64
+  calico-upgrade-amd64.tar.gz: calico-upgrade
+  calico-upgrade-arm64.tar.gz: calico-upgrade-arm64
   flannel-amd64.tar.gz: flannel
   flannel-arm64.tar.gz: flannel-arm64
 'cs:~containers/calico':


### PR DESCRIPTION
Canal builds are currently failing:

```
15:13:22   RAN: /snap/bin/charm release cs:~containers/canal-613 --channel edge --resource calico-163 --resource calico-arm64-160 --resource calico-upgrade--1 --resource calico-upgrade-arm64--1 --resource flannel-161 --resource flannel-arm64-163
15:13:22 
15:13:22   STDOUT:
15:13:22 
15:13:22 
15:13:22   STDERR:
15:13:22 ERROR cannot release charm or bundle: charm does not have resource "calico-upgrade-"
```

This should fix it.