### PR TITLE
Add logging around revisions listing

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -19,35 +19,15 @@ def get_tracks(all=False):
     Returns: the tracks valid for the architecture at hand
 
     """
-    arch = get_arch()
-    if arch == "arm64" and not all:
-        # 1.12 and 1.13 removed temporarily because of failing builds blocking our CI
-        return [
-            "latest",
-            "1.14",
-            "1.15",
-            "1.16",
-            "1.17",
-            "1.18",
-            "1.19",
-            "1.20",
-            "1.21",
-            "1.22",
-        ]
-    else:
-        # 1.10, 1.11, 1.12 and 1.13 removed temporarily because of failing builds blocking our CI
-        return [
-            "latest",
-            "1.14",
-            "1.15",
-            "1.16",
-            "1.17",
-            "1.18",
-            "1.19",
-            "1.20",
-            "1.21",
-            "1.22",
-        ]
+    return [
+        "latest",
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20",
+        "1.21",
+        "1.22",
+    ]
 
 
 snap_name = "microk8s"

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -11,17 +11,19 @@ sh2 = sh(_iter=True, _err_to_out=True, _env=os.environ.copy())
 class Microk8sSnap:
     def __init__(self, track, channel, juju_unit=None, juju_controller=None):
         arch = configbag.get_arch()
-        cmd = "snapcraft list-revisions microk8s --arch {}".format(arch).split()
-        click.echo("Callling {}".format(cmd))
-        revisions_list = run(cmd, stdout=PIPE, stderr=STDOUT)
-        revisions_list = revisions_list.stdout.decode("utf-8").split("\n")
         channel_patern = "{}/{}*".format(track, channel)
-
         self.juju_unit = juju_unit
         self.juju_controller = juju_controller
         self.track = track
         self.channel = channel
         revision_info_str = None
+
+        cmd = "snapcraft list-revisions microk8s --arch {}".format(arch).split()
+        click.echo("Callling {}".format(cmd))
+        revisions_list = run(cmd, stdout=PIPE, stderr=STDOUT)
+        revisions_list = revisions_list.stdout.decode("utf-8").split("\n")
+        click.echo(revisions_list)
+        click.echo("Searching for {}".format(channel_patern))
         for revision in revisions_list:
             if channel_patern in revision:
                 revision_info_str = revision


### PR DESCRIPTION
Stop playing with stale branches.

More logs on the list of revisions returned by the snap store.

---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
