### PR TITLE
Make Vault test use HA

### DIFF
--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -39,7 +39,7 @@ applications:
   easyrsa: null
   vault:
     charm: cs:vault
-    num_units: 1
+    num_units: 2
     options:
       auto-generate-root-ca-cert: true
       disable-mlock: true
@@ -56,6 +56,7 @@ relations:
   - ["vault:certificates", "kubeapi-load-balancer:certificates"]
   - ["vault:certificates", "etcd:certificates"]
   - ["vault:shared-db", "percona-cluster:shared-db"]
+  - ["vault:etcd", "etcd:db"]
   - ["kubernetes-master:vault-kv", "vault:secrets"]
 EOF
 }

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -68,18 +68,8 @@ function now_min
 
 function juju::wait
 {
-    # We can only wait for Vault to be ready to unseal. The test itself has to
-    # wait for the rest of the cluster to settle after that is done.
-    echo "Waiting for Vault to be ready to initialize..."
-    start_min=$(now_min)
-    while ! juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" vault | grep -q "Vault needs to be initialized"; do
-        sleep 60
-        if (( $(now_min) - start_min > 20 )); then
-            echo "Timed out waiting for Vault"
-            juju status -m "$JUJU_CONTROLLER:$JUJU_MODEL" vault
-            exit 124
-        fi
-    done
+    # Cluster status won't be stable because Vault requires manual unsealing.
+    return
 }
 
 function test::execute

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ invoke
 importlib-metadata
 jenkins-job-builder
 jinja2
-juju==2.8.2
+juju
 jujubundlelib
 kv
 loguru

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@
 #
 aiocontextvars==0.2.2
     # via -r requirements.in
-aioify==0.3.2
+aioify==0.4.0
     # via -r requirements.in
-ansible-base==2.10.2
+ansible-base==2.10.7
     # via ansible
-ansible==2.10.1
+ansible==3.2.0
     # via -r requirements.in
 appdirs==1.4.4
     # via
@@ -22,11 +22,14 @@ async-generator==1.10
     #   asyncio-extras
 asyncio-extras==1.3.2
     # via -r requirements.in
-attrs==20.2.0
-    # via pytest
-autopep8==1.5.4
+attrs==20.3.0
+    # via
+    #   charmcraft
+    #   jsonschema
+    #   pytest
+autopep8==1.5.6
     # via -r requirements.in
-awscli==1.18.169
+awscli==1.19.41
     # via -r requirements.in
 backcall==0.2.0
     # via ipython
@@ -38,9 +41,9 @@ beautifulsoup4==4.9.3
     # via bs4
 black==20.8b1
     # via -r requirements.in
-boto3==1.16.9
+boto3==1.17.41
     # via -r requirements.in
-botocore==1.19.9
+botocore==1.20.41
     # via
     #   awscli
     #   boto3
@@ -49,16 +52,16 @@ bs4==0.0.1
     # via -r requirements.in
 canonicalwebteam.snapstoreapi==0.4.4
     # via -r requirements.in
-certifi==2020.6.20
+certifi==2020.12.5
     # via requests
-cffi==1.14.3
+cffi==1.14.5
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
 chardet==3.0.4
     # via requests
-charmcraft==0.6.0
+charmcraft==0.9.0
     # via -r requirements.in
 click==7.1.2
     # via
@@ -71,13 +74,12 @@ click==7.1.2
 colorama==0.3.9
     # via
     #   awscli
-    #   hunter
     #   ogc
 configobj==5.0.6
     # via -r requirements.in
 contextvars==2.4
     # via -r requirements.in
-cryptography==3.3.2
+cryptography==3.4.7
     # via
     #   ansible-base
     #   paramiko
@@ -86,7 +88,7 @@ decorator==4.4.2
     # via
     #   ipython
     #   retry
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via python3-openid
 dict-deep==2.0.2
     # via ogc
@@ -100,45 +102,49 @@ docutils==0.15.2
     # via awscli
 drypy==1.0.1
     # via -r requirements.in
-fasteners==0.15
+fasteners==0.16
     # via jenkins-job-builder
-flake8==3.8.4
+flake8==3.9.0
     # via -r requirements.in
 flaky==3.7.0
     # via -r requirements.in
 future==0.18.2
     # via lunr
-httplib2==0.19.0
+httplib2==0.19.1
     # via
     #   launchpadlib
     #   lazr.restfulclient
-hunter==3.3.1
+humanize==3.3.0
+    # via charmcraft
+hunter==3.3.2
     # via -r requirements.in
 idna==2.10
     # via requests
