### PR TITLE
Disabling arm prereleases until snapcraft suports lxd

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -122,28 +122,6 @@ plan:
           TRACKS=$TRACKS TESTS_BRANCH=$TESTS_BRANCH \
           PROXY=$PROXY JUJU_UNIT=ubuntu/0 \
           python3 jobs/microk8s/release-pre-releases.py
-  - <<: *BASE_JOB
-    env:
-      - DRY_RUN=no
-      - ALWAYS_RELEASE=no
-      - JUJU_CLOUD=aws/us-east-1
-      - JUJU_CONTROLLER=release-microk8s-pre-release-arm64
-      - JUJU_MODEL=release-microk8s-pre-release-model
-      - ARCH=arm64
-    tags:
-      - arm64/prerelease
-      - arm64
-    script:
-      - |
-        #!/bin/bash
-        set -x
-
-        juju ssh -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --pty=true ubuntu/0 -- 'sudo snap install snapcraft --classic'
-        DRY_RUN=$DRY_RUN ALWAYS_RELEASE=$ALWAYS_RELEASE \
-          TRACKS=$TRACKS TESTS_BRANCH=$TESTS_BRANCH \
-          PROXY=$PROXY JUJU_UNIT=ubuntu/0 \
-          python3 jobs/microk8s/release-pre-releases.py
-
 
 meta:
   name: Release Microk8s to Beta, Stable


### PR DESCRIPTION
Building microk8s for arm64 is failing because snapcraft does not have the right lxc image for that architecture. Disabling it until this is fixed.

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
