### PR TITLE
Auth webhook test

### DIFF
--- a/jobs/integration/test_auth_webhook.py
+++ b/jobs/integration/test_auth_webhook.py
@@ -81,17 +81,20 @@ async def test_validate_auth_webhook(model, tools):
     await verify_service(one_master)
 
     # Verify authn with a valid token
+    log("verifying valid token")
     valid_token = await get_valid_token(one_master)
     good_curl = get_curl_cmd("https://{}:5000/v1beta1".format(hostname), valid_token)
     await verify_auth_success(one_master, good_curl)
 
     # Verify no auth with an invalid token
+    log("verifying invalid token")
     invalid_token = "this_cant_be_right"
     bad_curl = get_curl_cmd("https://{}:5000/v1beta1".format(hostname), invalid_token)
     await verify_auth_failure(one_master, bad_curl)
 
     try:
         # Verify invalid token triggers a call to a custom endpoint
+        log("verifying custom endpoint")
         ep = "https://localhost:6000/v1beta1"
         await masters.set_config({"authn-webhook-endpoint": ep})
         log("waiting for cluster to settle...")

--- a/jobs/integration/test_auth_webhook.py
+++ b/jobs/integration/test_auth_webhook.py
@@ -1,0 +1,95 @@
+import json
+import pytest
+import random
+from .logger import log
+from yaml import safe_load
+
+
+def get_curl_cmd(url, token):
+    json_data = {"kind": "TokenReview",
+                 "apiVersion": "authentication.k8s.io/v1beta1",
+                 "spec": {"token": token}}
+    return "curl -X POST -H 'Content-Type: application/json' \
+           -d '{}' {}".format(json.dumps(json_data), url)
+
+
+async def get_hostname(one_master):
+    cmd = "hostname -i"
+    output = await one_master.run(cmd, timeout=15)
+    assert output.status == "completed"
+    return output.results.get("Stdout", "").strip()
+
+
+async def get_valid_token(one_master):
+    output = await one_master.run("cat /home/ubuntu/config")
+    assert output.status == "completed"
+    kubeconfig = safe_load(output.results.get("Stdout", ""))
+    assert "users" in kubeconfig
+    return kubeconfig["users"][0]["user"]["token"]
+
+
+async def verify_service(one_master):
+    cmd = "systemctl is-active cdk.master.auth-webhook.service"
+    output = await one_master.run(cmd)
+    assert output.status == "completed"
+    assert output.results.get("Stdout", "").strip() == "active"
+
+
+async def verify_auth_success(one_master, cmd):
+    output = await one_master.run(cmd)
+    assert output.status == "completed"
+    assert "authenticated:true" in output.results.get("Stdout", "").replace('"', '')
+
+
+async def verify_auth_failure(one_master, cmd):
+    output = await one_master.run(cmd)
+    assert output.status == "completed"
+    assert "authenticated:false" in output.results.get("Stdout", "").replace('"', '')
+
+
+async def verify_custom_auth(one_master, cmd):
+    output = await one_master.run(cmd)
+    assert output.status == "completed"
+
+    # make sure expected custom log entry is present
+    output = await one_master.run("grep Forwarding /root/cdk/auth-webhook/auth-webhook.log")
+    assert output.status == "completed"
+    assert "Forwarding to" in output.results.get("Stdout", "").strip()
+
+
+@pytest.mark.asyncio
+async def test_validate_auth_webhook(model, tools):
+    # This test verifies the auth-webhook service is working
+    log("starting auth-webhook test")
+    masters = model.applications["kubernetes-master"]
+    k8s_version_str = masters.data["workload-version"]
+    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
+    if k8s_minor_version < (1, 17):
+        log("skipping, k8s version v" + k8s_version_str)
+        return
+
+    one_master = random.choice(masters.units)
+    hostname = await get_hostname(one_master)
+    await verify_service(one_master)
+
+    # Verify authn with a valid token
+    valid_token = await get_valid_token(one_master)
+    good_curl = get_curl_cmd("https://{}:5000/v1beta1".format(hostname), valid_token)
+    await verify_auth_success(one_master, good_curl)
+
+    # Verify no auth with an invalid token
+    invalid_token = "this_cant_be_right"
+    bad_curl = get_curl_cmd("https://{}:5000/v1beta1".format(hostname), invalid_token)
+    await verify_auth_failure(one_master, bad_curl)
+
+    try:
+        # Verify invalid token triggers a call to a custom endpoint
+        await masters.set_config({"authn-webhook-endpoint": "https://localhost:6000/v1beta1"})
+        log("waiting for cluster to settle...")
+        await tools.juju_wait()
+        await verify_custom_auth(one_master, bad_curl)
+    finally:
+        # Reset config
+        await masters.set_config({"authn-webhook-endpoint": ""})
+        log("waiting for cluster to settle...")
+        await tools.juju_wait()

