### PR TITLE
Fix test_audit_webhook for k8s 1.17

### DIFF
--- a/jobs/integration/templates/test-audit-webhook.yaml
+++ b/jobs/integration/templates/test-audit-webhook.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-audit-webhook
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 80;
+        location / {
+          return 200;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-audit-webhook
+spec:
+  volumes:
+  - name: nginx-config
+    configMap:
+      name: test-audit-webhook
+  containers:
+  - name: nginx
+    image: nginx:1.15.0-alpine
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: nginx-config
+      mountPath: /etc/nginx


### PR DESCRIPTION
This fixes a failure that occurs during test_audit_webhook on k8s 1.17.

The test is failing because the test-audit-webhook pod responds to audit events with HTTP 405 Method Not Allowed. In k8s 1.16 and earlier, this didn't cause any problems, but in k8s 1.17 it causes kube-apiserver to block and stop serving responses (see the [upstream PR](https://github.com/kubernetes/kubernetes/pull/83238)).

This PR fixes it by configuring nginx on the test-audit-webhook pod to respond with HTTP 200 OK.