### PR TITLE
Add test for IPv6 to validate-calico

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -182,6 +182,7 @@ function ci::run
         retry 15 juju::bootstrap
         juju::bootstrap::after
         juju::deploy::before
+        juju::deploy::overlay
         retry 15 juju::deploy
         juju::wait
         juju::deploy::after

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -122,10 +122,7 @@ def get_instance_id(machine_id):
 @def_command("bootstrap")
 def bootstrap():
     # Create VPC
-    vpc = ec2.create_vpc(
-        CidrBlock=VPC_CIDR,
-        AmazonProvidedIpv6CidrBlock=True,
-    )["Vpc"]
+    vpc = ec2.create_vpc(CidrBlock=VPC_CIDR, AmazonProvidedIpv6CidrBlock=True,)["Vpc"]
     vpc_id = ["VpcId"]
     ipv6_cidr_block = vpc["Ipv6CidrBlockAssociationSet"]["Ipv6CidrBlock"]
     tag_resource(vpc_id)
@@ -292,8 +289,7 @@ def assign_ipv6_addr_on_instance(instance_id):
         log("Assigning IPv6 address to " + network_interface_id)
 
         ec2.modify_network_interface_attribute(
-            NetworkInterfaceId=network_interface_id,
-            Ipv6AddressCount=1,
+            NetworkInterfaceId=network_interface_id, Ipv6AddressCount=1,
         )
 
 

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -122,7 +122,12 @@ def get_instance_id(machine_id):
 @def_command("bootstrap")
 def bootstrap():
     # Create VPC
-    vpc_id = ec2.create_vpc(CidrBlock=VPC_CIDR)["Vpc"]["VpcId"]
+    vpc = ec2.create_vpc(
+        CidrBlock=VPC_CIDR,
+        AmazonProvidedIpv6CidrBlock=True,
+    )["Vpc"]
+    vpc_id = ["VpcId"]
+    ipv6_cidr_block = vpc["Ipv6CidrBlockAssociationSet"]["Ipv6CidrBlock"]
     tag_resource(vpc_id)
     # Must be done in separate requests per doc
     ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsHostnames={"Value": True})
@@ -134,7 +139,10 @@ def bootstrap():
     subnet_cidrs = SUBNET_CIDRS[:num_subnets]
     for subnet_cidr in subnet_cidrs:
         subnet_id = ec2.create_subnet(
-            VpcId=vpc_id, CidrBlock=subnet_cidr, AvailabilityZone=AVAILABILITY_ZONE,
+            VpcId=vpc_id,
+            CidrBlock=subnet_cidr,
+            Ipv6CidrBlock=ipv6_cidr_block,
+            AvailabilityZone=AVAILABILITY_ZONE,
         )["Subnet"]["SubnetId"]
         tag_resource(subnet_id)
         ec2.modify_subnet_attribute(
@@ -265,6 +273,51 @@ def disable_source_dest_check():
         instance_id = get_instance_id(machine_id)
         if instance_id:
             disable_source_dest_check_on_instance(instance_id)
+
+
+def assign_ipv6_addr_on_instance(instance_id):
+    log("Getting network interfaces for instance " + instance_id)
+    network_interface_ids = []
+    reservations = ec2.describe_instances(InstanceIds=[instance_id])["Reservations"]
+    for reservation in reservations:
+        instances = reservation["Instances"]
+        for instance in instances:
+            for network_interface in instance["NetworkInterfaces"]:
+                network_interface_id = network_interface["NetworkInterfaceId"]
+                ipv6_addrs = network_interface["Ipv6Addresses"]
+                if not ipv6_addrs:
+                    network_interface_ids.append(network_interface_id)
+
+    for network_interface_id in network_interface_ids:
+        log("Assigning IPv6 address to " + network_interface_id)
+
+        ec2.modify_network_interface_attribute(
+            NetworkInterfaceId=network_interface_id,
+            Ipv6AddressCount=1,
+        )
+
+
+@def_command("assign-ipv6-addrs")
+def assign_ipv6_addrs():
+    status = juju_json("status")
+
+    if status["model"]["cloud"] != "aws":
+        log("Cloud is not AWS, doing nothing")
+        return
+
+    apps = ["calico", "tigera-secure-ee"]
+    if not any(app in status["applications"] for app in apps):
+        log("No apps need source dest check disabled, doing nothing")
+        return
+
+    global REGION
+    REGION = status["model"]["region"]
+
+    status = juju_json("status")
+    for machine_id in status["machines"]:
+        instance_id = get_instance_id(machine_id)
+        if instance_id:
+            assign_ipv6_addr_on_instance(instance_id)
 
 
 def get_model_vpc_id():

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import ipaddress
 import json
 import os
 import subprocess
@@ -510,3 +511,44 @@ async def finish_series_upgrade(machine, tools):
         "complete",
     )
     await wait_for_status("active", _units(machine))
