### PR TITLE
Fix netpolicy-test Deployment API version for 1.16

### DIFF
--- a/jobs/integration/templates/netpolicy-test.yaml
+++ b/jobs/integration/templates/netpolicy-test.yaml
@@ -3,13 +3,16 @@ kind: Namespace
 metadata:
   name: netpolicy
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
   namespace: netpolicy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:


### PR DESCRIPTION
This should fix the failure seen in validate-tigera-secure-ee. The extensions/v1beta1 API for Deployments has been removed in k8s 1.16.

I gave this a quick test run against `cs:~containers/kubernetes-calico --channel edge` and got a passing result.

Related to https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1841674