### PR TITLE
Set the arch to be model wide constraint

### DIFF
--- a/jobs/release-microk8s-pre-release/Jenkinsfile
+++ b/jobs/release-microk8s-pre-release/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         stage('Provision VM') {
             steps {
                 sh "juju kill-controller -y ${params.controller} --destroy-all-models || true"
-                sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
+                sh "juju bootstrap ${params.cloud} ${params.controller} --constraints arch=${params.arch} --debug"
                 sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64


### PR DESCRIPTION
bootstrap-costraints affect only the controller. We want the units to also be of the selected arch.

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

