### PR TITLE
Fix calico cleanup operations occurring in wrong order

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -71,10 +71,10 @@ function ci::cleanup
 {
     local log_name_custom=$(echo "$JOB_NAME_CUSTOM" | tr '/' '-')
     {
-        python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
         if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
             timeout 2m juju kill-controller -y "$JUJU_CONTROLLER" || true
         fi
+        python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
     } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"
 }
 


### PR DESCRIPTION
I'm seeing runs fail cleanup with:

```
11:26:25 + ci::cleanup
11:26:25 ++ tr / -
11:26:25 ++ echo validate-ck-calico-bgp-simple-focal-1.18/edge
11:26:25 + local log_name_custom=validate-ck-calico-bgp-simple-focal-1.18-edge
11:26:25 + tee -a ci.log
11:26:25 + sed -u -e 's/^/[validate-ck-calico-bgp-simple-focal-1.18-edge] /'
11:26:25 [validate-ck-calico-bgp-simple-focal-1.18-edge] + python /var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/jobs/integration/tigera_aws.py cleanup
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge] Traceback (most recent call last):
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 563, in <module>
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]     main()
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 560, in main
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]     command_defs[args.command]()
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 237, in cleanup
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]     ec2.detach_internet_gateway(
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 357, in _api_call
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]     return self._make_api_call(operation_name, kwargs)
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-2/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/focal/snap_version/1.18/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 676, in _make_api_call
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge]     raise error_class(parsed_response, operation_name)
11:26:27 [validate-ck-calico-bgp-simple-focal-1.18-edge] botocore.exceptions.ClientError: An error occurred (DependencyViolation) when calling the DetachInternetGateway operation: Network vpc-0d7e1b2b644df2675 has some mapped public address(es). Please unmap those public address(es) before detaching the gateway.
```

I'm pretty sure this is happening because the Juju controller / instances haven't been destroyed yet. This PR should fix it.