### PR TITLE
Fix failure to assign ipv6 address in validate-ck-calico

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -318,7 +318,7 @@ def assign_ipv6_addr_on_instance(instance_id):
     for network_interface_id in network_interface_ids:
         log("Assigning IPv6 address to " + network_interface_id)
 
-        ec2.modify_network_interface_attribute(
+        ec2.assign_ipv6_addresses(
             NetworkInterfaceId=network_interface_id,
             Ipv6AddressCount=1,
         )


### PR DESCRIPTION
Fixes:
```
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge] Assigning IPv6 address to eni-08167811303ae8386
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge] Traceback (most recent call last):
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/jobs/integration/tigera_aws.py", line 563, in <module>
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     main()
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/jobs/integration/tigera_aws.py", line 560, in main
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     command_defs[args.command]()
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/jobs/integration/tigera_aws.py", line 347, in assign_ipv6_addrs
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     assign_ipv6_addr_on_instance(instance_id)
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/jobs/integration/tigera_aws.py", line 321, in assign_ipv6_addr_on_instance
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     ec2.modify_network_interface_attribute(
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 357, in _api_call
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     return self._make_api_call(operation_name, kwargs)
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 648, in _make_api_call
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     request_dict = self._convert_to_request_dict(
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/venv/lib/python3.8/site-packages/botocore/client.py", line 696, in _convert_to_request_dict
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     request_dict = self._serializer.serialize_to_request(
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]   File "/var/lib/jenkins/slaves/jenkins-slave-8/workspace/validate-ck-calico/channel/edge/node/runner-validate/routing_mode/bgp-simple/series/bionic/snap_version/1.17/edge/venv/lib/python3.8/site-packages/botocore/validate.py", line 297, in serialize_to_request
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge]     raise ParamValidationError(report=report.generate_report())
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge] botocore.exceptions.ParamValidationError: Parameter validation failed:
14:31:28 [validate-ck-calico-bgp-simple-bionic-1.17-edge] Unknown parameter in input: "Ipv6AddressCount", must be one of: Attachment, Description, DryRun, Groups, NetworkInterfaceId, SourceDestCheck
```

Per the [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.assign_ipv6_addresses), the correct API call is assign_ipv6_addresses not modify_network_interface_attribute.