### PR TITLE
force tag creation

### DIFF
--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -129,7 +129,7 @@ def _tag_stable_forks(
                 git.checkout("stable", _cwd=identifier)
                 try:
                     for line in git.tag(
-                        tag, _cwd=identifier, _iter=True, _bg_exc=False
+                        "--force", tag, _cwd=identifier, _iter=True, _bg_exc=False
                     ):
                         click.echo(line)
                     for line in git.push(


### PR DESCRIPTION
If we're creating a bugfix release, we always want the bugfix_rev tag to be the most current bits from stable.  Force tag creation to make sure this happens.

Without this, we may have a situation where a bugfix release was created, then failed QA, then had more stable bits merged.  If this happens, the pre-existing tag won't match the latest stable code.

By forcing tag creation, we'll always tag the current stable branch with the tag name.