### PR TITLE
Switch to create_subprocess_exec

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1580,7 +1580,7 @@ async def test_encryption_at_rest(model, tools):
     try:
         await asyncio.wait_for(tools.juju_wait(), timeout=30 * 60)
     except asyncio.TimeoutError:
-        stdout, stderr = await tools.run(f"juju status -m {tools.connection}")
+        stdout, stderr = await tools.run("juju", "status", "-m", tools.connection)
         click.echo(f"Timed out waiting for cluster:\n{stderr}\n{stdout}")
         raise
 


### PR DESCRIPTION
Use `asyncio.create_subprocess_exec` instead of `create_subprocess_shell`, as well as use the absolute path for
`juju-wait`, to rule out additional sources of possible exec error. Also include the exit code in the error if a run command fails.