### PR TITLE
Disconnect latest stable from master branch

### DIFF
--- a/jobs/microk8s/update-gh-branches-and-lp-builders.py
+++ b/jobs/microk8s/update-gh-branches-and-lp-builders.py
@@ -85,13 +85,13 @@ class Builder:
     This class encapsulated all the functionality we need to manipulate the LP builders
     """
 
-    def __init__(self, track, is_latest=False):
+    def __init__(self, track, build_from_master=False):
         self.track = track
         self.is_latest = is_latest
         # the latest and the latest stable tracks (1.12 at the time of this writing)
         # build from the master head GH repo
         self.gh_branch = (
-            "refs/heads/master" if is_latest else "refs/heads/{}".format(track)
+            "refs/heads/master" if build_from_master else "refs/heads/{}".format(track)
         )
         self.snap = None
         self.lp = None
@@ -200,7 +200,8 @@ if __name__ == "__main__":
             continue
 
         # Take care of the LP builders
-        builder = Builder(track, is_latest(track))
+        build_from_master = is_latest(track) and not gh_branch_exists(track)
+        builder = Builder(track, build_from_master)
         if not builder.exists():
             builder.create()
         else:


### PR DESCRIPTION
With this PR we want to make sure that if there is a branch on GH for any track even the current stable (eg 1.16 at the time of this PR) that branch will be used in the LP builders.

The behavior we have until now is that the current stable and the latest stable LP builders build from the master GH branch.  

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
