### PR TITLE
Ensure $HOME/.local/bin first on PATH

### DIFF
--- a/jobs/build-charms/spec.yml
+++ b/jobs/build-charms/spec.yml
@@ -3,7 +3,7 @@ plan:
       - |
         #!/bin/bash
         set -eux
-        export PATH=/snap/bin:$PATH
+        export PATH=$HOME/.local/bin:/snap/bin:$PATH
 
         IS_REBUILD_CACHE=""
         if [[ $REBUILD_CACHE = "true" ]]; then


### PR DESCRIPTION
Due to confinement and the use of a non-standard HOME dir, CI needs to use the pip package of charmcraft rather than the snap. This is being installed, but we need to ensure that the directory where the `pip install --user` command puts it is first on the PATH.