### PR TITLE
Fix Vault test failure due to percona-cluster being in "dying" state

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1243,6 +1243,18 @@ data:
 async def test_encryption_at_rest(model, tools):
     try:
         # setup
+        if 'percona-cluster' in model.applications and \
+           model.applications['percona-cluster'].life != 'alive':
+            try:
+                await model.block_until(
+                    lambda: ('percona-cluster' not in model.applications or
+                             model.applications['percona-cluster'].life == 'alive'),
+                    timeout=120)
+            except asyncio.TimeoutError:
+                life = model.applications['percona-cluster'].life
+                pytest.fail('Timed out waiting for percona-cluster '
+                            'to settle or go away ({} != alive)'.format(life))
+
         if 'percona-cluster' not in model.applications:
             await model.deploy(
                 "percona-cluster",


### PR DESCRIPTION
I would have expected `juju-wait` to wait for the application to fully go away, but apparently it does not, so we have to do it ourselves.