### PR TITLE
Use different controllers for microk8s arm and amd

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -4,14 +4,14 @@ plan:
       - DRY_RUN="no"
       - ALWAYS_RELEASE="no"
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-beta
+      - JUJU_CONTROLLER=release-microk8s-beta-amd64
       - JUJU_MODEL=release-microk8s-beta-model
       - ARCH=amd64
     tags:
       - amd64/beta
       - amd64
     before-script:
-      - python3 jobs/infra/collect-debug.py set-key 'job_name_custom' "$JUJU_CONTROLLER-$ARCH"
+      - python3 jobs/infra/collect-debug.py set-key 'job_name_custom' "$JUJU_CONTROLLER"
       - |
         #!/bin/bash
         set -x
@@ -55,7 +55,7 @@ plan:
       - DRY_RUN=no
       - ALWAYS_RELEASE=no
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-beta
+      - JUJU_CONTROLLER=release-microk8s-beta-arm64
       - JUJU_MODEL=release-microk8s-beta-model
       - ARCH=arm64
     tags:
@@ -66,7 +66,7 @@ plan:
       - DRY_RUN=no
       - ALWAYS_RELEASE=no
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-stable
+      - JUJU_CONTROLLER=release-microk8s-stable-arm64
       - JUJU_MODEL=release-microk8s-stable-model
       - ARCH=arm64
     tags:
@@ -86,7 +86,7 @@ plan:
       - DRY_RUN=no
       - ALWAYS_RELEASE=no
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-stable
+      - JUJU_CONTROLLER=release-microk8s-stable-amd64
       - JUJU_MODEL=release-microk8s-stable-model
       - ARCH=amd64
     tags:
@@ -106,7 +106,7 @@ plan:
       - DRY_RUN=no
       - ALWAYS_RELEASE=no
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-pre-release
+      - JUJU_CONTROLLER=release-microk8s-pre-release-amd64
       - JUJU_MODEL=release-microk8s-pre-release-model
       - ARCH=amd64
     tags:
@@ -125,7 +125,7 @@ plan:
       - DRY_RUN=no
       - ALWAYS_RELEASE=no
       - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-pre-release
+      - JUJU_CONTROLLER=release-microk8s-pre-release-arm64
       - JUJU_MODEL=release-microk8s-pre-release-model
       - ARCH=arm64
     tags:


### PR DESCRIPTION
The two jobs fail if queued at the same time. Even if you disagree with this PR please merge it for a couple of day to help me debug this.

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
