### PR TITLE
Add validation for Calico in VXLAN mode

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -484,16 +484,17 @@
             - edge
       - axis:
           type: user-defined
-          name: test_bgp
+          name: routing_mode
           values:
-            - 0
-            - 1
+            - bgp-simple
+            - bgp-router
+            - vxlan
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
       - run-venv:
           COMMAND: |
-            bash jobs/validate/calico-spec $snap_version $series $channel amd64 $test_bgp
+            bash jobs/validate/calico-spec $snap_version $series $channel amd64 $routing_mode
 
 - job:
     name: 'validate-ck-tigera-secure-ee'

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -18,15 +18,14 @@ function juju::bootstrap
 {
     python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
 
-    export NUM_SUBNETS=1
-    if [ "$TEST_BGP" = "1" ]; then
-      export NUM_SUBNETS=2
-      export JOB_NAME_CUSTOM="validate-ck-calico-bgp-router-$SERIES-$SNAP_VERSION"
+    export NUM_SUBNETS=2
+    if [ "$ROUTING_MODE" = "bgp-simple" ]; then
+      export NUM_SUBNETS=1
     fi
 
     python $WORKSPACE/jobs/integration/tigera_aws.py bootstrap
 
-    if [ "$TEST_BGP" = "1" ]; then
+    if [ "$ROUTING_MODE" = "bgp-router" ]; then
       echo "Deploying bgp router"
       python3 $WORKSPACE/jobs/integration/tigera_aws.py deploy-bgp-router
     fi
@@ -34,6 +33,10 @@ function juju::bootstrap
 
 function juju::deploy::overlay
 {
+    vxlan_mode=Never
+    if [ "$ROUTING_MODE" = "vxlan" ]; then
+      vxlan_mode=Always
+    fi
     cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
@@ -49,6 +52,7 @@ applications:
     charm: cs:~containers/calico
     options:
       cidr: "192.168.0.0/16,fd00:c00b:1::/112"
+      vxlan: $vxlan_mode
 relations:
 - [calico:etcd, etcd:db]
 - [calico:cni, kubernetes-master:cni]
@@ -58,11 +62,13 @@ EOF
 
 function juju::deploy::after
 {
-    python $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
+    if [[ "$ROUTING_MODE" = bgp* ]]; then
+      python $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
+    fi
 
     python $WORKSPACE/jobs/integration/tigera_aws.py assign-ipv6-addrs
 
-    if [ "$TEST_BGP" = "1" ]; then
+    if [ "$ROUTING_MODE" = "bgp-router" ]; then
       python $WORKSPACE/jobs/integration/tigera_aws.py configure-bgp
     fi
 }
@@ -89,8 +95,8 @@ JUJU_CLOUD=aws/us-east-2
 JUJU_CONTROLLER=validate-$(identifier::short)
 JUJU_MODEL=validate-calico
 ARCH=${4:-amd64}
-TEST_BGP=${5:0}
-JOB_NAME_CUSTOM="validate-ck-calico-$SERIES-$SNAP_VERSION"
+ROUTING_MODE=${5:bgp-simple}
+JOB_NAME_CUSTOM="validate-ck-calico-$ROUTING_MODE-$SERIES-$SNAP_VERSION"
 JOB_ID=$(identifier)
 
 


### PR DESCRIPTION
This extends the existing Calico spec to support VXLAN as a routing mode. I did a bit of refactoring in there to make this work, replacing the TEST_BGP parameter with ROUTING_MODE that supports three options: `bgp-simple`, `bgp-router`, and `vxlan`.

This will change the job prefixes from:

```
validate-ck-calico-*
validate-ck-calico-bgp-router-*
```

to:

```
validate-ck-calico-bgp-simple-*
validate-ck-calico-bgp-router-*
validate-ck-calico-vxlan-*
```

Originally I was going to write calico-vxlan as a separate and much simpler spec, but that would have meant giving up ipv6 test coverage in that scenario, and it looked like it would take a bit of work to detangle calico from ipv6 testing. I think this approach ended up nicer anyway.