-immutables==0.14
+immutables==0.15
     # via contextvars
-importlib-metadata==2.0.0
-    # via -r requirements.in
+importlib-metadata==3.10.0
+    # via
+    #   -r requirements.in
+    #   keyring
 iniconfig==1.1.1
     # via pytest
-invoke==1.4.1
+invoke==1.5.0
     # via -r requirements.in
-ipdb==0.13.4
+ipdb==0.13.7
     # via -r requirements.in
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.19.0
+ipython==7.22.0
     # via ipdb
 iso8601==0.1.14
     # via surl
-jedi==0.17.2
+jedi==0.18.0
     # via ipython
-jeepney==0.4.3
+jeepney==0.6.0
     # via
     #   keyring
     #   secretstorage
-jenkins-job-builder==3.6.0
+jenkins-job-builder==3.9.0
     # via -r requirements.in
 jinja2==2.11.2
     # via
@@ -152,15 +158,17 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-joblib==0.17.0
+joblib==1.0.1
     # via nltk
-juju==2.8.2
+jsonschema==3.2.0
+    # via charmcraft
+juju==2.8.6
     # via -r requirements.in
 jujubundlelib==0.5.6
     # via
     #   -r requirements.in
     #   theblues
-keyring==21.4.0
+keyring==23.0.1
     # via launchpadlib
 kv==0.3
     # via
@@ -190,9 +198,9 @@ macaroonbakery==1.3.1
     #   charmcraft
     #   juju
     #   theblues
-manhole==1.6.0
+manhole==1.7.0
     # via hunter
-markdown==3.3.3
+markdown==3.3.4
     # via
     #   mkdocs
     #   mkdocs-material
@@ -205,7 +213,7 @@ melddict==1.0.1
     # via ogc
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==6.1.2
+mkdocs-material==7.1.0
     # via
     #   -r requirements.in
     #   mkdocs-material-extensions
@@ -213,13 +221,11 @@ mkdocs==1.1.2
     # via
     #   -r requirements.in
     #   mkdocs-material
-module-wrapper==0.2.4
+module-wrapper==0.3.1
     # via aioify
-monotonic==1.5
-    # via fasteners
 multi-key-dict==2.0.3
     # via python-jenkins
-multiprocess==0.70.10
+multiprocess==0.70.11.1
     # via pathos
 mypy-extensions==0.4.3
     # via
@@ -238,17 +244,17 @@ ogc==1.0.2
     #   -r requirements.in
     #   ogc-plugins-juju
     #   ogc-plugins-runner
-packaging==20.4
+packaging==20.9
     # via
     #   ansible-base
     #   pytest
 paramiko==2.7.2
     # via juju
-parso==0.7.1
+parso==0.8.2
     # via jedi
-pathos==0.2.6
+pathos==0.2.7
     # via -r requirements.in
-pathspec==0.8.0
+pathspec==0.8.1
     # via black
 pbr==5.5.1
     # via
@@ -262,23 +268,21 @@ pickleshare==0.7.5
     # via ipython
 pluggy==0.13.1
     # via pytest
-poetry-version==0.1.5
-    # via module-wrapper
 pox==0.2.9
     # via pathos
 ppft==1.6.6.3
     # via pathos
-prettytable==1.0.1
+prettytable==2.1.0
     # via -r requirements.in
-prometheus-client==0.8.0
+prometheus-client==0.9.0
     # via canonicalwebteam.snapstoreapi
-prompt-toolkit==3.0.8
+prompt-toolkit==3.0.18
     # via ipython
-protobuf==3.13.0
+protobuf==3.15.6
     # via macaroonbakery
-ptyprocess==0.6.0
+ptyprocess==0.7.0
     # via pexpect
-py==1.9.0
+py==1.10.0
     # via
     #   pytest
     #   retry
@@ -286,7 +290,7 @@ pyasn1==0.4.8
     # via
     #   juju
     #   rsa
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via
     #   autopep8
     #   flake8
@@ -294,9 +298,9 @@ pycountry==20.7.3
     # via canonicalwebteam.snapstoreapi
 pycparser==2.20
     # via cffi
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pygments==2.7.4
+pygments==2.8.1
     # via
     #   ipython
     #   mkdocs-material
@@ -306,7 +310,7 @@ pymacaroons==0.13.0
     #   canonicalwebteam.snapstoreapi
     #   macaroonbakery
     #   surl
-pymdown-extensions==8.0.1
+pymdown-extensions==8.1.1
     # via mkdocs-material
 pynacl==1.1.2
     # via
