### PR TITLE
Add log output for JSONDecodeError in get_last_audit_entry_date

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -111,7 +111,11 @@ async def get_last_audit_entry_date(application):
     for unit in application.units:
         cmd = "cat /root/cdk/audit/audit.log | tail -n 1"
         raw = await run_until_success(unit, cmd)
-        data = json.loads(raw)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            print(raw)
+            raise
         if "timestamp" in data:
             timestamp = data["timestamp"]
             time = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Adding log output to help troubleshoot this failure:

```
Traceback (most recent call last):
File "/var/lib/jenkins/slaves/jenkins-slave-4/workspace/validate-minor-release/jobs/integration/validation.py", line 991, in test_audit_empty_policy
before_date = await get_last_audit_entry_date(app)
File "/var/lib/jenkins/slaves/jenkins-slave-4/workspace/validate-minor-release/jobs/integration/validation.py", line 114, in get_last_audit_entry_date
data = json.loads(raw)
File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
return _default_decoder.decode(s)
File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "/usr/lib/python3.6/json/decoder.py", line 355, in raw_decode
obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 777 (char 776)
```