### PR TITLE
Adding missing snapcraft in VMs doing the microk8s pre-release

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -116,6 +116,8 @@ plan:
       - |
         #!/bin/bash
         set -x
+
+        juju ssh -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --pty=true ubuntu/0 -- 'sudo snap install snapcraft --classic''
         DRY_RUN=$DRY_RUN ALWAYS_RELEASE=$ALWAYS_RELEASE \
           TRACKS=$TRACKS TESTS_BRANCH=$TESTS_BRANCH \
           PROXY=$PROXY JUJU_UNIT=ubuntu/0 \
@@ -135,6 +137,8 @@ plan:
       - |
         #!/bin/bash
         set -x
+
+        juju ssh -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --pty=true ubuntu/0 -- 'sudo snap install snapcraft --classic''
         DRY_RUN=$DRY_RUN ALWAYS_RELEASE=$ALWAYS_RELEASE \
           TRACKS=$TRACKS TESTS_BRANCH=$TESTS_BRANCH \
           PROXY=$PROXY JUJU_UNIT=ubuntu/0 \


### PR DESCRIPTION
Pre-releases need to build the MicroK8s snap, so they need snapcraft. 

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