@@ -322,15 +326,17 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyrsistent==0.17.3
+    # via jsonschema
 pytest-asyncio==0.14.0
     # via -r requirements.in
-pytest-html==2.1.1
+pytest-html==3.1.1
     # via -r requirements.in
-pytest-metadata==1.10.0
+pytest-metadata==1.11.0
     # via pytest-html
-pytest-mock==3.3.1
+pytest-mock==3.5.1
     # via -r requirements.in
-pytest==6.1.2
+pytest==6.2.2
     # via
     #   -r requirements.in
     #   pytest-asyncio
@@ -346,15 +352,15 @@ python-dotenv==0.10.3
     # via
     #   -r requirements.in
     #   ogc
-python-frontmatter==0.5.0
+python-frontmatter==1.0.0
     # via -r requirements.in
 python-jenkins==1.7.0
     # via jenkins-job-builder
 python3-openid==3.2.0
     # via canonicalwebteam.snapstoreapi
-pytz==2020.4
+pytz==2021.1
     # via pyrfc3339
-pyyaml-include==1.2
+pyyaml-include==1.2.post2
     # via ogc
 pyyaml==5.3.1
     # via
@@ -370,7 +376,7 @@ pyyaml==5.3.1
     #   ogc-plugins-juju
     #   python-frontmatter
     #   pyyaml-include
-regex==2020.10.28
+regex==2021.3.17
     # via
     #   black
     #   nltk
@@ -389,13 +395,13 @@ requests==2.24.0
     #   theblues
 retry==0.9.2
     # via -r requirements.in
-rsa==4.5
+rsa==4.7.2
     # via awscli
-s3transfer==0.3.3
+s3transfer==0.3.6
     # via
     #   awscli
     #   boto3
-secretstorage==3.1.2
+secretstorage==3.3.1
     # via keyring
 semver==2.13.0
     # via ogc
@@ -409,25 +415,25 @@ six==1.15.0
     # via
     #   bcrypt
     #   configobj
-    #   cryptography
     #   fasteners
     #   jenkins-job-builder
+    #   jsonschema
     #   launchpadlib
     #   lazr.restfulclient
     #   livereload
     #   lunr
     #   macaroonbakery
-    #   packaging
     #   ppft
     #   protobuf
     #   pymacaroons
     #   pynacl
     #   python-dateutil
-    #   python-frontmatter
     #   python-jenkins
-soupsieve==2.0.1
+soupsieve==2.2.1
     # via beautifulsoup4
-stevedore==3.2.2
+stdlib-list==0.8.0
+    # via module-wrapper
+stevedore==3.3.0
     # via jenkins-job-builder
 surl==0.7.2
     # via -r requirements.in
@@ -445,20 +451,19 @@ toml==0.10.2
     # via
     #   autopep8
     #   black
+    #   ipdb
     #   pytest
-tomlkit==0.5.11
-    # via poetry-version
-toposort==1.5
+toposort==1.6
     # via juju
 tornado==6.1
     # via
     #   livereload
     #   mkdocs
-tqdm==4.51.0
+tqdm==4.59.0
     # via nltk
 traitlets==5.0.5
     # via ipython
-typed-ast==1.4.1
+typed-ast==1.4.2
     # via black
 typing-extensions==3.7.4.3
     # via
@@ -470,7 +475,7 @@ urllib3==1.25.11
     # via
     #   botocore
     #   requests
-wadllib==1.3.4
+wadllib==1.3.5
     # via
     #   launchpadlib
     #   lazr.restfulclient
@@ -480,9 +485,9 @@ wcwidth==0.2.5
     #   prompt-toolkit
 websockets==7.0
     # via juju
-wheel==0.35.1
+wheel==0.36.2
     # via -r requirements.in
-zipp==3.4.0
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Test Vault in an HA configuration without EasyRSA.

The TL;DR process for using Vault HA w/o EasyRSA is:

* Deploy Vault as per normal but with multiple units and a cert relation to etcd
* Wait for at least the Vault leader to settle
* Manually Init and unseal the leader unit
* Generate or provide a root CA cert to Vault
* Wait for the etcd units to settle
* Manually restart the `vault` service and (re)do the unseal on all of the Vault units

There are a couple of status issues in the k8s-master and vault charms which will be fixed with upcoming releases (including a potential hook error on k8s-master depending on the timing of when the vault services are restarted / re-unsealed due to https://github.com/juju-solutions/layer-vault-kv/pull/11) but these are just reporting issues which don't impact functionality (the errored hook, if encountered, can just be retried once the Vault units are back up).

Part of [lp:1897818](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1897818)