### PR TITLE
Fix multus venv activate calls and set concurrent: no

### DIFF
--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -27,6 +27,8 @@ matrix:
   arch:
     - amd64
 
+concurrent: no
+
 plan:
   env:
     - JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
@@ -51,7 +53,9 @@ plan:
 
     # use libjuju from master for juju 2.8 support
     virtualenv --system-site-packages venv
+    set +u
     source venv/bin/activate
+    set -u
     pip3 install -U git+https://github.com/juju/python-libjuju
 
     juju bootstrap $JUJU_CLOUD $JUJU_CONTROLLER \
@@ -103,7 +107,9 @@ plan:
 
     export JUJU_DATA="$WORKSPACE/juju-data"
     export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+    set +u
     source venv/bin/activate
+    set -u
 
     timeout 2h python -m pytest -m "not slow" \
        --html=$OGC_JOB_WORKDIR/report.html --self-contained-html \
@@ -121,7 +127,9 @@ plan:
 
     export JUJU_DATA="$WORKSPACE/juju-data"
     export PATH="$WORKSPACE/juju-snap/bin:$PATH"
+    set +u
     source venv/bin/activate
+    set -u
 
     collect_env
 


### PR DESCRIPTION
Fixes:

```
venv/bin/activate: line 57: PS1: unbound variable
```

and disables concurrent runs for now while we get the job working