### PR TITLE
uses bearer auth token instead of user/pass for dashboard query

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -342,10 +342,9 @@ async def test_dashboard(model, log_dir, tools):
             config = yaml.safe_load(stream)
     # make sure we can hit the api-server
     url = config["clusters"][0]["cluster"]["server"]
-    user = config["users"][0]["user"]["username"]
-    password = config["users"][0]["user"]["password"]
-    auth = tools.requests.auth.HTTPBasicAuth(user, password)
-    resp = await tools.requests.get(url, auth=auth, verify=False)
+    token = config["users"][0]["user"]["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await tools.requests.get(url, headers=headers, verify=False)
     assert resp.status_code == 200
 
     # get k8s version
@@ -371,7 +370,7 @@ async def test_dashboard(model, log_dir, tools):
     click.echo("Waiting for dashboard to stabilize...")
 
     async def dashboard_present(url):
-        resp = await tools.requests.get(url, auth=auth, verify=False)
+        resp = await tools.requests.get(url, headers=headers, verify=False)
         if resp.status_code == 200 and "Dashboard" in resp.text:
             return True
         return False


### PR DESCRIPTION
I referenced https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#without-kubectl-proxy for passing a Bearer token via the cli (in this case requests)

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
