### PR TITLE
Do not test mk8s on 16.04

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -15,9 +15,6 @@ class Microk8sSnap:
         click.echo("Callling {}".format(cmd))
         revisions_list = run(cmd, stdout=PIPE, stderr=STDOUT)
         revisions_list = revisions_list.stdout.decode("utf-8").split("\n")
-        click.echo("Snap revisions on {}".format(arch))
-        click.echo(revisions_list)
-        click.echo("")
         channel_patern = "{}/{}*".format(track, channel)
 
         self.juju_unit = juju_unit
@@ -85,7 +82,7 @@ class Microk8sSnap:
         channel_to_upgrade=None,
         track_to_upgrade=None,
         tests_branch=None,
-        distributions=["ubuntu:16.04", "ubuntu:18.04"],
+        distributions=["ubuntu:18.04"],
         proxy=None,
     ):
         """


### PR DESCRIPTION
mk8s on 16.04 started failing with:
```
01:27:44 2020-11-23 at 23:27:44 | INFO Script started, file is typescript
01:27:44 2020-11-23 at 23:27:44 | INFO Traceback (most recent call last):
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/bin/pytest", line 7, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO from pytest import console_main
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/pytest/__init__.py", line 3, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO from . import collect
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/pytest/collect.py", line 8, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO from _pytest.deprecated import PYTEST_COLLECT_MODULE
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/_pytest/deprecated.py", line 11, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO from _pytest.warning_types import PytestDeprecationWarning
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/_pytest/warning_types.py", line 7, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO from _pytest.compat import final
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/_pytest/compat.py", line 57, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO import importlib_metadata  # noqa: F401
01:27:44 2020-11-23 at 23:27:44 | INFO File "/usr/local/lib/python3.5/dist-packages/importlib_metadata/__init__.py", line 43, in <module>
01:27:44 2020-11-23 at 23:27:44 | INFO class PackageNotFoundError(ModuleNotFoundError):
01:27:44 2020-11-23 at 23:27:44 | INFO NameError: name 'ModuleNotFoundError' is not defined
```

I think it is time to start testing 20.04 instead of 16.04.

This PR stops testing on 16.04 to unblock the releases.

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
