### PR TITLE
Fix calico/tigera-secure-ee cleanup

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -67,15 +67,9 @@ function juju::deploy::after
     fi
 }
 
-function ci::cleanup
+function ci::cleanup::after
 {
-    local log_name_custom=$(echo "$JOB_NAME_CUSTOM" | tr '/' '-')
-    {
-        if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
-            timeout 5m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
-        fi
-        python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
-    } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"
+    python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
 }
 
 ###############################################################################

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -52,7 +52,7 @@ function juju::deploy::after
     python3 $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
 }
 
-function ci::cleanup::before
+function ci::cleanup::after
 {
     python3 $WORKSPACE/jobs/integration/tigera_aws.py cleanup
 }


### PR DESCRIPTION
This should fix two issues:
1. validate-ck-calico is not collecting crashdumps.
2. validate-ck-tigera-secure-ee is not cleaning up VPCs after itself.

I also introduced a new `ci::cleanup::after` hook, and I moved the `ci::cleanup::before` call to ensure it will always be called at cleanup.