### PR TITLE
use single equality for compat with both bash and sh

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -62,7 +62,7 @@ pipeline {
                     else
                         echo "Getting cdk-addons from master branch."
                         git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
-                        if [ "${kube_status}" == "stable" ]
+                        if [ "${kube_status}" = "stable" ]
                         then
                             echo "Creating \$ADDONS_BRANCH for cdk-addons."
                             cd cdk-addons


### PR DESCRIPTION
Jenkins shell uses `/bin/sh`, which doesn't like `==` for testing string equality:
```
13:51:45 Getting cdk-addons from master branch.
13:51:45 + git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
13:51:45 Cloning into 'cdk-addons'...
13:51:47 + [ stable == stable ]
13:51:47 /var/lib/jenkins/slaves/jenkins-slave-6/workspace/build-release-cdk-addons-amd64-1.16@tmp/durable-dcbfaee8/script.sh: 11: [: stable: unexpected operator
[Pipeline] sh
```

Proper string equality within single brackets is a single `=` (for bash, dash, sh, and others).