### PR TITLE
Changing agent label

### DIFF
--- a/jobs/validate-aws-iam/Jenkinsfile
+++ b/jobs/validate-aws-iam/Jenkinsfile
@@ -5,7 +5,7 @@ def juju_controller = String.format("%s-%s", params.controller, uuid())
 
 pipeline {
     agent {
-        label "${params.build_node}"
+        label "runner"
     }
     /* XXX: Global $PATH setting doesn't translate properly in pipelines
      https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh


### PR DESCRIPTION
Any node with the label runner can handle this job. Originally it was copy-pasted from another Jenkinsfile that controlled this with a parameter. No parameter on this side made it null and explode.


