### PR TITLE
switch image-registry references to rocks

### DIFF
--- a/jobs/aws-iam-docker/README.md
+++ b/jobs/aws-iam-docker/README.md
@@ -6,5 +6,5 @@
 
 Build aws-iam-authenticator from source and published the image. The default values pull from
 github.com/kubernetes-sigs/aws-iam-authenticator and push to
-image-registry.canonical.com:5000/cdk/aws-iam-authenticator. By default, the source will be changed
+rocks.canonical.com:5000/cdk/aws-iam-authenticator. By default, the source will be changed
 to the latest release tag and the image will be tagged the same.

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -16,7 +16,7 @@ pipeline {
         PATH = "${utils.cipaths}"
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
-        REGISTRY_URL = 'upload.image-registry.canonical.com:5000'
+        REGISTRY_URL = 'upload.rocks.canonical.com:5000'
         REGISTRY_REPLACE = 'docker.io/ k8s.gcr.io/ quay.io/'
     }
     options {


### PR DESCRIPTION
Related to https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841469, we're moving all our default registry settings to `rocks.canonical.com`.