### PR TITLE
set kube_ersion early if we have a kube_version

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -5,7 +5,7 @@ def kube_status = "stable"
 def kube_version = params.k8s_tag
 def kube_ersion = null
 if (kube_version != "") {
-    kube_ersion = kube_version.substring(1);
+    kube_ersion = kube_version.substring(1)
 }
 def lxd_exec(String container, String cmd) {
     sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
@@ -55,7 +55,6 @@ pipeline {
                     }
                     kube_ersion = kube_version.substring(1);
                 }
-                echo "Set K8s version to: ${kube_version} and K8s ersion: ${kube_ersion}"
             }
         }
         stage('Setup Source') {
@@ -89,6 +88,7 @@ pipeline {
         }
         stage('Build cdk-addons and image list'){
             steps {
+                echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
 
                     cd cdk-addons

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -152,7 +152,7 @@ pipeline {
         stage('Setup LXD container for ctr'){
             steps {
                 sh "sudo lxc launch ubuntu:18.04 image-processor"
-                lxd_exec("image-processor", "sleep 5")
+                lxd_exec("image-processor", "sleep 10")
                 lxd_exec("image-processor", "apt update")
                 lxd_exec("image-processor", "apt install containerd -y")
             }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -3,11 +3,9 @@
 def bundle_image_file = "./bundle/container-images.txt"
 def kube_status = "stable"
 def kube_version = params.k8s_tag
-if (kube_version == "") {
-    def kube_ersion = null
-} else {
-    def kube_ersion = kube_version.substring(1);
-}
+def kube_ersion = null
+if (kube_version != "") {
+    kube_ersion = kube_version.substring(1);
 def lxd_exec(String container, String cmd) {
     sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
 }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -3,7 +3,11 @@
 def bundle_image_file = "./bundle/container-images.txt"
 def kube_status = "stable"
 def kube_version = params.k8s_tag
-def kube_ersion = null
+if (kube_version == "") {
+    def kube_ersion = null
+} else {
+    def kube_ersion = kube_version.substring(1);
+}
 def lxd_exec(String container, String cmd) {
     sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
 }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -6,6 +6,7 @@ def kube_version = params.k8s_tag
 def kube_ersion = null
 if (kube_version != "") {
     kube_ersion = kube_version.substring(1);
+}
 def lxd_exec(String container, String cmd) {
     sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
 }


### PR DESCRIPTION
If we specify a `kube_version` param, we'll never set the `kube_ersion`.  Fix that by setting it early when a `kube_version` is present.