### PR TITLE
fix multus-spec deploying ceph with wrong series

### DIFF
--- a/jobs/validate/multus-spec.yml
+++ b/jobs/validate/multus-spec.yml
@@ -75,12 +75,17 @@ plan:
           channel: $SNAP_VERSION
     EOF
 
-    wget https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/ceph-rbd.yaml
     juju deploy -m $JUJU_CONTROLLER:$JUJU_MODEL \
           --overlay overlay.yaml \
-          --overlay ceph-rbd.yaml \
           --force \
           --channel $JUJU_DEPLOY_CHANNEL $JUJU_DEPLOY_BUNDLE
+    juju deploy -m $JUJU_CONTROLLER:$JUJU_MODEL -n 3 ceph-mon
+    juju deploy -m $JUJU_CONTROLLER:$JUJU_MODEL -n 3 ceph-osd \
+          --storage osd-devices=32G,2 \
+          --storage osd-journals=8G,1
+    juju add-relation -m $JUJU_CONTROLLER:$JUJU_MODEL ceph-osd ceph-mon
+    juju add-relation -m $JUJU_CONTROLLER:$JUJU_MODEL ceph-mon:admin kubernetes-master
+    juju add-relation -m $JUJU_CONTROLLER:$JUJU_MODEL ceph-mon:client kubernetes-master
 
     timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 


### PR DESCRIPTION
The validate-ck-multus runs on xenial and focal failed because ceph-mon was also deployed on xenial/focal, and it hits hook errors on those series.

This PR updates the multus spec to deploy ceph-mon and ceph-osd directly. This ensures when we deploy those charms that we will get the default series for them, which is currently bionic, which is what works.