+
+
+class KubectlError(AssertionError):
+    def __init__(self, command, result):
+        self.command = command
+        self.code = result["Code"]
+        self.stdout = result.get("Stdout", "")
+        self.stderr = result.get("Stderr", "")
+        super().__init__("`{}` failed: {}".format(self.command,
+                                                  self.stderr or self.stdout))
+
+
+class KubectlResult:
+    def __init__(self, result):
+        self.code = result["Code"]
+        self.stdout = result.get("Stdout", "")
+        self.stderr = result.get("Stderr", "")
+
+
+async def kubectl(model, cmd):
+    master = model.applications["kubernetes-master"].units[0]
+    cmd = "/snap/bin/kubectl --kubeconfig /root/.kube/config {}".format(cmd)
+    result = await master.run(cmd)
+    if result.status != "completed" or result.results["Code"] != 0:
+        raise KubectlError(cmd, result.results)
+    return KubectlResult(result.results)
+
+
+async def get_ipv6_addr(unit):
+    """Return the first globally scoped IPv6 address found on the given unit, or None.
+    """
+    output = await unit.run("ip -br a show scope global")
+    assert output.status == "completed" and output.results["Code"] == 0
+    for intf in output.results["Stdout"].splitlines():
+        if 'UP' not in intf:
+            continue
+        for addr in intf.split("  ")[-1].split():
+            addr = ipaddress.ip_interface(addr).ip
+            if addr.version == 6:
+                return str(addr)
+    return None

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -519,8 +519,9 @@ class KubectlError(AssertionError):
         self.code = result["Code"]
         self.stdout = result.get("Stdout", "")
         self.stderr = result.get("Stderr", "")
-        super().__init__("`{}` failed: {}".format(self.command,
-                                                  self.stderr or self.stdout))
+        super().__init__(
+            "`{}` failed: {}".format(self.command, self.stderr or self.stdout)
+        )
 
 
 class KubectlResult:
@@ -545,7 +546,7 @@ async def get_ipv6_addr(unit):
     output = await unit.run("ip -br a show scope global")
     assert output.status == "completed" and output.results["Code"] == 0
     for intf in output.results["Stdout"].splitlines():
-        if 'UP' not in intf:
+        if "UP" not in intf:
             continue
         for addr in intf.split("  ")[-1].split():
             addr = ipaddress.ip_interface(addr).ip

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -569,7 +569,9 @@ async def test_network_policies(model, tools):
 @pytest.mark.skip_apps(["calico"])
 async def test_ipv6(model, tools):
     master = model.applications["kubernetes-master"].units[0]
