### PR TITLE
fix test_extra_args kubelet args for k8s 1.19

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -774,7 +774,7 @@ async def test_extra_args(model, tools):
             "kubelet-extra-args": " ".join(
                 [
                     "v=1",  # int arg, overrides a charm default
-                    "enable-server",  # bool arg, implied true
+                    "add-dir-header",  # bool arg, implied true
                     "alsologtostderr=false",  # bool arg, explicit false
                 ]
             ),
@@ -787,7 +787,7 @@ async def test_extra_args(model, tools):
             ),
         },
         expected_args={
-            "kubelet": {"v=1", "enable-server=true", "alsologtostderr=false"},
+            "kubelet": {"v=1", "add-dir-header=true", "alsologtostderr=false"},
             "kube-proxy": {"v=1", "profiling=true", "alsologtostderr=false"},
         },
     )


### PR DESCRIPTION
The test fails because --enable-server is deprecated:

```
      --enable-server                                            Enable the Kubelet's server (default true) (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
```

We'll have the test use this harmless looking flag instead:

```
      --add-dir-header                                           If true, adds the file directory to the header of the log messages
```

That flag has been available since kubelet 1.16 at least, possibly earlier. It should be safe to use.