### PR TITLE
Ensure any charm builds use unique dirs

### DIFF
--- a/cilib/run.py
+++ b/cilib/run.py
@@ -37,21 +37,21 @@ def script(script_data, **kwargs):
             stderr=subprocess.STDOUT,
             **kwargs,
         )
-
-    if not script_data[:2] != "#!":
-        script_data = "#!/bin/bash\n" + script_data
-    tmp_script = tempfile.mkstemp()
-    tmp_script_path = Path(tmp_script[-1])
-    tmp_script_path.write_text(script_data, encoding="utf8")
-    make_executable(tmp_script_path)
-    os.close(tmp_script[0])
-    process = subprocess.Popen(
-        ["bash", str(tmp_script_path)],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        **kwargs,
-    )
+    else:
+        if not script_data[:2] != "#!":
+            script_data = "#!/bin/bash\n" + script_data
+        tmp_script = tempfile.mkstemp()
+        tmp_script_path = Path(tmp_script[-1])
+        tmp_script_path.write_text(script_data, encoding="utf8")
+        make_executable(tmp_script_path)
+        os.close(tmp_script[0])
+        process = subprocess.Popen(
+            ["bash", str(tmp_script_path)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            **kwargs,
+        )
     with process.stdout:
         _log_sub_out(process.stdout, echo)
     exitcode = process.wait()

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -223,10 +223,10 @@
           rm -rf $WORKSPACE/.env || true
 
           export GIT_SSH_COMMAND='"ssh -i $HOME/.ssh/cdkbot_rsa -oStrictHostKeyChecking=no"'
-          export CHARM_BUILD_DIR="$HOME/.cache/charmbuild/${{CHARM_BUILD_DIR:-build/charms}}"
-          export CHARM_LAYERS_DIR="$HOME/.cache/charmbuild/${{CHARM_LAYERS_DIR:-build/layers}}"
-          export CHARM_INTERFACES_DIR="$HOME/.cache/charmbuild/${{CHARM_INTERFACES_DIR:-build/interfaces}}"
-          export CHARM_CACHE_DIR=$WORKSPACE/tmp/.charm
+          export CHARM_BUILD_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_BUILD_DIR:-build/charms}}"
+          export CHARM_LAYERS_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_LAYERS_DIR:-build/layers}}"
+          export CHARM_INTERFACES_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_INTERFACES_DIR:-build/interfaces}}"
+          export CHARM_CACHE_DIR=$WORKSPAACE/tmp/.charm/charmbuild/$BUILD_TAG/cache
 
           export GOPATH=$HOME/go
           export GOBIN=$HOME/go/bin
@@ -234,7 +234,7 @@
 
           mkdir -p $HOME/bin || true
           mkdir -p $HOME/go/bin || true
-          rm -rf "$HOME/.cache/charmbuild" || true
+          rm -rf "$WORKSPAACE/.cache/charmbuild" || true
           mkdir -p "$CHARM_BUILD_DIR"
           mkdir -p "$CHARM_LAYERS_DIR"
           mkdir -p "$CHARM_INTERFACES_DIR"

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -223,10 +223,10 @@
           rm -rf $WORKSPACE/.env || true
 
           export GIT_SSH_COMMAND='"ssh -i $HOME/.ssh/cdkbot_rsa -oStrictHostKeyChecking=no"'
-          export CHARM_BUILD_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_BUILD_DIR:-build/charms}}"
-          export CHARM_LAYERS_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_LAYERS_DIR:-build/layers}}"
-          export CHARM_INTERFACES_DIR="$WORKSPAACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_INTERFACES_DIR:-build/interfaces}}"
-          export CHARM_CACHE_DIR=$WORKSPAACE/tmp/.charm/charmbuild/$BUILD_TAG/cache
+          export CHARM_BUILD_DIR="$WORKSPACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_BUILD_DIR:-build/charms}}"
+          export CHARM_LAYERS_DIR="$WORKSPACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_LAYERS_DIR:-build/layers}}"
+          export CHARM_INTERFACES_DIR="$WORKSPACE/.cache/charmbuild/$BUILD_TAG/${{CHARM_INTERFACES_DIR:-build/interfaces}}"
+          export CHARM_CACHE_DIR=$WORKSPACE/tmp/.charm/charmbuild/$BUILD_TAG/cache
 
           export GOPATH=$HOME/go
           export GOBIN=$HOME/go/bin
@@ -234,7 +234,7 @@
 
           mkdir -p $HOME/bin || true
           mkdir -p $HOME/go/bin || true
-          rm -rf "$WORKSPAACE/.cache/charmbuild" || true
+          rm -rf "$WORKSPACE/.cache/charmbuild" || true
           mkdir -p "$CHARM_BUILD_DIR"
           mkdir -p "$CHARM_LAYERS_DIR"
           mkdir -p "$CHARM_INTERFACES_DIR"


### PR DESCRIPTION
Using the Jenkins BUILD_TAG env var ensures that every build of every job will use its own directory, and moving it under WORKSPACE provides further isolation.