### PR TITLE
Add validate-multus job

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -37,6 +37,12 @@ def pytest_addoption(parser):
         required=False,
         help="Snap channel to use eg 1.16/edge",
     )
+    parser.addoption(
+        "--addons-model",
+        action="store",
+        required=False,
+        help="Juju k8s model for addons"
+    )
 
     # Set when performing upgrade tests
     parser.addoption(
@@ -223,3 +229,16 @@ async def deploy(request, tools):
     yield (tools.controller_name, _model_obj)
     await _model_obj.disconnect()
     await tools.run("juju", "destroy-model", "-y", nonce_model)
+
+
+@pytest.fixture(scope="module")
+async def addons_model(request):
+    controller_name = request.config.getoption("--controller")
+    model_name = request.config.getoption("--addons-model")
+    if not model_name:
+        pytest.skip("--addons-model not specified")
+        return
+    model = Model()
+    await model.connect(controller_name + ":" + model_name)
+    yield model
+    await model.disconnect()

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1668,3 +1668,113 @@ async def test_preupgrade_stub(model, tools):
 async def test_postupgrade_stub(model, tools):
     log('Post-upgrade')
     assert True
+
+
+@pytest.mark.asyncio
+async def test_multus(model, tools, addons_model):
+    if "multus" not in addons_model.applications:
+        pytest.skip("multus is not deployed")
+
+    unit = model.applications['kubernetes-master'].units[0]
+
+    async def cleanup():
+        resources = ['net-attach-def flannel', 'pod multus-test']
+        for resource in resources:
+            await run_until_success(
+                unit, '/snap/bin/kubectl delete --ignore-not-found ' + resource
+            )
+
+    await cleanup()
+
+    # Create NetworkAttachmentDefinition for Flannel
+    network_attachment_definition = {
+        "apiVersion": "k8s.cni.cncf.io/v1",
+        "kind": "NetworkAttachmentDefinition",
+        "metadata": {
+            "name": "flannel"
+        },
+        "spec": {
+            "config": json.dumps({
+                "cniVersion": "0.3.1",
+                "plugins": [
+                    {
+                        "type": "flannel",
+                        "delegate": {
+                            "hairpinMode": True,
+                            "isDefaultGateway": True
+                        }
+                    },
+                    {
+                        "type": "portmap",
+                        "capabilities": {"portMappings": True},
+                        "snat": True
+                    }
+                ]
+            })
+        }
+    }
+    remote_path = '/tmp/network-attachment-definition.yaml'
+    with NamedTemporaryFile('w') as f:
+        yaml.dump(network_attachment_definition, f)
+        await scp_to(
+            f.name, unit, remote_path,
+            tools.controller_name, tools.connection
+        )
+    await run_until_success(unit, '/snap/bin/kubectl apply -f ' + remote_path)
+
+    # Create pod with 2 extra flannel interfaces
+    pod_definition = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "multus-test",
+            "annotations": {
+                "k8s.v1.cni.cncf.io/networks": "flannel, flannel"
+            }
+        },
+        "spec": {
+            "containers": [{
+                "name": "ubuntu",
+                "image": "ubuntu",
+                "command": ["sleep", "3600"]
+            }]
+        }
+    }
+    remote_path = '/tmp/pod.yaml'
+    with NamedTemporaryFile('w') as f:
+        yaml.dump(pod_definition, f)
+        await scp_to(
+            f.name, unit, remote_path,
+            tools.controller_name, tools.connection
+        )
+    await run_until_success(unit, '/snap/bin/kubectl apply -f ' + remote_path)
+
+    # Verify pod has the expected interfaces
+    await run_until_success(
+        unit, '/snap/bin/kubectl exec multus-test -- apt update'
+    )
+    await run_until_success(
+        unit, '/snap/bin/kubectl exec multus-test -- apt install -y iproute2'
+    )
+    output = await run_until_success(
+        unit, '/snap/bin/kubectl exec multus-test -- ip addr'
+    )
+    # behold, ugly output parsing :(
+    lines = output.splitlines()
+    active_interfaces = set()
+    while lines:
+        line = lines.pop(0)
+        interface = line.split()[1].rstrip(':').split('@')[0]
+        while lines and lines[0].startswith(' '):
+            line = lines.pop(0)
+            if line.split()[0] == "inet":
+                # interface has an address, we'll call that good enough
+                active_interfaces.add(interface)
+    expected_interfaces = ['eth0', 'net1', 'net2']
+    for interface in expected_interfaces:
+        if interface not in active_interfaces:
+            pytest.fail('Interface %s is missing from ip addr output:\n%s' % (
+                interface, output
+            ))
+
+    await cleanup()

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1681,7 +1681,7 @@ async def test_multus(model, tools, addons_model):
         resources = ['net-attach-def flannel', 'pod multus-test']
         for resource in resources:
             await run_until_success(
-                unit, '/snap/bin/kubectl delete --ignore-not-found ' + resource
+                unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config delete --ignore-not-found ' + resource
             )
 
     await cleanup()
