### PR TITLE
Add script to build addon-resizer for multiple architectures

### DIFF
--- a/jobs/build-addon-resizer/addon-resizer-arch-support.diff
+++ b/jobs/build-addon-resizer/addon-resizer-arch-support.diff
@@ -1,0 +1,13 @@
+diff --git a/addon-resizer/Makefile b/addon-resizer/Makefile
+index 4fdfe3f..b2c4516 100644
+--- a/addon-resizer/Makefile
++++ b/addon-resizer/Makefile
+@@ -35,7 +35,7 @@ deps:
+ 		go get -u github.com/tools/godep
+ 
+ compile: nanny/ deps
+-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -o $(OUT_DIR)/pod_nanny nanny/main/pod_nanny.go
++		GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 godep go build -a -o $(OUT_DIR)/pod_nanny nanny/main/pod_nanny.go
+ 
+ test: nanny/
+ 		godep go test ${PACKAGE}/nanny -v

--- a/jobs/build-addon-resizer/build-addon-resizer.sh
+++ b/jobs/build-addon-resizer/build-addon-resizer.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eux
+
+# This script builds the addon-resizer image for multiple architectures and
+# pushes them to rocks.canonical.com.
+#
+# Assumes docker is available on the host environment and has been logged in
+# to upload.rocks.canonical.com.
+
+addon_resizer_version="1.8.5"
+golang_version="1.10.8"
+arches="amd64 arm64 s390x"
+registry="upload.rocks.canonical.com:5000/cdk"
+
+root_dir="$(readlink -f "$(dirname $0)")"
+temp_dir="$root_dir/build-addon-resizer.tmp"
+
+rm -rf "$temp_dir"
+mkdir "$temp_dir"
+cd "$temp_dir"
+
+wget https://dl.google.com/go/go$golang_version.linux-amd64.tar.gz
+tar -xf go$golang_version.linux-amd64.tar.gz
+export GOPATH="$temp_dir/gopath"
+export PATH="$GOPATH/bin:$temp_dir/go/bin:$PATH"
+go version
+
+go get -d k8s.io/autoscaler/addon-resizer
+cd "$GOPATH/src/k8s.io/autoscaler/addon-resizer"
+git checkout addon-resizer-$addon_resizer_version
+git apply "$root_dir/addon-resizer-arch-support.diff"
+
+for arch in $arches; do
+  make build REGISTRY=$registry IMGNAME=addon-resizer-$arch ARCH=$arch
+  docker push $registry/addon-resizer-$arch:$addon_resizer_version
+done
+
+rm -rf "$temp_dir"


### PR DESCRIPTION
Standalone script to build addon-resizer 1.8.5 for multiple architectures and upload them to upload.rocks.canonical.com.

We could make a whole jenkins job for this, but I'm struggling to see the value in it. We won't need to run it often, and the diff means it's probably going to break as soon as we bump versions anyway. I wrote this mostly to document how it's done.