### PR TITLE
Make test_rbac non-destructive, remove obsolete test_rbac_flag

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -292,8 +292,8 @@ async def test_rbac(model):
     """ When RBAC is enabled, validate kubelet creds cannot get ClusterRoles """
     app = model.applications["kubernetes-master"]
     config = await app.get_config()
-    if 'RBAC' not in config['authorization-mode']['value']:
-        pytest.skip('Cluster does not have RBAC enabled')
+    if "RBAC" not in config["authorization-mode"]["value"]:
+        pytest.skip("Cluster does not have RBAC enabled")
 
     cmd = "/snap/bin/kubectl --kubeconfig /root/cdk/kubeconfig get clusterroles"
     worker = model.applications["kubernetes-worker"].units[0]

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -289,26 +289,15 @@ async def test_snap_versions(model):
 
 @pytest.mark.asyncio
 async def test_rbac(model):
-    """ Validate RBAC is actually on """
+    """ When RBAC is enabled, validate kubelet creds cannot get ClusterRoles """
     app = model.applications["kubernetes-master"]
-    await app.set_config({"authorization-mode": "RBAC,Node"})
-    await wait_for_process(model, "RBAC")
+    config = await app.get_config()
+    if 'RBAC' not in config['authorization-mode']['value']:
+        pytest.skip('Cluster does not have RBAC enabled')
+
     cmd = "/snap/bin/kubectl --kubeconfig /root/cdk/kubeconfig get clusterroles"
     worker = model.applications["kubernetes-worker"].units[0]
     await run_until_success(worker, cmd + " 2>&1 | grep Forbidden")
-    await app.set_config({"authorization-mode": "AlwaysAllow"})
-    await wait_for_process(model, "AlwaysAllow")
-    await run_until_success(worker, cmd)
-
-
-@pytest.mark.asyncio
-async def test_rbac_flag(model):
-    """ Switch between auth modes and check the apiserver follows """
-    master = model.applications["kubernetes-master"]
-    await master.set_config({"authorization-mode": "RBAC"})
-    await wait_for_process(model, "RBAC")
-    await master.set_config({"authorization-mode": "AlwaysAllow"})
-    await wait_for_process(model, "AlwaysAllow")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I noticed that `test_rbac` and `test_rbac_flag` set authorization-mode to AlwaysAllow when they are done. This disables RBAC.

This will be a problem when testing CK 1.19, where authorization-mode=Node,RBAC is the new default and we want *all* of our tests to be running with RBAC enabled.

To fix this, I've done two things:
1. Make `test_rbac` non-destructive so it does not change authorization-mode. This means it will be skipped on clusters that don't have RBAC enabled.
2. Remove `test_rbac_flag`, whose behavior was covered by `test_rbac` anyway.