### PR TITLE
Add Kubernetes Dashboard Bundle

### DIFF
--- a/jobs/bundles/kubernetes-dashboard-bundle.yaml
+++ b/jobs/bundles/kubernetes-dashboard-bundle.yaml
@@ -1,0 +1,17 @@
+verify: |
+  #!/bin/bash
+  set -x
+
+  echo "Verifying bundle"
+  exit 0
+description: A charm bundle to deploy the Kubernetes Dashboard
+bundle: kubernetes
+applications:
+  k8s-dashboard:
+    charm: cs:~containers/kubernetes-dashboard
+    scale: 1
+  dashboard-metrics-scraper:
+    charm: cs:~containers/dashboard-metrics-scraper
+    scale: 1
+relations:
+  - [dashboard-metrics-scraper, k8s-dashboard]


### PR DESCRIPTION
The charms for this bundle currently still aren't public and not in the stable channel.