### PR TITLE
Specify charm store namespace for Kubeflow bundle

### DIFF
--- a/jobs/build-charms/kubeflow.groovy
+++ b/jobs/build-charms/kubeflow.groovy
@@ -70,7 +70,7 @@ pipeline {
         stage('Release Kubeflow Bundle') {
             steps {
                 exec 'git clone https://github.com/juju-solutions/bundle-kubeflow.git'
-                exec 'cd bundle-kubeflow && CHARM_BUILD_DIR=/tmp/charms juju bundle publish --url cs:kubeflow'
+                exec 'cd bundle-kubeflow && CHARM_BUILD_DIR=/tmp/charms juju bundle publish --url cs:~kubeflow-charmers/kubeflow'
             }
             when { expression { ゴゴゴ } }
         }


### PR DESCRIPTION
Otherwise it gets pushed up to the cdkbot namespace.