### PR TITLE
Update validate-snapd to use stable charms

### DIFF
--- a/jobs/integration/test_snapd.py
+++ b/jobs/integration/test_snapd.py
@@ -41,9 +41,7 @@ async def test_snapd(log_dir):
         await enable_snapd_on_model(model)
     await asyncify(juju.deploy)(
         '-m', '{}:{}'.format(_controller_from_env(), _model_from_env()),
-        'cs:~containers/canonical-kubernetes',
-        '--channel', 'edge',
-        '--overlay', 'overlays/1.13-edge-overlay.yaml')
+        'cs:~containers/charmed-kubernetes')
     await asyncify(_juju_wait)()
 
     async with UseModel() as model:


### PR DESCRIPTION
The validate-snapd job failed because of a bug in the edge channels of our charms. I propose we use the stable charms (and stable k8s snaps) when we want to validate snapd releases.