### PR TITLE
Add test for cdk-cinder storage class on OpenStack

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -242,3 +242,15 @@ async def addons_model(request):
     await model.connect(controller_name + ":" + model_name)
     yield model
     await model.disconnect()
+
+
+@pytest.fixture
+def cloud():
+    return 'unknown'  # TODO: get the actual cloud
+
+
+@pytest.fixture(autouse=True)
+def skip_by_cloud(request, cloud):
+    clouds_marker = request.node.get_closest_marker("clouds")
+    if clouds_marker and cloud not in clouds_marker.args[0]:
+        pytest.skip("skipped on this cloud: {}".format(cloud))

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -13,6 +13,7 @@ import click
 from asyncio_extras import async_contextmanager
 from async_generator import yield_
 from base64 import b64encode
+from cilib import log
 from datetime import datetime
 from pprint import pformat
 from tempfile import NamedTemporaryFile
@@ -1839,3 +1840,34 @@ async def test_multus(model, tools, addons_model):
             )
 
     await cleanup()
+
+
+@pytest.mark.clouds(['openstack'])
+@pytest.mark.asyncio
+async def test_cinder(model, tools):
+    # setup
+    log.info("deploying openstack-integrator")
+    series = 'bionic'
+    await model.deploy(
+        "openstack-integrator",
+        num_units=1,
+        series=series,
+        trust=True,
+    )
+
+    log.info("adding relations")
+    await model.add_relation("openstack-integrator", "kubernetes-master")
+    await model.add_relation("openstack-integrator", "kubernetes-worker")
+    log.info("waiting...")
+    await tools.juju_wait()
+
+    log.info("waiting for csi to settle")
+    unit = model.applications["kubernetes-master"].units[0]
+    await retry_async_with_timeout(
+        verify_ready, (unit, "po", ["csi-cinder-controllerplugin-0"], "-n kube-system"),
+        timeout_msg="CSI pod not ready!"
+    )
+    # create pod that writes to a pv from cinder
+    await validate_storage_class(model, "cdk-cinder", "Cinder")
+    # cleanup
+    await model.applications["openstack-integrator"].destroy()

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ markers =
     skip_arch
     skip_model
     skip_apps
+    cloud
 log_cli = 1
 log_cli_level = CRITICAL
 log_cli_format = %(message)s


### PR DESCRIPTION
Modified from the Ceph test, and marked to only run on OpenStack clouds.
The implementation for getting the cloud is incomplete.