### PR TITLE
Fix calico cleanup failing due to early timeout

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -233,7 +233,7 @@ function ci::cleanup
         test::capture || true
 
         if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
-            timeout 5m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
+            timeout 10m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
         fi
         ci::cleanup::after || true
     } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"


### PR DESCRIPTION
Extend timeout to 10 minutes.