### PR TITLE
Refactor charm building to support charmcraft

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -1,27 +1,31 @@
 'cs:~containers/canal':
-  calico-amd64.tar.gz: calico
-  calico-arm64.tar.gz: calico-arm64
-  calico-upgrade-amd64.tar.gz: calico-upgrade
-  calico-upgrade-arm64.tar.gz: calico-upgrade-arm64
-  calico-node-image.tar.gz: calico-node-image
-  flannel-amd64.tar.gz: flannel
-  flannel-arm64.tar.gz: flannel-arm64
+  calico: '{out_path}/calico-amd64.tar.gz'
+  calico-arm64: '{out_path}/calico-arm64.tar.gz'
+  calico-upgrade: '{out_path}/calico-upgrade-amd64.tar.gz'
+  calico-upgrade-arm64: '{out_path}/calico-upgrade-arm64.tar.gz'
+  calico-node-image: '{out_path}/calico-node-image.tar.gz'
+  flannel: '{out_path}/flannel-amd64.tar.gz'
+  flannel-arm64: '{out_path}/flannel-arm64.tar.gz'
 'cs:~containers/calico':
-  calico-amd64.tar.gz: calico
-  calico-arm64.tar.gz: calico-arm64
-  calico-upgrade-amd64.tar.gz: calico-upgrade
-  calico-upgrade-arm64.tar.gz: calico-upgrade-arm64
-  calico-node-image.tar.gz: calico-node-image
+  calico: '{out_path}/calico-amd64.tar.gz'
+  calico-arm64: '{out_path}/calico-arm64.tar.gz'
+  calico-upgrade: '{out_path}/calico-upgrade-amd64.tar.gz'
+  calico-upgrade-arm64: '{out_path}/calico-upgrade-arm64.tar.gz'
+  calico-node-image: '{out_path}/calico-node-image.tar.gz'
 'cs:~containers/flannel':
-  flannel-amd64.tar.gz: flannel-amd64
-  flannel-arm64.tar.gz: flannel-arm64
-  flannel-s390x.tar.gz: flannel-s390x
+  flannel-amd64: '{out_path}/flannel-amd64.tar.gz'
+  flannel-arm64: '{out_path}/flannel-arm64.tar.gz'
+  flannel-s390x: '{out_path}/flannel-s390x.tar.gz'
 'cs:~containers/kubernetes-worker':
-  cni-amd64.tgz: cni-amd64
-  cni-arm64.tgz: cni-arm64
-  cni-s390x.tgz: cni-s390x
+  cni-amd64: '{out_path}/cni-amd64.tgz'
+  cni-arm64: '{out_path}/cni-arm64.tgz'
+  cni-s390x: '{out_path}/cni-s390x.tgz'
 'cs:~containers/tigera-secure-ee':
-  calico-cni-amd64.tar.gz: calico-cni
-  calico-cni-arm64.tar.gz: calico-cni-arm64
-  calicoctl-image.tar.gz: calicoctl-image
-  calico-node-image.tar.gz: calico-node-image
+  calico-cni: '{out_path}/calico-cni-amd64.tar.gz'
+  calico-cni-arm64: '{out_path}/calico-cni-arm64.tar.gz'
+  calicoctl-image: '{out_path}/calicoctl-image.tar.gz'
+  calico-node-image: '{out_path}/calico-node-image.tar.gz'
+'cs:~containers/multus':
+  net-attach-def-manager-image: 'net-attach-def-manager'
+'cs:~containers/sriov-cni':
+  sriov-cni-image: 'sriov-cni'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -2,13 +2,13 @@
 - calico:
     upstream: "https://github.com/charmed-kubernetes/layer-calico.git"
     downstream: 'charmed-kubernetes/layer-calico.git'
-    resource_build_sh: 'build-calico-resource.sh'
+    build-resources: "cd {out_path}; bash {src_path}/build-calico-resource.sh"
     namespace: 'containers'
     tags: ['k8s', 'calico']
 - canal:
     upstream: "https://github.com/charmed-kubernetes/layer-canal.git"
     downstream: 'charmed-kubernetes/layer-canal.git'
-    resource_build_sh: 'build-canal-resources.sh'
+    build-resources: "cd {out_path}; bash {src_path}/build-canal-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'canal']
 - containerd:
@@ -34,7 +34,7 @@
 - flannel:
     upstream: "https://github.com/charmed-kubernetes/charm-flannel.git"
     downstream: 'charmed-kubernetes/charm-flannel.git'
-    resource_build_sh: 'build-flannel-resources.sh'
+    build-resources: "cd {out_path}; bash {src_path}/build-flannel-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'flannel']
 - kata:
@@ -60,13 +60,13 @@
 - kubernetes-worker:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-worker.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-worker.git'
-    resource_build_sh: 'build-cni-resources.sh'
+    build-resources: "cd {out_path}; bash {src_path}/build-cni-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'kubernetes-worker']
 - tigera-secure-ee:
     upstream: "https://github.com/charmed-kubernetes/layer-tigera-secure-ee.git"
     downstream: 'charmed-kubernetes/layer-tigera-secure-ee.git'
-    resource_build_sh: 'build-resources.sh'
+    build-resources: "cd {out_path}; bash {src_path}/build-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'tigera-secure-ee']
 - keepalived:
@@ -114,43 +114,33 @@
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
     tags: ["k8s", "metallb", "metallb-controller"]
-    override-build: make charm
-    override-push: make upload
 - metallb-speaker:
     upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
     tags: ["k8s", "metallb", "metallb-speaker"]
-    override-build: make charm
-    override-push: make upload
 - multus:
     upstream: "https://github.com/charmed-kubernetes/charm-multus.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-multus"
     tags: ["k8s", "multus"]
-    override-build: make charm
-    override-push: make upload
+    build-resources: "cd {src_path}/net-attach-def-manager; ./build"
 - sriov-cni:
     upstream: "https://github.com/charmed-kubernetes/charm-sriov-cni.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-sriov-cni"
     tags: ["k8s", "sriov", "sriov-cni"]
-    override-build: make charm
-    override-push: make upload
-- sriov-cni:
+    build-resources: "cd {src_path}/image; ./build"
+- sriov-network-device-plugin:
     upstream: "https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-sriov-network-device-plugin"
     tags: ["k8s", "sriov", "sriov-network-device-plugin"]
-    override-build: make charm
-    override-push: make upload
 - coredns:
     upstream: "https://github.com/charmed-kubernetes/charm-coredns.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-coredns"
     tags: ["k8s", "coredns"]
-    override-build: make charm
-    override-push: make upload
 
 # - nfs:
 #     upstream: "https://github.com/hyperbolic2346/nfs-charm.git"


### PR DESCRIPTION
With this, we can support charms in either style, driven off of the existence or not of a `layer.yaml` file, as well as handling both file and image type resources which must be custom built.