### PR TITLE
snapcraft called as normal user

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -183,7 +183,7 @@ class Microk8sSnap:
             for line in sh2.env(cmd_array):
                 click.echo(line.strip())
 
-        cmd = "(cd microk8s; pwd; sudo usermod --append --groups lxd $USER; sg lxd -c SNAPCRAFT_BUILD_ENVIRONMENT=lxd /snap/bin/snapcraft)"
+        cmd = "(cd microk8s; pwd; sudo usermod --append --groups lxd $USER; sg lxd -c \"SNAPCRAFT_BUILD_ENVIRONMENT=lxd /snap/bin/snapcraft\")"
         cmd_array = self.cmd_array_to_run(cmd)
         for line in sh2.env(cmd_array):
             click.echo(line.strip())

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -183,7 +183,7 @@ class Microk8sSnap:
             for line in sh2.env(cmd_array):
                 click.echo(line.strip())
 
-        cmd = "(cd microk8s; pwd; sudo /snap/bin/snapcraft --use-lxd)"
+        cmd = "(cd microk8s; pwd; sudo usermod --append --groups lxd $USER; sg lxc -c SNAPCRAFT_BUILD_ENVIRONMENT=lxd /snap/bin/snapcraft)"
         cmd_array = self.cmd_array_to_run(cmd)
         for line in sh2.env(cmd_array):
             click.echo(line.strip())

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -183,7 +183,7 @@ class Microk8sSnap:
             for line in sh2.env(cmd_array):
                 click.echo(line.strip())
 
-        cmd = "(cd microk8s; pwd; sudo usermod --append --groups lxd $USER; sg lxc -c SNAPCRAFT_BUILD_ENVIRONMENT=lxd /snap/bin/snapcraft)"
+        cmd = "(cd microk8s; pwd; sudo usermod --append --groups lxd $USER; sg lxd -c SNAPCRAFT_BUILD_ENVIRONMENT=lxd /snap/bin/snapcraft)"
         cmd_array = self.cmd_array_to_run(cmd)
         for line in sh2.env(cmd_array):
             click.echo(line.strip())


### PR DESCRIPTION
Sudoers cannot call snapcraft --use-lxd anymore [1]. This PR makes sure we build the pre-stable releases as a normal user.

[1] https://forum.snapcraft.io/t/call-for-testing-snapcraft-4-0/16956/50
