### PR TITLE
Add us.gcr.io to REGISTRY_REPLACE

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -20,7 +20,7 @@ pipeline {
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
         REGISTRY_URL = 'upload.rocks.canonical.com:5000'
-        REGISTRY_REPLACE = 'docker.io/ k8s.gcr.io/ quay.io/'
+        REGISTRY_REPLACE = 'docker.io/ k8s.gcr.io/ quay.io/ us.gcr.io/'
     }
     options {
         ansiColor('xterm')


### PR DESCRIPTION
The new ingress-nginx image is hosted on us.gcr.io rather than k8s.gcr.io and is failing to replace the registry portion properly.