### PR TITLE
Fix calico and tigera-secure-ee running juju wait before configuring instances

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -54,8 +54,13 @@ applications:
 EOF
 }
 
-function juju::deploy::after
+function juju::deploy
 {
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
+         --overlay overlay.yaml \
+         --force \
+         --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
+
     if [[ "$ROUTING_MODE" = bgp* ]]; then
       python $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
     fi

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -43,8 +43,13 @@ relations:
 EOF
 }
 
-function juju::deploy::after
+function juju::deploy
 {
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
+         --overlay overlay.yaml \
+         --force \
+         --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
+
     juju config -m $JUJU_CONTROLLER:$JUJU_MODEL tigera-secure-ee \
         license-key=$(base64 -w0 $TIGERA_SECURE_EE_LICENSE_KEY_FILE) \
         registry-credentials=$(base64 -w0 $TIGERA_PRIVATE_REGISTRY_CREDENTIALS_FILE)


### PR DESCRIPTION
Calico deployments are failing because the runs are calling `juju::wait` before the instances have been fully configured. The current `juju::deploy::after` override doesn't work because that comes after `juju::wait`. So, override `juju::deploy` instead.