### PR TITLE
use stable layer branch in bugfix release; be explicit with k8s tag

### DIFF
--- a/jobs/release/charmBugfix.groovy
+++ b/jobs/release/charmBugfix.groovy
@@ -29,9 +29,12 @@ pipeline {
             steps {
                 build job:"build-charms",
                     parameters: [string(name:'charm_branch', value: 'stable'),
+                                 string(name:'layer_branch', value: 'stable'),
+                                 string(name:'tag', value: 'k8s'),
                                  string(name:'to_channel', value: params.charm_promote_to)]
                 build job:"build-k8s-bundles",
-                    parameters: [string(name:'to_channel', value: 'candidate')]
+                    parameters: [string(name:'to_channel', value: 'candidate'),
+                                 string(name:'tag', value: 'k8s')]
             }
             post {
                 failure {


### PR DESCRIPTION
Without this, build-charms uses the `master` branch for dependent layers.  We want the `stable` branch for a bugfix release.

Adding the tag param just to be explicit, even though the current job defaults this to `k8s`. We *always* want it to be `k8s` when building charms/bundles for a bugfix release.