### PR TITLE
Fix secret value in encryption test not being b64 encoded

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -10,6 +10,7 @@ import pytest
 import juju
 from asyncio_extras import async_contextmanager
 from async_generator import yield_
+from base64 import b64encode
 from datetime import datetime
 from .logger import log
 from pprint import pformat
@@ -1293,7 +1294,7 @@ async def test_encryption_at_rest(model, tools):
         # read secret
         output = await worker.run("kubectl get secret test-secret -o yaml")
         assert output.status == "completed"
-        assert "secret-value" in output.results["Stdout"]
+        assert b64encode(b"secret-value").decode("utf8") in output.results["Stdout"]
         # verify secret is encrypted
         etcd = model.applications["etcd"].units[0]
         etcd.run(
@@ -1302,7 +1303,7 @@ async def test_encryption_at_rest(model, tools):
             "get /registry/secrets/default/test-secret | hexdump -C"
         )
         assert output.status == "completed"
-        assert "secret-value" not in output.results["Stdout"]
+        assert b64encode(b"secret-value").decode("utf8") not in output.results["Stdout"]
     finally:
         # cleanup
         if "vault" in model.applications:


### PR DESCRIPTION
Secrets, when read back via kubectl, come out base64 encoded, so the test needs to do the same to validate it.