### PR TITLE
Fix ci::cleanup aborting early if _out does not exist

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -154,7 +154,7 @@ function test::capture
     if which juju-crashdump; then
         juju-crashdump -s -a debug-layer -a config -m "$JUJU_CONTROLLER:$JUJU_MODEL"
     fi
-    tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures*
+    tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* || true
     /usr/local/bin/columbo -r columbo.yaml -o "_out" "artifacts.tar.gz" || true
     python bin/s3 cp "columbo-report.json" columbo-report.json || true
 
@@ -223,13 +223,13 @@ function ci::cleanup
 {
     local log_name_custom=$(echo "$JOB_NAME_CUSTOM" | tr '/' '-')
     {
-        ci::cleanup::before
-        test::capture
+        ci::cleanup::before || true
+        test::capture || true
 
         if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
             timeout 5m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
         fi
-        ci::cleanup::after
+        ci::cleanup::after || true
     } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"
 }
 trap ci::cleanup EXIT


### PR DESCRIPTION
Fixes:
```
11:13:01 [validate-ck-calico-bgp-simple-bionic-1.17-edge] + test::capture
11:13:01 [validate-ck-calico-bgp-simple-bionic-1.17-edge] + which juju-crashdump
11:13:01 [validate-ck-calico-bgp-simple-bionic-1.17-edge] /snap/bin/juju-crashdump
11:13:01 [validate-ck-calico-bgp-simple-bionic-1.17-edge] + juju-crashdump -s -a debug-layer -a config -m validate-5fa2f458:validate-calico
11:13:03 [validate-ck-calico-bgp-simple-bionic-1.17-edge] 2020-11-18 17:13:03,122 - juju-crashdump started.
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] 2020-11-18 17:15:57,522 - juju-crashdump finished.
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] + tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump-229e4de0-f6d6-48e1-ae98-c936b1420773.tar.xz 'report.*' 'failures*'
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] ci.log
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] tar: _out: Cannot stat: No such file or directory
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] meta/
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] meta/snap_version-1.17-edge
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] meta/name-validate-ck-calico-bgp-simple-bionic-1.17-edge
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] meta/series-bionic
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] meta/channel-edge
11:15:57 [validate-ck-calico-bgp-simple-bionic-1.17-edge] juju-crashdump-229e4de0-f6d6-48e1-ae98-c936b1420773.tar.xz
11:15:59 [validate-ck-calico-bgp-simple-bionic-1.17-edge] tar: report.*: Cannot stat: No such file or directory
11:15:59 [validate-ck-calico-bgp-simple-bionic-1.17-edge] tar: failures*: Cannot stat: No such file or directory
11:15:59 [validate-ck-calico-bgp-simple-bionic-1.17-edge] tar: Exiting with failure status due to previous errors
```

which stopped the rest of test::capture and ci::cleanup from running.

Also made ci::cleanup more tolerant of errors in general.