### PR TITLE
Add validate-calico-upgrade jobs

### DIFF
--- a/jobs/integration/test_cdk.py
+++ b/jobs/integration/test_cdk.py
@@ -4,14 +4,8 @@ from .utils import upgrade_charms, upgrade_snaps
 from .validation import validate_all
 from .base import UseModel
 
-namespace = os.environ.get('TEST_CHARM_NAMESPACE', 'containers')
 test_charm_channel = os.environ.get('TEST_CHARM_CHANNEL', 'edge')
-test_snap_channel = os.environ.get('TEST_SNAP_CHANNEL', 'edge')
-test_cloud = os.environ.get('TEST_CLOUD', '')
-upgrade_from_snap_channel = os.environ.get(
-    'UPGRADE_FROM_SNAP_CHANNEL', 'stable')
-upgrade_from_charm_channel = os.environ.get(
-    'UPGRADE_FROM_CHARM_CHANNEL', 'stable')
+test_snap_channel = os.environ.get('TEST_SNAP_CHANNEL')
 
 
 @pytest.mark.asyncio
@@ -26,5 +20,6 @@ async def test_validate(log_dir):
 async def test_upgrade(log_dir):
     async with UseModel() as model:
         await upgrade_charms(model, test_charm_channel)
-        await upgrade_snaps(model, test_snap_channel)
+        if test_snap_channel:
+            await upgrade_snaps(model, test_snap_channel)
         await validate_all(model, log_dir)

--- a/jobs/validate-calico.yaml
+++ b/jobs/validate-calico.yaml
@@ -1,7 +1,7 @@
 # Validates a deployed CDK
 
 - job-template:
-    name: 'validate-calico-{version}'
+    name: '{name}-{version}'
     description: |
       Validates Calico support on {version}
     project-type: pipeline
@@ -28,13 +28,25 @@
       - string:
           name: bundle
           default: 'kubernetes-calico'
+      - string:
+          name: upgrade_from_bundle_channel
+          default: '{upgrade_from_bundle_channel}'
     properties:
       - build-discarder:
           num-to-keep: 2
 
 - project:
     name: validate-calico
+    upgrade_from_bundle_channel: ''
     version:
       !include: includes/k8s-support-matrix.inc
     jobs:
-      - 'validate-calico-{version}'
+      - '{name}-{version}'
+
+- project:
+    name: validate-calico-upgrade
+    upgrade_from_bundle_channel: stable
+    version:
+      !include: includes/k8s-support-matrix.inc
+    jobs:
+      - '{name}-{version}

--- a/jobs/validate-calico/Jenkinsfile
+++ b/jobs/validate-calico/Jenkinsfile
@@ -2,6 +2,9 @@
 
 def juju_model = String.format("%s-%s", params.model, uuid())
 def juju_controller = String.format("%s-%s", params.controller, uuid())
+def upgrade = params.upgrade_from_bundle_channel != ''
+def deploy_channel = upgrade ? params.upgrade_from_bundle_channel : params.bundle_channel
+def test = upgrade ? 'test_upgrade' : 'test_validate'
 
 pipeline {
     agent {
@@ -36,7 +39,7 @@ pipeline {
                           cloud: params.cloud,
                           bundle: "cs:~containers/${params.bundle}",
                           version_overlay: params.overlay,
-                          bundle_channel: params.bundle_channel,
+                          bundle_channel: deploy_channel,
                           disable_wait: true)
                 dir('jobs') {
                     sh "${utils.cipy} integration/tigera/disable_source_dest_check.py -m ${juju_controller}:${juju_model}"
@@ -52,7 +55,7 @@ pipeline {
 
             steps {
                 dir('jobs') {
-                    sh "CONTROLLER=${juju_controller} MODEL=${juju_model} ${utils.pytest} --junit-xml=validate.xml integration/test_cdk.py::test_validate"
+                    sh "CONTROLLER=${juju_controller} MODEL=${juju_model} TEST_CHARM_CHANNEL=${params.bundle_channel} ${utils.pytest} --junit-xml=validate.xml integration/test_cdk.py::${test}"
                 }
             }
         }


### PR DESCRIPTION
This adds new `validate-calico-upgrade-<version>` jobs for testing charm upgrades with Calico.