### PR TITLE
make cdk-addons great again

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -103,7 +103,7 @@ pipeline {
                 sh """
                     STATIC_KEY=v${params.version}-static:
                     UPSTREAM_KEY=${kube_version}-upstream:
-                    ALL_IMAGES=\$(grep -e \${STATIC_KEY} -e \${UPSTREAM_KEY} ${bundle_image_file} | sed -e "s|\${STATIC_KEY}||g" -e "s|\${UPSTREAM_KEY}||g")
+                    ALL_IMAGES=\$(grep -e \${STATIC_KEY} -e \${UPSTREAM_KEY} ${bundle_image_file} | sed -e "s|\${STATIC_KEY}||g" -e "s|\${UPSTREAM_KEY}||g" -e "s|{{ arch }}|${params.arch}|g")
 
                     TAG_PREFIX=${env.REGISTRY_URL}/cdk
                     TAG_REPLACE='k8s.gcr.io/ quay.io/'

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -129,6 +129,7 @@ pipeline {
                         fi
                     done
 
+                    echo "All images known to this builder:"
                     docker images
                 """
             }
@@ -148,13 +149,14 @@ pipeline {
             steps {
                 dir('jobs'){
                     script {
+                        def kube_ersion = kube_version.substring(1)
                         def snaps_to_release = ['cdk-addons']
                         params.channels.split().each { channel ->
                             snaps_to_release.each  { snap ->
                                 if(params.dry_run) {
-                                    sh "${snap_sh} release --name ${snap} --channel ${channel} --version ${kube_version} --dry-run"
+                                    sh "${snap_sh} release --name ${snap} --channel ${channel} --version ${kube_ersion} --dry-run"
                                 } else {
-                                    sh "${snap_sh} release --name ${snap} --channel ${channel} --version ${kube_version}"
+                                    sh "${snap_sh} release --name ${snap} --channel ${channel} --version ${kube_ersion}"
                                 }
                             }
                         }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -57,11 +57,11 @@ pipeline {
         stage('Build cdk-addons and image list'){
             steps {
                 sh """
-                    if ${params.k8s_tag}
+                    if [ -z "${params.k8s_tag}" ]
                     then
-                        KUBE_VERSION=${params.k8s_tag}
-                    else
                         KUBE_VERSION=\$(curl -L https://dl.k8s.io/release/stable-${params.version}.txt)
+                    else
+                        KUBE_VERSION=${params.k8s_tag}
                     fi
 
                     echo "Building cdk-addons snap."
@@ -94,11 +94,11 @@ pipeline {
         stage('Push Images'){
             steps {
                 sh """
-                    if ${params.k8s_tag}
+                    if [ -z "${params.k8s_tag}" ]
                     then
-                        KUBE_VERSION=${params.k8s_tag}
-                    else
                         KUBE_VERSION=\$(curl -L https://dl.k8s.io/release/stable-${params.version}.txt)
+                    else
+                        KUBE_VERSION=${params.k8s_tag}
                     fi
 
                     STATIC_KEY=v${params.version}-static:

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -63,18 +63,20 @@ pipeline {
                 script {
                     kube_version = sh(returnStdout: true, script: "curl -L https://dl.k8s.io/release/stable-${params.version}.txt").trim()
                 }
-                echo "Set K8s version to: ${kube_version}a"
+                echo "Set K8s version to: ${kube_version}"
             }
         }
         stage('Build cdk-addons and image list'){
             steps {
                 sh """
                     echo "Building cdk-addons snap."
-                    cd cdk-addons && make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version} default; cd -
+                    cd cdk-addons
+                    make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version} default
+                    cd -
 
                     echo "Processing upstream images."
                     UPSTREAM_KEY=${kube_version}-upstream:
-                    UPSTREAM_LINE=\$(cd cdk-addons && make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version} upstream-images 2>/dev/null | grep ^\${UPSTREAM_KEY}; cd -)
+                    UPSTREAM_LINE=\$(cd cdk-addons && make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version} upstream-images 2>/dev/null | grep ^\${UPSTREAM_KEY})
 
                     echo "Updating bundle with upstream images."
                     if grep -q ^\${UPSTREAM_KEY} ${bundle_image_file}

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -61,7 +61,7 @@ pipeline {
             }
             steps {
                 script {
-                    kube_version = sh(returnStdout: true, script: "curl -L https://dl.k8s.io/release/stable-${params.version}.txt")
+                    kube_version = sh(returnStdout: true, script: "curl -L https://dl.k8s.io/release/stable-${params.version}.txt").trim()
                 }
                 echo "Set K8s version to: ${kube_version}a"
             }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -70,7 +70,7 @@ pipeline {
             steps {
                 sh """
                     echo "Building cdk-addons snap."
-                    cd cdk-addons && make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version}; cd -
+                    cd cdk-addons && make KUBE_ARCH=${params.arch} KUBE_VERSION=${kube_version} default; cd -
 
                     echo "Processing upstream images."
                     UPSTREAM_KEY=${kube_version}-upstream:


### PR DESCRIPTION
Lots of trial-and-error to get the cdk-addons job working right.  In addition to getting the right versions for the release branch and k8s source, we now tag and push images to the registry.