### PR TITLE
force push tags

### DIFF
--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -133,7 +133,7 @@ def _tag_stable_forks(
                     ):
                         click.echo(line)
                     for line in git.push(
-                        "origin", tag, _cwd=identifier, _bg_exc=False, _iter=True
+                        "--force", "origin", tag, _cwd=identifier, _bg_exc=False, _iter=True
                     ):
                         click.echo(line)
                 except sh.ErrorReturnCode as error:


### PR DESCRIPTION
Just in case we need to push an existing tag again, we'll need --force.

This is part deux of https://github.com/charmed-kubernetes/jenkins/pull/550