### PR TITLE
Update validate-ck-calico and validate-ck-tigera-secure-ee to reuse VPCs

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -87,10 +87,7 @@ def sh(*args, **kwargs):
 
 
 def tag_resource(resource_id):
-    ec2.create_tags(
-        Resources=[resource_id],
-        Tags=[{"Key": "owner", "Value": OWNER}]
-    )
+    ec2.create_tags(Resources=[resource_id], Tags=[{"Key": "owner", "Value": OWNER}])
 
 
 def juju(cmd, *args, json=True):
@@ -199,7 +196,7 @@ def create_vpc():
             GatewayId=gateway_id,
         )
 
-    log('Successfully created VPC ' + vpc_id)
+    log("Successfully created VPC " + vpc_id)
 
 
 @def_command("cleanup")

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -574,9 +574,14 @@ async def test_network_policies(model, tools):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip_apps(["calico"])
 async def test_ipv6(model, tools):
-    master = model.applications["kubernetes-master"].units[0]
+    master_app = model.applications["kubernetes-master"]
+    master_config = await master_app.get_config()
+    service_cidr = master_config["service-cidr"]["value"]
+    if all(ipaddress.ip_network(cidr).version != 6 for cidr in service_cidr.split(',')):
+        pytest.skip("kubernetes-master not configured for IPv6")
+
+    master = master_app.units[0]
     kubectl(
         "create -f - << EOF{}EOF".format(
             """

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -578,7 +578,7 @@ async def test_ipv6(model, tools):
     master_app = model.applications["kubernetes-master"]
     master_config = await master_app.get_config()
     service_cidr = master_config["service-cidr"]["value"]
-    if all(ipaddress.ip_network(cidr).version != 6 for cidr in service_cidr.split(',')):
+    if all(ipaddress.ip_network(cidr).version != 6 for cidr in service_cidr.split(",")):
         pytest.skip("kubernetes-master not configured for IPv6")
 
     master = master_app.units[0]

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -16,14 +16,26 @@ set -ex
 ###############################################################################
 function juju::bootstrap
 {
-    python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
-
-    export NUM_SUBNETS=2
+    # VPC with multiple subnets and IPv6, created with:
+    # NUM_SUBNETS=2 jobs/integration/tigera_aws.py create-vpc
+    vpc_id=vpc-0e296b9c1d803d8c9
     if [ "$ROUTING_MODE" = "bgp-simple" ]; then
-      export NUM_SUBNETS=1
+      # VPC with a single subnet and IPv6, created with:
+      # NUM_SUBNETS=1 jobs/integration/tigera_aws.py create-vpc
+      vpc_id=vpc-031851c4ad28b316f
     fi
 
-    python $WORKSPACE/jobs/integration/tigera_aws.py bootstrap
+    juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
+      -d "$JUJU_MODEL" \
+      --bootstrap-series "$SERIES" \
+      --force \
+      --bootstrap-constraints arch="$ARCH" \
+      --model-default test-mode=true \
+      --model-default resource-tags=owner=k8sci \
+      --model-default image-stream=daily \
+      --model-default automatically-retry-hooks=false \
+      --model-default logging-config="<root>=DEBUG" \
+      --model-default vpc-id=$vpc_id
 
     if [ "$ROUTING_MODE" = "bgp-router" ]; then
       echo "Deploying bgp router"
@@ -33,11 +45,26 @@ function juju::bootstrap
 
 function juju::deploy::overlay
 {
-    vxlan_mode=Never
     if [ "$ROUTING_MODE" = "vxlan" ]; then
+      # Calico does not support VXLAN + IPv6, so we need to skip the IPv6 CIDRs
+      cat <<EOF > overlay.yaml
+series: $SERIES
+applications:
+  kubernetes-master:
+    options:
+      channel: $SNAP_VERSION
+  kubernetes-worker:
+    options:
+      channel: $SNAP_VERSION
+  calico:
+    options:
+      vxlan: Always
+      ignore-loose-rpf: true
+EOF
       vxlan_mode=Always
-    fi
-    cat <<EOF > overlay.yaml
+    else
+      # No VXLAN, so we'll test IPv6
+      cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
   kubernetes-master:
@@ -50,8 +77,9 @@ applications:
   calico:
     options:
       cidr: "192.168.0.0/16,fd00:c00b:1::/112"
-      vxlan: $vxlan_mode
+      ignore-loose-rpf: true
 EOF
+    fi
 }
 
 function juju::deploy
@@ -63,18 +91,12 @@ function juju::deploy
 
     if [[ "$ROUTING_MODE" = bgp* ]]; then
       python $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
+      python $WORKSPACE/jobs/integration/tigera_aws.py assign-ipv6-addrs
     fi
-
-    python $WORKSPACE/jobs/integration/tigera_aws.py assign-ipv6-addrs
 
     if [ "$ROUTING_MODE" = "bgp-router" ]; then
       python $WORKSPACE/jobs/integration/tigera_aws.py configure-bgp
     fi
-}
-
-function ci::cleanup::after
-{
-    python $WORKSPACE/jobs/integration/tigera_aws.py cleanup
 }
 
 ###############################################################################

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -16,31 +16,21 @@ set -x
 ###############################################################################
 function juju::bootstrap
 {
-    python3 $WORKSPACE/jobs/integration/tigera_aws.py cleanup
-    python3 $WORKSPACE/jobs/integration/tigera_aws.py bootstrap
-}
+    # VPC with a single subnet and IPv6, created with:
+    # NUM_SUBNETS=1 jobs/integration/tigera_aws.py create-vpc
+    vpc_id=vpc-031851c4ad28b316f
 
-function juju::deploy::overlay
-{
-    cat <<EOF > overlay.yaml
-series: $SERIES
-applications:
-  kubernetes-master:
-    options:
-      channel: $SNAP_VERSION
-      service-cidr: "10.152.183.0/24,fd00:c00b:2::/112"
-  kubernetes-worker:
-    options:
-      channel: $SNAP_VERSION
-  flannel:
-  tigera-secure-ee:
-    charm: cs:~containers/tigera-secure-ee
-relations:
-- [tigera-secure-ee:etcd, etcd:db]
-- [tigera-secure-ee:cni, kubernetes-master:cni]
-- [tigera-secure-ee:cni, kubernetes-worker:cni]
-- [tigera-secure-ee:kube-api-endpoint, kubernetes-master:kube-api-endpoint]
-EOF
+    juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
+      -d "$JUJU_MODEL" \
+      --bootstrap-series "$SERIES" \
+      --force \
+      --bootstrap-constraints arch="$ARCH" \
+      --model-default test-mode=true \
+      --model-default resource-tags=owner=k8sci \
+      --model-default image-stream=daily \
+      --model-default automatically-retry-hooks=false \
+      --model-default logging-config="<root>=DEBUG" \
+      --model-default vpc-id=$vpc_id
 }
 
 function juju::deploy
@@ -57,17 +47,12 @@ function juju::deploy
     python3 $WORKSPACE/jobs/integration/tigera_aws.py disable-source-dest-check
 }
 
-function ci::cleanup::after
-{
-    python3 $WORKSPACE/jobs/integration/tigera_aws.py cleanup
-}
-
 ###############################################################################
 # ENV
 ###############################################################################
 SNAP_VERSION=${1:-1.19/edge}
 SERIES=${2:-bionic}
-JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
+JUJU_DEPLOY_BUNDLE=cs:~containers/kubernetes-tigera-secure-ee
 JUJU_DEPLOY_CHANNEL=${3:-edge}
 JUJU_CLOUD=aws/us-east-2
 JUJU_CONTROLLER=validate-$(identifier::short)


### PR DESCRIPTION
This should fix the issues we're constantly seeing with VPC quota limits and cleanup failures. Instead of creating a new VPC each time a validate-ck-calico job runs, we'll have two long-lived VPCs that we reuse between jobs.

This PR removes `tigera_aws.py bootstrap` completely, and removes all calls to `tigera_aws.py cleanup` from the jobs. The VPC creation code has been moved over to a new `tigera_aws.py create-vpc` command that can be called manually by engineers as needed. I have already done this.

Included in this PR are several IPv6 fixes which I'll highlight inline.