### PR TITLE
Fix Kubeflow bundle publishing process

### DIFF
--- a/jobs/build-charms/kubeflow.groovy
+++ b/jobs/build-charms/kubeflow.groovy
@@ -71,6 +71,12 @@ pipeline {
         }
         stage('Release Kubeflow Bundle') {
             steps {
+                // Copy forked mysql interface from charmed-osm into interfaces dir
+                exec 'git clone git://git.launchpad.net/canonical-osm'
+                exec 'mkdir -p ~/charms/interfaces'
+                exec 'cp -r canonical-osm/charms/interfaces/juju-relation-mysql ~/charms/interfaces/mysql'
+
+                // Publish bundle to charm store
                 exec 'git clone https://github.com/juju-solutions/bundle-kubeflow.git'
                 exec 'cd bundle-kubeflow && CHARM_BUILD_DIR=/tmp/charms juju bundle publish --url cs:~kubeflow-charmers/kubeflow'
             }


### PR DESCRIPTION
We rely on a forked mysql interface, and we need to include it in the build process.