### PR TITLE
Fix upstream repo for ceph-admin interface

### DIFF
--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -118,7 +118,7 @@
     tags: ['k8s']
 - interface:ceph-admin:
     downstream: "charmed-kubernetes/juju-interface-ceph-admin.git"
-    upstream: "https://github.com/cholcombe973/juju-interface-ceph-admin"
+    upstream: "https://github.com/openstack-charmers/juju-interface-ceph-admin"
     tags: ['k8s']
 - interface:ceph-client:
     downstream: "charmed-kubernetes/charm-interface-ceph-client.git"


### PR DESCRIPTION
The upstream repo was moved to the `openstack-charmers` and changes have since landed there that we have not synced.  Updating to the new upstream so we can get those fixes.

Fixes [lp:1893440](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1893440)