### PR TITLE
Keep fewer runs for Kubeflow bundle push

### DIFF
--- a/jobs/build-bundles.yaml
+++ b/jobs/build-bundles.yaml
@@ -58,4 +58,4 @@
       script-path: jobs/build-bundles/Jenkinsfile.kubeflow
     properties:
       - build-discarder:
-          days-to-keep: 7
+          num-to-keep: 36

--- a/jobs/build-bundles/Jenkinsfile.kubeflow
+++ b/jobs/build-bundles/Jenkinsfile.kubeflow
@@ -93,7 +93,7 @@ pipeline {
         }
         cleanup {
             saveMeta()
-            sh "[[ sudo lxc info ${CONTAINER} ]] && sudo lxc delete --force ${CONTAINER}"
+            sh "sudo lxc delete --force ${CONTAINER} || true"
         }
     }
 }


### PR DESCRIPTION
Since it runs every 10 minutes, keeping 7 days is a long time. Instead,
keep last 6 hours.

Also, go with simpler cleanup syntax
