### PR TITLE
32 GB of ram needed for amd64

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -7,7 +7,7 @@ plan:
       - JUJU_CONTROLLER=release-microk8s-beta-amd64
       - JUJU_MODEL=release-microk8s-beta-model
       - ARCH=amd64
-      - INSTANCE_TYPE=m5.xlarge
+      - INSTANCE_TYPE=m5.2xlarge
     tags:
       - amd64/beta
       - amd64
@@ -96,7 +96,7 @@ plan:
       - JUJU_CONTROLLER=release-microk8s-stable-amd64
       - JUJU_MODEL=release-microk8s-stable-model
       - ARCH=amd64
-      - INSTANCE_TYPE=m5.xlarge
+      - INSTANCE_TYPE=m5.2xlarge
     tags:
       - amd64/stable
       - amd64
@@ -117,7 +117,7 @@ plan:
       - JUJU_CONTROLLER=release-microk8s-pre-release-amd64
       - JUJU_MODEL=release-microk8s-pre-release-model
       - ARCH=amd64
-      - INSTANCE_TYPE=m5.xlarge
+      - INSTANCE_TYPE=m5.2xlarge
     tags:
       - amd64/prerelease
       - amd64


### PR DESCRIPTION
We will have to get back to 32 GB for amd64.

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
