### PR TITLE
Use containerd in canonical-kubernetes-canal bundle

### DIFF
--- a/jobs/includes/charm-bundles-list.inc
+++ b/jobs/includes/charm-bundles-list.inc
@@ -16,7 +16,7 @@
     namespace: containers/bundle
     tags: ['k8s', 'kubernetes-calico']
 - canonical-kubernetes-canal:
-    fragments: 'k8s/cdk cni/canal cri/docker'
+    fragments: 'k8s/cdk cni/canal cri/containerd'
     namespace: containers/bundle
     tags: ['k8s', 'canonical-kubernetes-canal']
 - kubernetes-tigera-secure-ee:


### PR DESCRIPTION
Canal with containerd should work now that https://github.com/charmed-kubernetes/layer-canal/pull/34 is merged and [in stable](https://github.com/charmed-kubernetes/layer-canal/commits/stable).