### PR TITLE
Don't delete Kubeflow validation controllers

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -35,6 +35,7 @@
           blocking-jobs:
             - "validate-ck.*"
             - "release-microk8s.*"
+            - "validate-kubeflow.*"
           block-level: 'NODE'
 
 


### PR DESCRIPTION
Skips running CI cleanup script while Kubeflow job is active
