### PR TITLE
Move Kubeflow bundle push trigger to JJB

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -60,6 +60,8 @@
     properties:
       - build-discarder:
           num-to-keep: 36
+    triggers:
+      - timed: "H/10 * * * *"
 
 - job:
     name: 'build-k8s-bundles'

--- a/jobs/build-charms/kubeflow.groovy
+++ b/jobs/build-charms/kubeflow.groovy
@@ -21,9 +21,6 @@ pipeline {
         ansiColor('xterm')
         timestamps()
     }
-    triggers {
-        pollSCM('*/10 * * * *')
-    }
     stages {
         stage('Set Start Time') {
             steps {


### PR DESCRIPTION
Since the `trigger` pipeline section and JJB will otherwise fight over the value, and JJB wins.