### PR TITLE
Fixes in the microk8s pre-release path

### DIFF
--- a/jobs/microk8s/release-pre-releases.py
+++ b/jobs/microk8s/release-pre-releases.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
             if not pre_release:
                 print("No {} pre-release".format(channel[1]))
                 continue
-            snap = Microk8sSnap(track, channel[0])
+            snap = Microk8sSnap(track, channel[0], juju_unit=juju_unit, juju_controller=juju_controller)
             if snap.released and compare_releases(snap.version, pre_release) >= 0 and always_release == 'no':
                 print("Nothing to do because snapstore has {} and pre-release is {} and always-release is {}"
                       .format(snap.released, pre_release, always_release))

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -16,6 +16,7 @@ class Microk8sSnap:
 
         self.juju_unit = juju_unit
         self.juju_controller = juju_controller
+        self.track = track
         self.channel = channel
         revision_info_str = None
         for revision in revisions_list:
@@ -26,7 +27,6 @@ class Microk8sSnap:
             # "180     2018-09-12T15:51:33Z  amd64   v1.11.3    1.11/edge*"
             revision_info = revision_info_str.split()
 
-            self.track = track
             self.under_testing_channel = channel
             if "edge" in self.under_testing_channel:
                 self.under_testing_channel = "{}/under-testing".format(self.under_testing_channel)

--- a/jobs/release-microk8s-pre-release/Jenkinsfile
+++ b/jobs/release-microk8s-pre-release/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 sh "juju kill-controller -y ${params.controller} --destroy-all-models || true"
                 sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
-                sh "juju deploy ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */


### PR DESCRIPTION
Minor fixes in the pre-release path of microk8s.
---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

