### PR TITLE
Fix bash exec in Kubeflow job

### DIFF
--- a/jobs/validate-kubeflow-aws/Jenkinsfile
+++ b/jobs/validate-kubeflow-aws/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('juju-pipeline@master') _
 
 def exec(cmd) {
-    sh "sudo lxc exec ${CONTAINER} -- bash -c '${cmd}'"
+    sh "sudo lxc exec ${CONTAINER} -- bash -c 'cd . && ${cmd}'"
 }
 
 pipeline {

--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('juju-pipeline@master') _
 
 def exec(cmd) {
-    sh "juju ssh -m ${CONTROLLER}:default ubuntu/0 -- bash -c '${cmd}'"
+    sh "juju ssh -m ${CONTROLLER}:default ubuntu/0 -- bash -c 'cd . && ${cmd}'"
 }
 
 pipeline {


### PR DESCRIPTION
Jenkins doesn't like just having `'${cmd}'`, but does like having some sort of `&&` in there.
