### PR TITLE
Increase kill-controller timeout in calico spec

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -72,7 +72,7 @@ function ci::cleanup
     local log_name_custom=$(echo "$JOB_NAME_CUSTOM" | tr '/' '-')
     {
         if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
-            timeout 2m juju kill-controller -y "$JUJU_CONTROLLER" || true
+            timeout 5m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
         fi
         python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
     } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"


### PR DESCRIPTION
The current 2 minute timeout is a bit short and is leading to calico cleanup errors:

```
13:02:47 [validate-ck-calico-bgp-simple-xenial-1.18-edge] + timeout 2m juju kill-controller -y validate-0276db5c
13:02:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Destroying controller "validate-0276db5c"
13:02:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting for resources to be reclaimed
13:02:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:02:53 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:02:59 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:03:04 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:03:09 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:03:14 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications
13:03:19 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m29s
13:03:25 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m23s
13:03:30 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m18s
13:03:35 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m13s
13:03:40 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m8s
13:03:45 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 8 machines, 7 applications, will kill machines directly in 4m3s
13:03:51 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:03:56 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:04:01 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:04:06 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:04:11 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:04:17 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications
13:04:22 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications, will kill machines directly in 4m29s
13:04:27 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications, will kill machines directly in 4m24s
13:04:32 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications, will kill machines directly in 4m19s
13:04:37 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications, will kill machines directly in 4m14s
13:04:43 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Waiting on 1 model, 7 machines, 7 applications, will kill machines directly in 4m8s
13:04:47 [validate-ck-calico-bgp-simple-xenial-1.18-edge] + true
13:04:47 [validate-ck-calico-bgp-simple-xenial-1.18-edge] + python /var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/jobs/integration/tigera_aws.py cleanup
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge] Traceback (most recent call last):
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 563, in <module>
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]     main()
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 560, in main
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]     command_defs[args.command]()
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/jobs/integration/tigera_aws.py", line 237, in cleanup
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]     ec2.detach_internet_gateway(
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 357, in _api_call
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]     return self._make_api_call(operation_name, kwargs)
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/xenial/snap_version/1.18/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 676, in _make_api_call
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge]     raise error_class(parsed_response, operation_name)
13:04:48 [validate-ck-calico-bgp-simple-xenial-1.18-edge] botocore.exceptions.ClientError: An error occurred (DependencyViolation) when calling the DetachInternetGateway operation: Network vpc-0fe57000fb25b7a8f has some mapped public address(es). Please unmap those public address(es) before detaching the gateway.
```

This PR updates it to 5 minutes to match the timeout for kill-controller used in ci.bash. I'm a bit skeptical that 5 minutes will be enough, but we can try it first and see.