### PR TITLE
Fix getting IPv6 CIDR block from new VPC

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -124,6 +124,7 @@ def bootstrap():
     # Create VPC
     vpc = ec2.create_vpc(CidrBlock=VPC_CIDR, AmazonProvidedIpv6CidrBlock=True,)["Vpc"]
     vpc_id = vpc["VpcId"]
+    tag_resource(vpc_id)
     for attempt in range(10):
         ipv6_cidr_block = vpc["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlock"]
         if ipv6_cidr_block:
@@ -137,7 +138,6 @@ def bootstrap():
                 vpc_id, vpc["Ipv6CidrBlockAssociationSet"],
             )
         )
-    tag_resource(vpc_id)
     # Must be done in separate requests per doc
     ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsHostnames={"Value": True})
     ec2.modify_vpc_attribute(VpcId=vpc_id, EnableDnsSupport={"Value": True})


### PR DESCRIPTION
It seems that the IPv6 association takes longer to become available than the IPv4 association, so we need to poll the VPC until it's ready.