### PR TITLE
Fix region/AZ for Tigera bootstrap script

### DIFF
--- a/jobs/integration/tigera/bootstrap_aws_single_subnet.py
+++ b/jobs/integration/tigera/bootstrap_aws_single_subnet.py
@@ -7,8 +7,8 @@ from pprint import pprint
 
 VPC_CIDR = "172.30.0.0/24"
 SUBNET0_CIDR = "172.30.0.0/24"
-REGION = "us-east-2a"
-AVAILABILITY_ZONE = "us-east-1b"
+REGION = "us-east-2"
+AVAILABILITY_ZONE = "us-east-2a"
 
 
 def aws(*args):


### PR DESCRIPTION
Looks like this got messed up when we moved everything over from us-east-1 to us-east-2. Hopefully this will fix the calico/tigera validation.