### PR TITLE
Fix validate-ck-calico always deploying calico from stable

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -47,16 +47,10 @@ applications:
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION
-  flannel:
   calico:
-    charm: cs:~containers/calico
     options:
       cidr: "192.168.0.0/16,fd00:c00b:1::/112"
       vxlan: $vxlan_mode
-relations:
-- [calico:etcd, etcd:db]
-- [calico:cni, kubernetes-master:cni]
-- [calico:cni, kubernetes-worker:cni]
 EOF
 }
 
@@ -89,7 +83,7 @@ function ci::cleanup
 ###############################################################################
 SNAP_VERSION=${1:-1.19/edge}
 SERIES=${2:-bionic}
-JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
+JUJU_DEPLOY_BUNDLE=cs:~containers/kubernetes-calico
 JUJU_DEPLOY_CHANNEL=${3:-edge}
 JUJU_CLOUD=aws/us-east-2
 JUJU_CONTROLLER=validate-$(identifier::short)


### PR DESCRIPTION
The most recent run failed with:

```
+ juju deploy -m validate-e94ccfa8:validate-calico --overlay overlay.yaml --force --channel edge 'cs:~containers/charmed-kubernetes'
Located bundle "cs:~containers/bundle/charmed-kubernetes-535"
Resolving charm: cs:~containers/calico
Resolving charm: cs:~containers/containerd-95
Resolving charm: cs:~containers/easyrsa-334
Resolving charm: cs:~containers/etcd-541
Resolving charm: cs:~containers/kubeapi-load-balancer-750
Resolving charm: cs:~containers/kubernetes-master-901
Resolving charm: cs:~containers/kubernetes-worker-709
Executing changes:
- upload charm cs:~containers/calico-747 for series focal
- deploy application calico on focal using cs:~containers/calico-747
ERROR cannot deploy bundle: cannot deploy application "calico": unknown option "vxlan"
```

The vxlan option is missing because calico-747 is a stable revision, not edge. We should be testing edge.