### PR TITLE
Handle default-track change to not latest

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -76,7 +76,7 @@ class Microk8sSnap:
 
     def test_cross_distro(
         self,
-        channel_to_upgrade="stable",
+        channel_to_upgrade="latest/stable",
         tests_branch=None,
         distributions=["ubuntu:16.04", "ubuntu:18.04"],
         proxy=None,
@@ -131,16 +131,12 @@ class Microk8sSnap:
         if "under-testing" in self.under_testing_channel:
             self.release_to(self.under_testing_channel)
         for distro in distributions:
-            if self.track == "latest":
-                track_channel_to_upgrade = channel_to_upgrade
-                testing_track_channel = self.under_testing_channel
-            else:
-                track_channel_to_upgrade = "{}/{}".format(
-                    self.track, channel_to_upgrade
-                )
-                testing_track_channel = "{}/{}".format(
-                    self.track, self.under_testing_channel
-                )
+            track_channel_to_upgrade = "{}/{}".format(
+                self.track, channel_to_upgrade
+            )
+            testing_track_channel = "{}/{}".format(
+                self.track, self.under_testing_channel
+            )
 
             cmd = "sudo tests/test-distro.sh {} {} {}".format(
                 distro, track_channel_to_upgrade, testing_track_channel

--- a/jobs/microk8s/update-gh-branches-and-lp-builders.py
+++ b/jobs/microk8s/update-gh-branches-and-lp-builders.py
@@ -65,7 +65,7 @@ def create_gh_branch(branch, gh_user, gh_token):
         branch
     ).split()
     check_call(cmd)
-    cmd = "sed -i s@UPGRADE_MICROK8S_FROM=edge@UPGRADE_MICROK8S_FROM={}/edge@g .travis.yml".format(
+    cmd = "sed -i s@UPGRADE_MICROK8S_FROM=latest/edge@UPGRADE_MICROK8S_FROM={}/edge@g .travis.yml".format(
         branch
     ).split()
     check_call(cmd)


### PR DESCRIPTION
We switched the default track from latest to whatever track the latest upstream has. This PR has some fixes but I need to verify them as soon as our CI gets into a healthy state.