### PR TITLE
Switch to pip3 in kubeflow validation job

### DIFF
--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
                 exec "sudo snap install microk8s --classic --channel ${params.microk8s_channel}"
                 exec 'sudo snap install yq'
                 exec 'sudo apt update && sudo apt install -y libssl-dev'
-                exec 'sudo pip install pytest sh kfp requests pyyaml'
+                exec 'sudo pip3 install pytest sh kfp requests pyyaml'
                 exec 'sudo usermod -a -G microk8s ubuntu'
                 exec 'echo \'PATH=$PATH:/snap/bin\' > ~/.bashrc'
             }


### PR DESCRIPTION
Since regular python2 isn't installed by default on newer releases