### PR TITLE
Bigger machines to host lxc containers for MicroK8s tests

### DIFF
--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 tearDown(params.controller)
                 sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
-                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */

--- a/jobs/release-microk8s-pre-release/Jenkinsfile
+++ b/jobs/release-microk8s-pre-release/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 tearDown(params.controller)
                 sh "juju bootstrap ${params.cloud} ${params.controller} --constraints arch=${params.arch} --debug"
-                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 tearDown(params.controller)
                 sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch} --debug"
-                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=4 mem=16G root-disk=40G'"
+                sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64
                 */


### PR DESCRIPTION
Chasing after some flakiness and want to make sure machines do not get in the way.

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

