### PR TITLE
Limit vault job to only run vault test

### DIFF
--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -25,6 +25,24 @@ function juju::bootstrap
          --config vpc-id=vpc-0e4f11d0d4e9ba35f
 }
 
+function test::execute
+{
+    declare -n is_pass=$1
+    timeout 2h pytest \
+        --html="report.html" \
+        jobs/integration/validation.py::test_encryption_at_rest \
+        --cloud "$JUJU_CLOUD" \
+        --model "$JUJU_MODEL" \
+        --controller "$JUJU_CONTROLLER" \
+        --addons-model addons
+    ret=$?
+    is_pass="True"
+    if (( $ret > 0 )); then
+        is_pass="False"
+    fi
+}
+
+
 
 # Setup Environment
 


### PR DESCRIPTION
The vault job was getting false failures due to other tests being run which are already being run in the other jobs.  This will also speed this job up some since it's not running tests it doesn't care about.

Part of [lp:1893278](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1893278)