### PR TITLE
update to include kube-masters interface

### DIFF
--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -68,6 +68,10 @@
     downstream: "charmed-kubernetes/interface-kube-dns.git"
     upstream: "https://github.com/juju-solutions/interface-kube-dns.git"
     tags: ['k8s']
+- interface:kube-masters:
+    downstream: "charmed-kubernetes/interface-kube-masters.git"
+    upstream: "https://github.com/charmed-kubernetes/interface-kube-masters.git"
+    tags: ['k8s']
 - interface:kubernetes-cni:
     downstream: "charmed-kubernetes/interface-kubernetes-cni.git"
     upstream: "https://github.com/juju-solutions/interface-kubernetes-cni.git"

--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -200,6 +200,10 @@
     downstream: "charmed-kubernetes/layer-cis-benchmark.git"
     upstream: "https://github.com/charmed-kubernetes/layer-cis-benchmark.git"
     tags: ['k8s']
+- layer:coordinator:
+    downstream: "charmed-kubernetes/layer-coordinator.git"
+    upstream: "https://git.launchpad.net/layer-coordinator"
+    tags: ['k8s']
 - layer:index:
     downstream: "charmed-kubernetes/layer-index.git"
     upstream: "https://github.com/juju/layer-index.git"


### PR DESCRIPTION
Masters need a peer interface to enable snap coherence:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1845559

Edit: We also now need `layer-coordinator` for masters and workers to roll out the snap refreshes safely.  Adding that to our list of includes.  Both of these forks have `master|candidate|hotfix|stable` branches like our other forks.