### PR TITLE
skip images that we already host

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -136,8 +136,14 @@ pipeline {
 
                     for i in \${ALL_IMAGES}
                     do
-                        # Skip images that dont exist for this arch; other pull failures will
-                        # manifest themselves when we attempt to tag.
+                        # Skip images that we already host
+                        if echo \${i} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
+                        then
+                            continue
+                        fi
+
+                        # Skip images that dont exist (usually due to non-existing arch). Other
+                        # pull failures will manifest themselves when we attempt to tag.
                         if docker pull \${i} 2>&1 | grep -qi 'no matching manifest for'
                         then
                             continue


### PR DESCRIPTION
We host some images (like `addons-resizer-$arch`) in our registry already.  No need to pull/tag/push these since they're already there.  Fixes cdk-addons job errors like this -- notice the 2nd operand of `docker tag` has `rocks.c.c` in it because that's not one of the registries we replace:

```
07:11:58 + RAW_IMAGE=rocks.canonical.com/cdk/addon-resizer-amd64:1.8.5
07:11:58 + docker tag rocks.canonical.com/cdk/addon-resizer-amd64:1.8.5 upload.rocks.canonical.com:5000/cdk/rocks.canonical.com/cdk/addon-resizer-amd64:1.8.5
07:11:58 Error response from daemon: No such image: rocks.canonical.com/cdk/addon-resizer-amd64:1.8.5
```