### PR TITLE
Fix validate-calico not collecting debug properly

### DIFF
--- a/jobs/validate-calico/Jenkinsfile
+++ b/jobs/validate-calico/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
         }
         always {
             setEndTime()
-            collectDebug(params.controller,
+            collectDebug(juju_controller,
                          juju_model)
         }
         cleanup {


### PR DESCRIPTION
Use the correct controller name, defined earlier in the file [here](https://github.com/charmed-kubernetes/jenkins/blob/e9b5008ebaf7192bb768df22cd512122bb81e62d/jobs/validate-calico/Jenkinsfile#L4)