### PR TITLE
Add metallb charms to support matrix

### DIFF
--- a/cilib/run.py
+++ b/cilib/run.py
@@ -22,11 +22,14 @@ def _log_sub_out(pipe):
 def script(script_data, **kwargs):
     is_single_command = len(script_data.splitlines()) == 1
     process = None
+    env = os.environ.copy()
+    if "charm" in kwargs:
+        env["CHARM"] = kwargs.pop("charm")
     if is_single_command:
         process = subprocess.Popen(
             script_data.strip(),
             shell=True,
-            env=os.environ.copy(),
+            env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             **kwargs
@@ -41,7 +44,7 @@ def script(script_data, **kwargs):
     os.close(tmp_script[0])
     process = subprocess.Popen(
         ["bash", str(tmp_script_path)],
-        env=env.copy(),
+        env=os.env.copy(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         **kwargs

--- a/cilib/run.py
+++ b/cilib/run.py
@@ -44,7 +44,7 @@ def script(script_data, **kwargs):
     os.close(tmp_script[0])
     process = subprocess.Popen(
         ["bash", str(tmp_script_path)],
-        env=os.env.copy(),
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         **kwargs

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -337,7 +337,9 @@ class BuildEntity:
         """Perform charm build against charm/bundle"""
         if "override-build" in self.opts:
             click.echo("Override build found, running in place of charm build.")
-            ret = script(self.opts["override-build"])
+            ret = script(
+                self.opts["override-build"], cwd=self.src_path, charm=self.name
+            )
         else:
             ret = cmd_ok(
                 "charm build -r --force -i https://localhost", cwd=self.src_path

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -236,7 +236,7 @@ class BuildEntity:
         self.name = name
 
         # Alias to name
-        self.src_path = self.name
+        self.src_path = opts.get("src-path", self.name)
 
         self.dst_path = str(self.build.build_dir / self.name)
 
@@ -498,7 +498,7 @@ class BundleBuildEntity(BuildEntity):
     def push(self):
         """Pushes a built charm to Charmstore"""
 
-        click.echo(f"Pushing built {self.name} to {self.entity}")
+        click.echo(f"Pushing bundle {self.name} from {self.src_path} to {self.entity}")
         out = sh.charm.push(self.name, self.entity)
         click.echo(f"Charm push returned: {out}")
         # Output includes lots of ansi escape sequences from the docker push,
@@ -511,12 +511,16 @@ class BundleBuildEntity(BuildEntity):
     def has_changed(self):
         charmstore_bundle = self.download("bundle.yaml")
         charmstore_bundle = yaml.safe_load(charmstore_bundle.text)
-        charmstore_bundle_services = charmstore_bundle["services"]
+        charmstore_bundle_services = charmstore_bundle.get(
+            "applications", charmstore_bundle.get("services", {})
+        )
 
         local_built_bundle = yaml.safe_load(
             (Path(self.name) / "bundle.yaml").read_text(encoding="utf8")
         )
-        local_built_bundle_services = local_built_bundle["services"]
+        local_built_bundle_services = local_built_bundle.get(
+            "applications", local_built_bundle.get("services", {})
+        )
         the_diff = [
             i["charm"]
             for _, i in charmstore_bundle_services.items()
@@ -654,7 +658,7 @@ def build_bundles(bundle_list, bundle_branch, filter_by_tag, bundle_repo, to_cha
         "to_channel": to_channel,
     }
 
-    bundle_repo_dir = build_env.tmp_dir / "bundles-kubernetes"
+    default_repo_dir = build_env.tmp_dir / "bundles-kubernetes"
     # bundle_build_dir = build_env.tmp_dir / "tmp-bundles"
     # sh.rm("-rf", bundle_repo_dir)
     # sh.rm("-rf", bundle_build_dir)
@@ -664,7 +668,7 @@ def build_bundles(bundle_list, bundle_branch, filter_by_tag, bundle_repo, to_cha
         "--branch",
         bundle_branch,
         bundle_repo,
-        str(bundle_repo_dir),
+        str(default_repo_dir),
         _iter=True,
         _bg_exc=False,
     ):
@@ -676,18 +680,35 @@ def build_bundles(bundle_list, bundle_branch, filter_by_tag, bundle_repo, to_cha
                 click.echo(f"Skipping {bundle_name}")
                 continue
             click.echo(f"Processing {bundle_name}")
-            cmd = [
-                str(bundle_repo_dir / "bundle"),
-                "-o",
-                bundle_name,
-                "-c",
-                to_channel,
-                bundle_opts["fragments"],
-            ]
-            click.echo(f"Running {' '.join(cmd)}")
-            import subprocess
+            if "repo" in bundle_opts:
+                # override the default repo
+                bundle_repo_dir = build_env.tmp_dir / bundle_name
+                for line in git.clone(
+                    "--branch",
+                    bundle_branch,
+                    bundle_opts["bundle_repo"],
+                    str(bundle_repo_dir),
+                    _iter=True,
+                    _bg_exc=False,
+                ):
+                    click.echo(line)
+            else:
+                bundle_repo_dir = default_repo_dir
 
-            subprocess.run(" ".join(cmd), shell=True)
+            if not bundle_opts.get("skip-build", False):
+                cmd = [
+                    str(bundle_repo_dir / "bundle"),
+                    "-o",
+                    bundle_name,
+                    "-c",
+                    to_channel,
+                    bundle_opts["fragments"],
+                ]
+                click.echo(f"Running {' '.join(cmd)}")
+                import subprocess
+
+                subprocess.run(" ".join(cmd), shell=True)
+
             bundle_entity = f"cs:~{bundle_opts['namespace']}/{bundle_name}"
             build_entity = BundleBuildEntity(
                 build_env, bundle_name, bundle_opts, bundle_entity

--- a/jobs/includes/charm-bundles-list.inc
+++ b/jobs/includes/charm-bundles-list.inc
@@ -26,3 +26,9 @@
 - kubeflow:
     namespace: kubeflow-charmers
     tags: ['general', 'kubeflow']
+- metallb:
+    namespace: containers
+    repo: "https://github.com/charmed-kubernetes/metallb-operator"
+    skip-build: true
+    src-path: "bundle"
+    tags: ['k8s', 'addons', 'metallb']

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -113,13 +113,13 @@
     upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
-    tags: ["k8s", "metallb-operator", "metallb-controller"]
+    tags: ["k8s", "metallb", "metallb-controller"]
     override-build: make charm
 - metallb-speaker:
     upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
-    tags: ["k8s", "metallb-operator", "metallb-speaker"]
+    tags: ["k8s", "metallb", "metallb-speaker"]
     override-build: make charm
 
 # - multus:

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -109,6 +109,19 @@
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-vsphere-integrator'
     tags: ['k8s', 'charm-vsphere-integrator']
+- metallb-controller:
+    upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
+    namespace: "containers"
+    downstream: "charmed-kubernetes/metallb-operator"
+    tags: ["k8s", "metallb-operator", "metallb-controller"]
+    override-build: make charm
+- metallb-speaker:
+    upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
+    namespace: "containers"
+    downstream: "charmed-kubernetes/metallb-operator"
+    tags: ["k8s", "metallb-operator", "metallb-speaker"]
+    override-build: make charm
+
 # - multus:
 #     upstream: "https://github.com/charmed-kubernetes/charm-multus.git"
 #     namespace: 'containers'

--- a/jobs/release-charm.yaml
+++ b/jobs/release-charm.yaml
@@ -49,6 +49,8 @@
             - 'kubeflow-charmers/kubeflow-tf-job-operator'
             - 'kubeflow-charmers/kubeflow-tf-serving'
             - 'kubeflow-charmers/redis-k8s'
+            - 'containers/metallb-controller'
+            - 'containers/metallb-speaker'
     properties:
       - build-discarder:
           num-to-keep: 2

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,11 @@ setenv   =
     PYTHONPATH = PYTHONPATH:{toxinidir}
 passenv = *
 
+[testenv:format]
+commands =
+         pip-sync {toxinidir}/requirements.txt
+         inv format
+
 [testenv:docs]
 commands =
          pip-sync {toxinidir}/requirements.txt


### PR DESCRIPTION
Uses override-build to use the new `make charm` pattern. This will be cleaned up in a future refactor. Also adds passes the name of the charm being built in, since the Makefile can build either charm from the same repo.