### PR TITLE
update url for dashboard-2.x used in 1.16+

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -339,8 +339,10 @@ async def test_dashboard(model, log_dir, tools):
     # dashboard will present a login form prompting for login
     if k8s_version < (1, 8):
         url = "%s/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/login"
-    else:
+    elif k8s_version < (1, 16):
         url = "%s/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login"
+    else:
+        url = "%s/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#!/login"
     url %= config["clusters"][0]["cluster"]["server"]
 
     log("Waiting for dashboard to stabilize...")


### PR DESCRIPTION
The 1.10.1 dashboard token auth no longer works in 1.16:

https://bugs.launchpad.net/cdk-addons/+bug/1845219

We've updated 1.16 to use dashboard-2.0.0-beta4:

https://github.com/charmed-kubernetes/cdk-addons/pull/149

The dashboard URL has changed in this version, so let's get it right in our validation test.