-    kubectl("create -f - << EOF{}EOF".format("""
+    kubectl(
+        "create -f - << EOF{}EOF".format(
+            """
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -619,7 +621,9 @@ spec:
     protocol: TCP
   selector:
     run: nginxdualstack
-"""))
+"""
+        )
+    )
 
     # wait for completion
     await retry_async_with_timeout(
@@ -634,16 +638,20 @@ spec:
     for worker in model.applications["kubernetes-worker"].units:
         ipv4_addr = worker.public_address
         ipv6_addr = get_ipv6_addr(worker)
-        assert ipv6_addr is not None, "Unable to find IPv6 address for {}".format(worker.name)
-        urls.extend([
-            "http://{}:{}/".format(ipv4_addr, ipv4_port),
-            "http://[{}]:{}/".format(ipv6_addr, ipv6_port),
-        ])
+        assert ipv6_addr is not None, "Unable to find IPv6 address for {}".format(
+            worker.name
+        )
+        urls.extend(
+            [
+                "http://{}:{}/".format(ipv4_addr, ipv4_port),
+                "http://[{}]:{}/".format(ipv6_addr, ipv6_port),
+            ]
+        )
 
     for url in urls:
         output = await master.run("curl '{}'".format(url))
         assert output.status == "completed" and output.results["Code"] == 0
-        assert 'Kubernetes IPv6 nginx' in output.results["Stdout"]
+        assert "Kubernetes IPv6 nginx" in output.results["Stdout"]
 
 
 @pytest.mark.asyncio

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -25,7 +25,9 @@ from .utils import (
     scp_to,
     scp_from,
     disable_source_dest_check,
+    find_entities,
     verify_deleted,
+    verify_completed,
     verify_ready,
     is_localhost,
     validate_storage_class,
@@ -33,6 +35,8 @@ from .utils import (
     prep_series_upgrade,
     do_series_upgrade,
     finish_series_upgrade,
+    kubectl,
+    get_ipv6_addr,
 )
 import urllib.request
 from .logger import log
@@ -559,6 +563,87 @@ async def test_network_policies(model, tools):
         "/snap/bin/kubectl --kubeconfig /root/.kube/config delete ns netpolicy"
     )
     assert cmd.status == "completed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_apps(["calico"])
+async def test_ipv6(model, tools):
+    master = model.applications["kubernetes-master"].units[0]
+    kubectl("create -f - << EOF{}EOF".format("""
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginxdualstack
+spec:
+  selector:
+    matchLabels:
+      run: nginxdualstack
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: nginxdualstack
+    spec:
+      containers:
+      - name: nginxdualstack
+        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx6
+  labels:
+    run: nginxdualstack
+spec:
+  type: NodePort
+  ipFamily: IPv6
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginxdualstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx4
+  labels:
+    run: nginxdualstack
+spec:
+  type: NodePort
+  ipFamily: IPv4
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginxdualstack
+"""))
+
+    # wait for completion
+    await retry_async_with_timeout(
+        verify_completed,
+        (master, "svc", ["nginx4", "nginx6"]),
+        timeout_msg="Timeout waiting for nginxdualstack services",
+    )
+    nginx4, nginx6 = await find_entities(master, "svc", ["nginx4", "nginx6"])
+    ipv4_port = nginx4["ports"][0]["nodePort"]
+    ipv6_port = nginx6["ports"][0]["nodePort"]
+    urls = []
+    for worker in model.applications["kubernetes-worker"].units:
+        ipv4_addr = worker.public_address
+        ipv6_addr = get_ipv6_addr(worker)
+        assert ipv6_addr is not None, "Unable to find IPv6 address for {}".format(worker.name)
+        urls.extend([
+            "http://{}:{}/".format(ipv4_addr, ipv4_port),
+            "http://[{}]:{}/".format(ipv6_addr, ipv6_port),
+        ])
+
+    for url in urls:
+        output = await master.run("curl '{}'".format(url))
+        assert output.status == "completed" and output.results["Code"] == 0
+        assert 'Kubernetes IPv6 nginx' in output.results["Stdout"]
 
 
 @pytest.mark.asyncio

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -32,9 +32,35 @@ function juju::bootstrap
     fi
 }
 
+function juju::deploy::overlay
+{
+    cat <<EOF > overlay.yaml
+series: $SERIES
+applications:
+  kubernetes-master:
+    options:
+      channel: $SNAP_VERSION
+      service-cidr: "10.152.183.0/24,fd00:c00b:2::/112"
+  kubernetes-worker:
+    options:
+      channel: $SNAP_VERSION
+  flannel:
+  calico:
+    charm: cs:~containers/calico
+    options:
+      cidr: "192.168.0.0/16,fd00:c00b:1::/112"
+relations:
+- [calico:etcd, etcd:db]
+- [calico:cni, kubernetes-master:cni]
+- [calico:cni, kubernetes-worker:cni]
+EOF
+}
+
 function juju::deploy::after
 {
     python $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
+
+    python $WORKSPACE/jobs/integration/tigera_aws.py assign-ipv6-addrs
 
     if [ "$TEST_BGP" = "1" ]; then
       python $WORKSPACE/jobs/integration/tigera_aws.py configure-bgp

--- a/juju.bash
+++ b/juju.bash
@@ -37,9 +37,9 @@ function juju::deploy::after
     echo "> skipping after tasks"
 }
 
-function juju::deploy
+function juju::deploy::overlay
 {
-    tee overlay.yaml <<EOF> /dev/null
+    cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
   kubernetes-master:
@@ -49,7 +49,10 @@ applications:
     options:
       channel: $SNAP_VERSION
 EOF
+}
 
+function juju::deploy
+{
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
          --overlay overlay.yaml \
          --force \


### PR DESCRIPTION
Extend the validate-calico test to include checking IPv6 dual-stack support.

Part of [lp:1881177](https://bugs.launchpad.net/charm-etcd/+bug/1881177)

Depends on:
* https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/99
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/63
* https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/13
* https://github.com/charmed-kubernetes/layer-calico/pull/58