### PR TITLE
Fix timeouts in microk8s jobs

### DIFF
--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 tearDown(params.controller)
                 sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
-                sh "juju deploy ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */
@@ -37,10 +37,8 @@ pipeline {
         }
         stage('Prepare VM') {
             steps {
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxc* -y'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxd* -y'"
                 sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo snap install lxd'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo lxd init --auto'"
+                sh "juju run -m ${params.controller}:default --unit ubuntu/0 --timeout=60m0s 'sudo lxd.migrate -yes'"
             }
         }
         stage('Setup') {

--- a/jobs/release-microk8s-pre-release/Jenkinsfile
+++ b/jobs/release-microk8s-pre-release/Jenkinsfile
@@ -29,10 +29,8 @@ pipeline {
         }
         stage('Prepare VM') {
             steps {
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxc* -y'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxd* -y'"
                 sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo snap install lxd'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo lxd init --auto'"
+                sh "juju run -m ${params.controller}:default --unit ubuntu/0 --timeout=60m0s 'sudo lxd.migrate -yes'"
                 sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo snap install snapcraft --classic'"
             }
         }

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 tearDown(params.controller)
                 sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
-                sh "juju deploy ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */
@@ -36,10 +36,8 @@ pipeline {
         }
         stage('Prepare VM') {
             steps {
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxc* -y'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo apt-get purge lxd* -y'"
                 sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo snap install lxd'"
-                sh "juju run -m ${params.controller}:default --unit ubuntu/0 'sudo lxd init --auto'"
+                sh "juju run -m ${params.controller}:default --unit ubuntu/0 --timeout=60m0s 'sudo lxd.migrate -yes'"
             }
         }
         stage('Setup') {


### PR DESCRIPTION
Make sure we create the ubuntu machine on the right model
Add a longer timeout for migrating to the snapped lxd 

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

