### PR TITLE
Add test for toggling metrics on/off

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -101,8 +101,11 @@ class Tools:
                 f"{stdout.decode()}\nstderr: {stderr.decode()}"
             )
 
-    async def juju_wait(self):
-        return await self.run(f"juju wait -e {self.connection} -w")
+    async def juju_wait(self, timeout_secs=None):
+        cmd = f"juju wait -e {self.connection} -w"
+        if timeout_secs:
+            cmd = f"{cmd} -t {timeout_secs}"
+        return await self.run(cmd)
 
 
 @pytest.fixture(scope="module")

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -283,6 +283,7 @@ async def verify_ready(unit, entity_type, name_list, extra_args=""):
         n
         for n in matches
         if n["kind"] == "DaemonSet"
+        or n["kind"] == "Service"
         or n["status"]["phase"] == "Running"
         or n["status"]["phase"] == "Active"
     ]


### PR DESCRIPTION
The new tests check that the right things happen when the enable-metrics
config on kubernetes-master is toggled on and off:

- Test that workload status returns to 'active' within a 2-minute
timeout
- Test that the metrics-server Service is present when
enable-metrics=True
- Test that the metrics-server Service is not present when
enable-metrics=False

In support of this, the patch includes two other changes:

- Add a way to pass a timeout to juju-wait
- Fix a bug that made verify_ready() not work for Services (Services do
not have a svc['status']['phase'] key in their json output)

This test is being added in support of
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1845962. I ran
the tests against kubernetes-master-747 (current stable), and a patched
version that contains the fix for lp-1845962, and confirmed that:

- The new test fails on kubernetes-master-747
- The new tests passes on the patched kubernetes-master
- All of the validation tests pass on the patched kubernetes-master

Depends on: https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/62
