### PR TITLE
Skip xenial on ceph test

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2154,8 +2154,10 @@ async def test_nfs(model, tools):
 async def test_ceph(model, tools):
     # setup
     series = os.environ["SERIES"]
+    if series == "xenial":
+        pytest.skip("Ceph not supported fully on xenial")
     snap_ver = os.environ["SNAP_VERSION"].split("/")[0]
-    check_cephfs = snap_ver not in ("1.15", "1.16") and series != "xenial"
+    check_cephfs = snap_ver not in ("1.15", "1.16")
     ceph_config = {}
     if check_cephfs and series == "bionic":
         log("adding cloud:train to k8s-master")


### PR DESCRIPTION
Related:
https://github.com/openstack/charm-ceph-mon/commit/3f62d003168d39055ad793e4a0236363acf6746d

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
