### PR TITLE
Make disable_source_dest_check tolerate removed machines

### DIFF
--- a/jobs/integration/tigera/disable_source_dest_check.py
+++ b/jobs/integration/tigera/disable_source_dest_check.py
@@ -29,7 +29,11 @@ def get_instance_id(machine_id):
     log('Getting instance ID for machine ' + machine_id)
     while True:
         status = get_juju_status()
-        machine = status['machines'][machine_id]
+        machines = status['machines']
+        if machine_id not in machines:
+            log('WARNING: machine %s disappeared' % machine_id)
+            return None
+        machine = machines[machine_id]
         if machine['instance-id'] == 'pending':
             time.sleep(1)
             continue
@@ -52,7 +56,8 @@ def disable_source_dest_check():
     status = get_juju_status()
     for machine_id in status['machines']:
         instance_id = get_instance_id(machine_id)
-        disable_source_dest_check_on_instance(instance_id)
+        if instance_id:
+            disable_source_dest_check_on_instance(instance_id)
 
 
 def main():


### PR DESCRIPTION
Should fix this error:
```
12:10:24 Getting instance ID for machine 6
12:10:25 Traceback (most recent call last):
12:10:25   File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-calico-v1.14.x/jobs/integration/tigera/disable_source_dest_check.py", line 83, in <module>
12:10:25     main()
12:10:25   File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-calico-v1.14.x/jobs/integration/tigera/disable_source_dest_check.py", line 80, in main
12:10:25     disable_source_dest_check()
12:10:25   File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-calico-v1.14.x/jobs/integration/tigera/disable_source_dest_check.py", line 54, in disable_source_dest_check
12:10:25     instance_id = get_instance_id(machine_id)
12:10:25   File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-calico-v1.14.x/jobs/integration/tigera/disable_source_dest_check.py", line 32, in get_instance_id
12:10:25     machine = status['machines'][machine_id]
12:10:25 KeyError: '6'
```

The missing machine 6 was expected. Juju removed it from the model because there were no more units on it.