### PR TITLE
Don't run validate-ck-calico on 1.17

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -528,7 +528,6 @@
             - 1.20/edge
             - 1.19/edge
             - 1.18/edge
-            - 1.17/edge
       - axis:
           type: user-defined
           name: series


### PR DESCRIPTION
IPv6 fails on 1.17. We no longer support 1.17 anyways, may as well drop it, right?