### PR TITLE
Fix test_encryption_at_rest asserting against wrong command output

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1445,7 +1445,7 @@ async def test_encryption_at_rest(model, tools):
         log("Verifying encryption")
         # verify secret is encrypted
         etcd = model.applications["etcd"].units[0]
-        await etcd.run(
+        output = await etcd.run(
             "ETCDCTL_API=3 /snap/bin/etcd.etcdctl "
             "--endpoints http://127.0.0.1:4001 "
             "get /registry/secrets/default/test-secret | strings"


### PR DESCRIPTION
The assert after this:

https://github.com/charmed-kubernetes/jenkins/blob/e3c857d27b8df2692b3fabf083828f174670d84f/jobs/integration/validation.py#L1454-L1456

is currently checking output from the wrong command.

I haven't tested this but I think it should fix the problem.