### PR TITLE
make channels a csv string; release through candidate by default

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -166,9 +166,9 @@
             the tag will be set to https://dl.k8s.io/release/[stable|latest]-`version`.txt.
       - string:
           name: channels
-          default: '{version}/edge'
+          default: '{version}/edge,{version}/beta,{version}/candidate'
           description: |
-            Snap store channels to release the built snap to.
+            Comma separated snap store channels to release the built snap to.
       - bool:
           name: dry_run
           default: false

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -187,9 +187,9 @@ pipeline {
             steps {
                 script {
                     if(params.dry_run) {
-                        echo "Dry run; would have pushed cdk-addons/*.snap to ${params.version}/edge"
+                        echo "Dry run; would have pushed cdk-addons/*.snap to ${params.channels}"
                     } else {
-                        sh "snapcraft push cdk-addons/*.snap --release ${params.version}/edge"
+                        sh "snapcraft push cdk-addons/*.snap --release ${params.channels}"
                     }
                 }
             }


### PR DESCRIPTION
Because we handle cdk-addons outside of our normal snaps, we sometimes forget to promote to appropriate channels when our normal snaps are released.

This PR updates the `channels` param to a comma separated string, and releases cdk-addons through $version/candidate by default.  Once in beta and candidate, it will be less likely to miss cdk-addons during a beta/candidate promotion.

According to `--help` output, we should be able to send the whole comma separated string (iow, we don't need to loop over a set of channels):
```
$ snapcraft push --help
Usage: snapcraft push [OPTIONS] <snap-file>

  Push <snap-file> to the store.

  By passing --release with a comma separated list of channels the snap
  would be released to the selected channels if the store review passes for
  this <snap-file>.

  This operation will block until the store finishes processing this <snap-
  file>.

  If --release is used, the channel map will be displayed after the
  operation takes place.

  Examples:
      snapcraft push my-snap_0.1_amd64.snap
      snapcraft push my-snap_0.2_amd64.snap --release edge
      snapcraft push my-snap_0.3_amd64.snap --release candidate,beta
```