### PR TITLE
Fix the syntax for the cloud pocket for Ceph tests

### DIFF
--- a/jobs/integration/test_ceph.py
+++ b/jobs/integration/test_ceph.py
@@ -9,17 +9,17 @@ async def test_ceph(model, tools):
     # setup
     log("adding cloud:train to k8s-master")
     await model.applications['kubernetes-master'].set_config({
-        'install_sources': '[cloud:train]',
+        'install_sources': '[cloud:bionic-train]',
     })
     await tools.juju_wait()
     log("deploying ceph mon")
-    await model.deploy("ceph-mon", num_units=3, config={'source': 'cloud:train'})
+    await model.deploy("ceph-mon", num_units=3, config={'source': 'cloud:bionic-train'})
     cs = {
         "osd-devices": {"size": 8 * 1024, "count": 1},
         "osd-journals": {"size": 8 * 1024, "count": 1},
     }
     log("deploying ceph osd")
-    await model.deploy("ceph-osd", storage=cs, num_units=3, config={'source': 'cloud:train'})
+    await model.deploy("ceph-osd", storage=cs, num_units=3, config={'source': 'cloud:bionic-train'})
     log("deploying ceph fs")
     await model.deploy("ceph-fs", num_units=1, config={'source': 'cloud:train'})
 


### PR DESCRIPTION
I got the syntax wrong on the last PR, and it expects `cloud:{series}-{release}` rather than just `cloud:{release}`.