### PR TITLE
Change Vault test to use custom waiting

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -117,6 +117,7 @@ class Tools:
                 f"Problem with run command [{' '.join(cmd)}]: \nstdout: "
                 f"{stdout.decode()}\nstderr: {stderr.decode()}"
             )
+        return stdout.decode("utf8"), stderr.decode("utf8")
 
     async def juju_wait(self, *args, **kwargs):
         cmd = f"juju wait -e {self.connection} -w"

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1546,12 +1546,7 @@ data:
 @pytest.mark.on_model("validate-vault")
 async def test_encryption_at_rest(model, tools):
     """Testing integrating vault secrets into cluster"""
-    click.echo("Waiting for Vault to be ready to initialize")
     vault = model.applications["vault"].units[0]
-    await model.block_until(
-        lambda: vault.workload_status_message == "Vault needs to be initialized",
-        timeout=5 * 60,  # 5 minutes
-    )
 
     click.echo("Unsealing vault")
     # unseal vault

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -61,13 +61,18 @@ EOF
 
 function juju::wait
 {
-    echo "Waiting for deployment to settle..."
-    timeout 45m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w -x vault
-
-    ret=$?
-    if (( ret > 0 )); then
-        exit "$ret"
-    fi
+    # We can only wait for Vault to be ready to unseal. The test itself has to
+    # wait for the rest of the cluster to settle after that is done.
+    echo "Waiting for Vault to be ready to initialize..."
+    start_min=$(now_min)
+    while ! juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" vault | grep -q "Vault needs to be initialized"; do
+        sleep 60
+        if (( $(now_min) - start_min > 20 )); then
+            echo "Timed out waiting for Vault"
+            juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" vault
+            exit 124
+        fi
+    done
 }
 
 function test::execute
@@ -82,7 +87,7 @@ function test::execute
         --addons-model addons
     ret=$?
     is_pass="True"
-    if (( $ret > 0 )); then
+    if (( ret > 0 )); then
         is_pass="False"
     fi
 }


### PR DESCRIPTION
The unsealing of Vault blocks the cluster from settling properly, so it needs to be handled specially in the test.