### PR TITLE
Destroy multus addons model before destroying controller

### DIFF
--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -124,4 +124,5 @@ plan:
 
     collect_env
 
+    juju destroy-model -y --destroy-storage $JUJU_CONTROLLER:addons || true
     teardown_env


### PR DESCRIPTION
https://jenkins.canonical.com/k8s/job/validate-ck-multus/13 has been hung for 14 hours trying to run the `juju destroy-controller` step during post-execute.

I suspect it's because it tried to destroy the addons k8s model while simultaneously tearing down the Kubernetes cluster that it is hosted on. Hopefully this fixes it.