### PR TITLE
Always set the MIcroK8s track when releasing

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -65,9 +65,7 @@ class Microk8sSnap:
                 )
             )
             raise Exception("Cannot release pre-releases.")
-        target = (
-            channel if self.track == "latest" else "{}/{}".format(self.track, channel)
-        )
+        target = "{}/{}".format(self.track, channel)
         cmd = "snapcraft release microk8s {} {}".format(self.revision, target)
         if dry_run == "no":
             run(cmd.split(), check=True, stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
Fixes the error:
```
jackal@aurora:~$ 'snapcraft' 'release' 'microk8s' '1443' 'stable'
invalid-field: Implicit track not allowed
```