### PR TITLE
Increase mk8s jobs timeouts

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -211,10 +211,11 @@ class Microk8sSnap:
 
         """
         if self.juju_unit:
-            cmd_array = "juju run -m {} --timeout=90m0s --unit {}".format(
+            cmd_array = "juju run -m {} --timeout=120m0s --unit {}".format(
                 self.juju_controller, self.juju_unit
             ).split()
             cmd_array.append(cmd)
         else:
             cmd_array = cmd.split()
+        print("Executing: {}".format(cmd_array))
         return cmd_array

--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     options {
         ansiColor('xterm')
         timestamps()
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
     }
 
     stages {

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     options {
         ansiColor('xterm')
         timestamps()
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
     }
     stages {
         stage('Provision VM') {


### PR DESCRIPTION
I have to increase the timeouts. 
---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

