### PR TITLE
update job metadata; actually push the snap when not dry-run

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -60,7 +60,12 @@
     name: 'build-release-cdk-addons-{arch}'
     description: |
       Builds, releases and promotes cdk-addons for supported k8s versions on {arch} to the snapstore.
-      Pushes CNI images used by CDK to the Canonical image registry.
+      Container images required by CDK are known during the build, so this job also tags and pushes
+      those to the Canonical image registry.
+
+      The full version of the cdk-addons snap is tied to the upstream k8s tag used during the build.
+      Explicitly set this with the `k8s_tag` parameter, or this job will determine it using the
+      `version` parameter and the contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
     project-type: pipeline
     pipeline-scm:
       scm:
@@ -77,18 +82,20 @@
           name: version
           default: '1.14'
           description: |
-            Kubernetes $major.$minor used to create the cdk-addons release branch.
-            Also used to determine the upstream source tag if not specified with
-            the 'k8s_tag' parameter.
+            Version to build and release. This job will clone (or create as needed) the
+            cdk-addons release-`version` branch, then build and release the snap to the
+            `version`/edge channel.
       - string:
           name: k8s_tag
           default: ''
           description: |
             Source tag from https://github.com/kubernetes/kubernetes. If not specified,
-            the tag will be set to https://dl.k8s.io/release/stable-`version`.txt
+            the tag will be set to https://dl.k8s.io/release/[stable|latest]-`version`.txt.
       - string:
           name: channels
-          default: '1.14.2/edge 1.14.2/beta 1.14.2/candidate 1.14.2/stable'
+          default: '1.14/edge 1.14/beta 1.14/candidate 1.14/stable'
+          description: |
+            Snap store channels to release the built snap to.
       - bool:
           name: dry_run
           default: false

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -143,7 +143,7 @@ pipeline {
                     if(params.dry_run) {
                         echo "Dry run; would have pushed cdk-addons/*.snap to ${params.version}/edge"
                     } else {
-                        echo "snapcraft push cdk-addons/*.snap --release ${params.version}/edge"
+                        sh "snapcraft push cdk-addons/*.snap --release ${params.version}/edge"
                     }
                 }
             }


### PR DESCRIPTION
Couple updates to the cdk-addons job:

- better descriptions
- update the push stage to actually push versus echo'ing what would be done