### PR TITLE
Speculative fix for validate-v1.14.x-canonical-kubernetes-canal not updating

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -99,7 +99,7 @@
 
 
 - job-template:
-    name: 'validate-{name}-{version}-{bundle}'
+    name: 'validate-{version}-{bundle}'
     id: validate-non-core
     description: |
       Validates non core k8s {version} {bundle} deployment.


### PR DESCRIPTION
@battlemidget Is this why validate-v1.14.x-canonical-kubernetes-canal didn't get updated?