### PR TITLE
Integration test case for kubernetes-master service cidr expansion

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -909,8 +909,7 @@ async def test_service_cidr_expansion(model):
 
     # Check if k8s service ip is changed as per new service cidr
     raw_output = output.data["results"].get("Stdout", "")
-    if new_service_ip_str not in raw_output:
-        raise
+    assert new_service_ip_str in raw_output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add new integration test to verify service cidr expansion.

Corresponding kubernetes-master charm PR:
https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/93

Related-Bug: #1868685

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
