### PR TITLE
Fix multus error on snap download

### DIFF
--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -47,10 +47,7 @@ plan:
     # use a copy of juju data to minimize risk to system-wide data
     cp -r "${JUJU_DATA:-$HOME/.local/share/juju}" juju-data
 
-    sudo snap set system proxy.http="http://squid.internal:3128"
-    sudo snap set system proxy.https="http://squid.internal:3128"
-
-    snap download juju --channel edge
+    HTTP_PROXY=http://squid.internal:3128 HTTPS_PROXY=http://squid.internal:3128 snap download juju --channel edge
     unsquashfs -d "$WORKSPACE/juju-snap" juju*.snap
     export JUJU_DATA="$WORKSPACE/juju-data"
     export PATH="$WORKSPACE/juju-snap/bin:$PATH"


### PR DESCRIPTION
Proposal to fix:

```
21:33:23 | INFO + snap download juju --channel edge
21:33:23 | INFO Fetching snap "juju"
21:34:55 | INFO error: Get https://canonical-lcy01.cdn.snapcraft.io/download-origin/canonical-lgw01/e2CPHpB1fUxcKtCyJTsm5t3hN9axJ0yj_11096.snap?token=1585616400_9aeb756653166455f6b4591b7f367347c101b3a2: dial tcp 91.189.88.179:443: i/o timeout
```

I think `snap download` uses the HTTP_PROXY and HTTPS_PROXY variables passed into the client, not the proxy config of snapd.

