### PR TITLE
Fix netpolicy-test Deployment API version for 1.16

### DIFF
--- a/jobs/integration/templates/netpolicy-test.yaml
+++ b/jobs/integration/templates/netpolicy-test.yaml
@@ -3,13 +3,16 @@ kind: Namespace
 metadata:
   name: netpolicy
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
   namespace: netpolicy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:


### PR DESCRIPTION
---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

# IF YOUR PR DEPENDS ON SOME OTHER CODE THATS NOT YET MERGED PREFIX YOUR PR WITH `WIP:`

