### PR TITLE
Setting the default models for the microk8s controllers

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -211,7 +211,7 @@ class Microk8sSnap:
 
         """
         if self.juju_unit:
-            cmd_array = "juju run -m {} --timeout=60m0s --unit {}".format(
+            cmd_array = "juju run -m {} --timeout=90m0s --unit {}".format(
                 self.juju_controller, self.juju_unit
             ).split()
             cmd_array.append(cmd)

--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         stage('Provision VM') {
             steps {
                 tearDown(params.controller)
-                sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch}"
+                sh "juju bootstrap ${params.cloud} ${params.controller} -d microk8s-model --bootstrap-constraints arch=${params.arch}"
                 sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64

--- a/jobs/release-microk8s-pre-release/Jenkinsfile
+++ b/jobs/release-microk8s-pre-release/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         stage('Provision VM') {
             steps {
                 tearDown(params.controller)
-                sh "juju bootstrap ${params.cloud} ${params.controller} --constraints arch=${params.arch}"
+                sh "juju bootstrap ${params.cloud} ${params.controller} -d microk8s-model --constraints arch=${params.arch}"
                 sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         stage('Provision VM') {
             steps {
                 tearDown(params.controller)
-                sh "juju bootstrap ${params.cloud} ${params.controller} --bootstrap-constraints arch=${params.arch}"
+                sh "juju bootstrap ${params.cloud} ${params.controller} -d microk8s-model --bootstrap-constraints arch=${params.arch}"
                 sh "juju deploy -m ${params.controller}:default ubuntu --constraints 'cores=8 mem=32G root-disk=80G'"
                 /* g3s.xlarge and p2.xlarge are for gpu
                    a1.2xlarge for arm, t2.xlarge for amd64


### PR DESCRIPTION
So jobs do not get killed.

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

