### PR TITLE
update upstream for layer-metrics

### DIFF
--- a/jobs/includes/repos.yaml
+++ b/jobs/includes/repos.yaml
@@ -163,7 +163,7 @@ repos:
     tags: ['k8s']
   - name: layer:metrics
     downstream: "charmed-kubernetes/layer-metrics.git"
-    upstream: "https://github.com/CanonicalLtd/layer-metrics.git"
+    upstream: "https://github.com/canonical/layer-metrics.git"
     tags: ['k8s']
   - name: layer:nagios
     downstream: "charmed-kubernetes/layer-nagios.git"


### PR DESCRIPTION
Not sure what repos.yaml is supposed to do, but may as well fix it like we did in #582 for:

https://github.com/juju/layer-index/pull/109

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
