### PR TITLE
use rocks images since not all ci infra can get upstream

### DIFF
--- a/jobs/integration/templates/integrator-charm-data/aws/bbox.yaml
+++ b/jobs/integration/templates/integrator-charm-data/aws/bbox.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: busybox
+    - image: rocks.canonical.com/cdk/busybox:1.32
       command:
         - sleep
         - "3600"

--- a/jobs/integration/templates/integrator-charm-data/azure/bbox.yaml
+++ b/jobs/integration/templates/integrator-charm-data/azure/bbox.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: busybox
+    - image: rocks.canonical.com/cdk/busybox:1.32
       command:
         - sleep
         - "3600"

--- a/jobs/integration/templates/integrator-charm-data/google/bbox.yaml
+++ b/jobs/integration/templates/integrator-charm-data/google/bbox.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: busybox
+    - image: rocks.canonical.com/cdk/busybox:1.32
       command:
         - sleep
         - "3600"

--- a/jobs/integration/templates/netpolicy-test.yaml
+++ b/jobs/integration/templates/netpolicy-test.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: rocks.canonical.com/cdk/nginx:1.18
         ports:
         - containerPort: 80
 ---
@@ -46,7 +46,7 @@ metadata:
     access: 'yes'
 spec:
   containers:
-  - image: 'busybox'
+  - image: rocks.canonical.com/cdk/busybox:1.32
     name: 'bboxgood'
     command:
       - sleep
@@ -61,7 +61,7 @@ metadata:
     access: 'no'
 spec:
   containers:
-  - image: 'busybox'
+  - image: rocks.canonical.com/cdk/busybox:1.32
     name: 'bboxbad'
     command:
       - sleep

--- a/jobs/integration/templates/test-audit-webhook.yaml
+++ b/jobs/integration/templates/test-audit-webhook.yaml
@@ -25,7 +25,7 @@ spec:
       name: test-audit-webhook
   containers:
   - name: nginx
-    image: rocks.canonical.com:443/cdk/diverdane/nginxdualstack:1.0.0
+    image: rocks.canonical.com/cdk/nginx:1.18
     ports:
     - containerPort: 80
     volumeMounts:

--- a/jobs/integration/templates/validate-dns-spec.yaml
+++ b/jobs/integration/templates/validate-dns-spec.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: rocks.canonical.com:443/v2/ubuntu:bionic
+      image: rocks.canonical.com/cdk/ubuntu:focal
       imagePullPolicy: IfNotPresent
       command: ['sh', '-c', 'apt update -qqy && apt install -qqfy bind9-host && echo "validate-dns: Ready" && sleep 3600 || echo "validate-dns: Failed"']
   restartPolicy: Never

--- a/jobs/integration/test_integrator_charm.py
+++ b/jobs/integration/test_integrator_charm.py
@@ -43,7 +43,7 @@ async def test_load_balancer(setup_storage_elb_resource):
         "hello-world",
         replicas=5,
         labels="run=load-balancer-example",
-        image="gcr.io/google-samples/node-hello:1.0",
+        image="rocks.canonical.com/cdk/google-samples/node-hello:1.0",
         port=8080,
     )
     sh.kubectl.expose("deployment", "hello-world", type="LoadBalancer", name="hello")

--- a/jobs/integration/test_service_endpoints.py
+++ b/jobs/integration/test_service_endpoints.py
@@ -33,7 +33,7 @@ async def is_pod_cleaned():
 async def setup_svc(svc_type):
     # Create Deployment
     sh.kubectl.create(
-        "deployment", "hello-world", image="gcr.io/google-samples/node-hello:1.0"
+        "deployment", "hello-world", image="rocks.canonical.com/cdk/google-samples/node-hello:1.0"
     )
     sh.kubectl.set("env", "deployment/hello-world", "PORT=50000")
 

--- a/jobs/integration/test_service_endpoints.py
+++ b/jobs/integration/test_service_endpoints.py
@@ -33,7 +33,9 @@ async def is_pod_cleaned():
 async def setup_svc(svc_type):
     # Create Deployment
     sh.kubectl.create(
-        "deployment", "hello-world", image="rocks.canonical.com/cdk/google-samples/node-hello:1.0"
+        "deployment",
+        "hello-world",
+        image="rocks.canonical.com/cdk/google-samples/node-hello:1.0",
     )
     sh.kubectl.set("env", "deployment/hello-world", "PORT=50000")
 

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -340,7 +340,7 @@ spec:
       readOnly: false
   containers:
     - name: {0}-write-test
-      image: ubuntu
+      image: rocks.canonical.com/cdk/ubuntu:focal
       command: ["/bin/bash", "-c", "echo 'JUJU TEST' > /data/juju"]
       volumeMounts:
       - name: shared-data
@@ -377,7 +377,7 @@ spec:
       readOnly: false
   containers:
     - name: {0}-read-test
-      image: ubuntu
+      image: rocks.canonical.com/cdk/ubuntu:focal
       command: ["/bin/bash", "-c", "cat /data/juju"]
       volumeMounts:
       - name: shared-data

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1246,7 +1246,6 @@ async def test_audit_custom_policy(model, tools):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_arch(["aarch64", "s390x"])
 async def test_audit_webhook(model, tools):
     app = model.applications["kubernetes-master"]
     unit = app.units[0]
@@ -1956,7 +1955,7 @@ async def test_multus(model, tools, addons_model):
         },
         "spec": {
             "containers": [
-                {"name": "ubuntu", "image": "ubuntu", "command": ["sleep", "3600"]}
+                {"name": "ubuntu", "image": "rocks.canonical.com/cdk/ubuntu:focal", "command": ["sleep", "3600"]}
             ]
         },
     }

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1955,7 +1955,11 @@ async def test_multus(model, tools, addons_model):
         },
         "spec": {
             "containers": [
-                {"name": "ubuntu", "image": "rocks.canonical.com/cdk/ubuntu:focal", "command": ["sleep", "3600"]}
+                {
+                    "name": "ubuntu",
+                    "image": "rocks.canonical.com/cdk/ubuntu:focal",
+                    "command": ["sleep", "3600"],
+                }
             ]
         },
     }


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1903213

Some CI infra can't get out to docker.io/gcr.io/etc, but rocks.c.c is ok.  Replace upstream images with rocks equivalents.