--- a/jobs/integration/test_auth_webhook.py
+++ b/jobs/integration/test_auth_webhook.py
@@ -6,11 +6,15 @@ from yaml import safe_load
 
 
 def get_curl_cmd(url, token):
-    json_data = {"kind": "TokenReview",
-                 "apiVersion": "authentication.k8s.io/v1beta1",
-                 "spec": {"token": token}}
+    json_data = {
+        "kind": "TokenReview",
+        "apiVersion": "authentication.k8s.io/v1beta1",
+        "spec": {"token": token},
+    }
     return "curl -X POST -H 'Content-Type: application/json' \
-           -d '{}' {}".format(json.dumps(json_data), url)
+           -d '{}' {}".format(
+        json.dumps(json_data), url
+    )
 
 
 async def get_hostname(one_master):
@@ -38,13 +42,13 @@ async def verify_service(one_master):
 async def verify_auth_success(one_master, cmd):
     output = await one_master.run(cmd)
     assert output.status == "completed"
-    assert "authenticated:true" in output.results.get("Stdout", "").replace('"', '')
+    assert "authenticated:true" in output.results.get("Stdout", "").replace('"', "")
 
 
 async def verify_auth_failure(one_master, cmd):
     output = await one_master.run(cmd)
     assert output.status == "completed"
-    assert "authenticated:false" in output.results.get("Stdout", "").replace('"', '')
+    assert "authenticated:false" in output.results.get("Stdout", "").replace('"', "")
 
 
 async def verify_custom_auth(one_master, cmd, endpoint):
@@ -52,9 +56,13 @@ async def verify_custom_auth(one_master, cmd, endpoint):
     assert output.status == "completed"
 
     # make sure expected custom log entry is present
-    output = await one_master.run("grep Forwarding /root/cdk/auth-webhook/auth-webhook.log")
+    output = await one_master.run(
+        "grep Forwarding /root/cdk/auth-webhook/auth-webhook.log"
+    )
     assert output.status == "completed"
-    assert "Forwarding to: {}".format(endpoint) in output.results.get("Stdout", "").strip()
+    assert (
+        "Forwarding to: {}".format(endpoint) in output.results.get("Stdout", "").strip()
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add a test to exercise the auth-webhook service included in the current stable k8s-master charm. Run looks like this:

```bash

py3 run-test: commands[1] | pytest jobs/integration/test_auth_webhook.py --controller aws-us-east-1 --model beta --cloud aws --charm-channel beta
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py3/.pytest_cache
rootdir: /home/kwmonroe/charms/charmed-kubernetes/jenkins, configfile: pytest.ini
plugins: asyncio-0.14.0, flaky-3.7.0, html-2.1.1, metadata-1.10.0
collected 1 item

jobs/integration/test_auth_webhook.py::test_validate_auth_webhook 
-------------------------------- live log setup --------------------------------
unknown facade CAASModelOperator
unexpected facade CAASModelOperator found, unable to decipher version to use
unknown delta type: id
  starting auth-webhook test
  verifying valid token
  verifying invalid token
  verifying custom endpoint
  waiting for cluster to settle...
  waiting for cluster to settle...
PASSED
```