### PR TITLE
Fix Vault test not actually running

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -59,7 +59,7 @@ async def validate_all(model, log_dir):
     if cpu_arch not in ['s390x', 'arm64', 'aarch64']:
         await validate_keystone(model)
     assert_no_unit_errors(model)
-    if ('validate-vault' == model.name and
+    if ('validate-vault' == model.info.name and
             cpu_arch not in ['s390x', 'arm64', 'aarch64']):
         await validate_encryption_at_rest(model)
     await validate_dns_provider(model)

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -59,7 +59,7 @@ async def validate_all(model, log_dir):
     if cpu_arch not in ['s390x', 'arm64', 'aarch64']:
         await validate_keystone(model)
     assert_no_unit_errors(model)
-    if ('vault' in model.applications and
+    if ('validate-vault' == model.name and
             cpu_arch not in ['s390x', 'arm64', 'aarch64']):
         await validate_encryption_at_rest(model)
     await validate_dns_provider(model)


### PR DESCRIPTION
The condition to run the Vault test logic was missed in the refactor in PR #282 causing the Vault parts of the tests to never run. This changes it to drive the Vault test off the model name.