@@ -1720,7 +1720,7 @@ async def test_multus(model, tools, addons_model):
             f.name, unit, remote_path,
             tools.controller_name, tools.connection
         )
-    await run_until_success(unit, '/snap/bin/kubectl apply -f ' + remote_path)
+    await run_until_success(unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f ' + remote_path)
 
     # Create pod with 2 extra flannel interfaces
     pod_definition = {
@@ -1747,17 +1747,17 @@ async def test_multus(model, tools, addons_model):
             f.name, unit, remote_path,
             tools.controller_name, tools.connection
         )
-    await run_until_success(unit, '/snap/bin/kubectl apply -f ' + remote_path)
+    await run_until_success(unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f ' + remote_path)
 
     # Verify pod has the expected interfaces
     await run_until_success(
-        unit, '/snap/bin/kubectl exec multus-test -- apt update'
+        unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config exec multus-test -- apt update'
     )
     await run_until_success(
-        unit, '/snap/bin/kubectl exec multus-test -- apt install -y iproute2'
+        unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config exec multus-test -- apt install -y iproute2'
     )
     output = await run_until_success(
-        unit, '/snap/bin/kubectl exec multus-test -- ip addr'
+        unit, '/snap/bin/kubectl --kubeconfig /root/.kube/config exec multus-test -- ip addr'
     )
     # behold, ugly output parsing :(
     lines = output.splitlines()

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -344,3 +344,28 @@
           COMMAND: |
             venv/bin/python -m pip install https://github.com/battlemidget/ogc/archive/master.zip
             venv/bin/ogc --spec jobs/validate/nagios-spec.yml
+
+- job:
+    name: 'validate-ck-multus'
+    node: runner-validate
+    description: |
+      Validates CK, with Multus.
+    project-type: freestyle
+    scm:
+      - k8s-jenkins-jenkaas
+    wrappers:
+      - default-job-wrapper
+      - ci-creds
+    properties:
+      - build-discarder:
+          num-to-keep: 7
+    triggers:
+        - timed: "@daily"
+    builders:
+      - set-env:
+          JOB_SPEC_DIR: "jobs/validate"
+      - run-venv:
+          JOB_SPEC_DIR: "jobs/validate"
+          COMMAND: |
+            venv/bin/python -m pip install https://github.com/battlemidget/ogc/archive/master.zip
+            venv/bin/ogc --spec jobs/validate/multus-spec.yml

--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -1,0 +1,132 @@
+meta:
+  name: Verify CK, with Multus.
+  synopsis:
+    - summary: Running the base validation suite against a deployed Kubernetes
+      code: |
+        ```
+        # edit spec.yml and update the appropriate vars under the `env:` section
+        > ogc --spec jobs/validate/multus-spec.yml
+        ```
+  description: |
+    Verifies that CK with Multus passes integration tests
+  mkdocs:
+    destination:
+      - "validations/ck/multus.md"
+
+matrix:
+  snap_version:
+    - 1.18/edge
+    - 1.17/edge
+    - 1.16/edge
+  series:
+    - focal
+    - bionic
+    - xenial
+  channel:
+    - edge
+  arch:
+    - amd64
+
+plan:
+  env:
+    - JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
+    - JUJU_DEPLOY_CHANNEL=$CHANNEL
+    - JUJU_CLOUD=aws/us-east-2
+    - JUJU_CONTROLLER=validate-ck-multus
+    - JUJU_MODEL=validate-multus
+
+  pre-execute: |
+    #!/bin/bash
+    . $WORKSPACE/cilib.sh
+
+    setup_env
+
+    # use juju client from edge because we need 2.8
+    # use a copy of juju data to minimize risk to system-wide data
+    cp -r "${JUJU_DATA:-$HOME/.local/share/juju}" juju-data
+    snap download juju --channel edge
+    unsquashfs -d "$WORKSPACE/juju-snap" juju*.snap
+    export JUJU_DATA="$WORKSPACE/juju-data"
+    export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+
+    # use libjuju from master for juju 2.8 support
+    virtualenv --system-site-packages venv
+    source venv/bin/activate
+    pip3 install -U git+https://github.com/juju/python-libjuju
+
+    juju bootstrap $JUJU_CLOUD $JUJU_CONTROLLER \
+         -d $JUJU_MODEL \
+         --bootstrap-series $SERIES \
+         --force \
+         --bootstrap-constraints arch=$ARCH \
+         --model-default test-mode=true \
+         --model-default resource-tags=owner=k8sci \
+         --model-default image-stream=daily
+
+    tee overlay.yaml <<EOF> /dev/null
+    series: $SERIES
+    applications:
+      kubernetes-master:
+        options:
+          channel: $SNAP_VERSION
+      kubernetes-worker:
+        options:
+          channel: $SNAP_VERSION
+    EOF
+
+    wget https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/ceph-rbd.yaml
+    juju deploy -m $JUJU_CONTROLLER:$JUJU_MODEL \
+          --overlay overlay.yaml \
+          --overlay ceph-rbd.yaml \
+          --force \
+          --channel $JUJU_DEPLOY_CHANNEL $JUJU_DEPLOY_BUNDLE
+
+    timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
+
+    juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL \
+          kubernetes-master/0:config "$WORKSPACE/kubeconfig"
+    export KUBECONFIG="$WORKSPACE/kubeconfig"
+    juju add-k8s k8s --controller $JUJU_CONTROLLER
+    juju add-model -c $JUJU_CONTROLLER addons k8s
+    juju deploy -m $JUJU_CONTROLLER:addons \
+          --channel $JUJU_DEPLOY_CHANNEL cs:~containers/multus
+
+    timeout 45m juju-wait -e $JUJU_CONTROLLER:addons -w
+
+  execute: |
+    #!/bin/bash
+    set -eu
+
+    . $WORKSPACE/cilib.sh
+
+    inject_env
+
+    export JUJU_DATA="$WORKSPACE/juju-data"
+    export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+    source venv/bin/activate
+
+    timeout 2h pytest -m "not slow" \
+       --html=$OGC_JOB_WORKDIR/report.html --self-contained-html \
+       $WORKSPACE/jobs/integration/validation.py \
+       --cloud $JUJU_CLOUD \
+       --model $JUJU_MODEL \
+       --controller $JUJU_CONTROLLER \
+       --addons-model addons
+
+  post-execute: |
+    #!/bin/bash
+    . $WORKSPACE/cilib.sh
+
+    export JUJU_DATA="$WORKSPACE/juju-data"
+    export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+    source venv/bin/activate
+
+    inject_env
+
+    export JUJU_DATA="$WORKSPACE/juju-data"
+    export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+    source venv/bin/activate
+
+    collect_env
+
+    teardown_env

--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -105,7 +105,7 @@ plan:
     export PATH="$WORKSPACE/juju-snap/bin:$PATH"
     source venv/bin/activate
 
-    timeout 2h pytest -m "not slow" \
+    timeout 2h python -m pytest -m "not slow" \
        --html=$OGC_JOB_WORKDIR/report.html --self-contained-html \
        $WORKSPACE/jobs/integration/validation.py \
        --cloud $JUJU_CLOUD \
@@ -116,10 +116,6 @@ plan:
   post-execute: |
     #!/bin/bash
     . $WORKSPACE/cilib.sh
-
-    export JUJU_DATA="$WORKSPACE/juju-data"
-    export PATH="$WORKSPACE/juju-snap/bin:$PATH"
-    source venv/bin/activate
 
     inject_env
 


### PR DESCRIPTION
Still working on this, but open to early feedback.

So far I've added `test_multus` to validation.py, which depends on a new `addons_model` fixture and corresponding `--addons-model` option in conftest.py.

The goal is to have a validate-multus job that will deploy charmed-kubernetes with Ceph, add a k8s model, deploy Multus to the k8s model, and then run pytest with the new `--addons-model` option.