### PR TITLE
Skip CephFS test on Xenial

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=110
+max-line-length=142


### PR DESCRIPTION
CephFS support requires OpenStack Train, but according to https://wiki.ubuntu.com/OpenStack/CloudArchive Xenial only goes up to Queens.  Skip the test on Xenial, and we'll need to update the docs to note this.

Drive-by: fix lint & black issues.

Fixes [lp:1879542](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1879542)