### PR TITLE
Use oci image staging area during the cdk-addons build job

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -92,7 +92,7 @@ pipeline {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
                     # workaround issue where motd-news-config is needed for arm64 snap env
-                    apt install motd-news-config -y
+                    sudo apt install motd-news-config -y
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -93,7 +93,7 @@ pipeline {
                 sh """
                     # motd-news-config is broken on some workers, but it is needed by ubuntu-server
                     # for non-intel snap builds. force install it with default config.
-                    sudo apt-get -o DPkg::Options::=--force-confdef -y install motd-news-config
+                    sudo apt-get -o DPkg::Options::=--force-confdef -y install motd-news-config || true
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -20,11 +20,9 @@ pipeline {
      */
     environment {
         PATH = "${utils.cipaths}"
-        DOCKERHUB_CREDS = credentials('cdkbot_dockerhub')
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
-        REGISTRY_PULL_URL = 'rocks.canonical.com'
-        REGISTRY_PUSH_URL = 'upload.rocks.canonical.com:5000'
+        REGISTRY_URL = 'upload.rocks.canonical.com:443'
         REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ quay.io/'
     }
     options {
@@ -177,8 +175,8 @@ pipeline {
                     ALL_IMAGES=\$(echo "\${ALL_IMAGES}" | xargs -n1 | sort -u | xargs)
 
                     # We pull images from staging and push to our production location
-                    PROD_PREFIX=${env.REGISTRY_PUSH_URL}/cdk
-                    STAGING_PREFIX=${env.REGISTRY_PULL_URL}/staging/cdk
+                    PROD_PREFIX=${env.REGISTRY_URL}/cdk
+                    STAGING_PREFIX=${env.REGISTRY_URL}/staging/cdk
 
                     for i in \${ALL_IMAGES}
                     do
@@ -205,7 +203,7 @@ pipeline {
                         then
                             echo "Dry run; would have pulled: \${STAGING_IMAGE}"
                         else
-                            sudo lxc exec image-processor -- ctr image pull \${STAGING_IMAGE} --all-platforms
+                            sudo lxc exec image-processor -- ctr image pull \${STAGING_IMAGE} --all-platforms --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
                         fi
 
                         # Tag and push

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -91,6 +91,8 @@ pipeline {
             steps {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
+                    # workaround issue where motd-news-config is needed for arm64 snap env
+                    apt install motd-news-config -y
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep
@@ -155,7 +157,7 @@ pipeline {
                 sh "sudo lxc launch ubuntu:20.04 image-processor"
                 lxd_exec("image-processor", "sleep 10")
                 lxd_exec("image-processor", "apt update")
-                lxd_exec("image-processor", "apt install containerd motd-news-config -y")
+                lxd_exec("image-processor", "apt install containerd -y")
             }
         }
         stage('Process Images'){

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -23,7 +23,8 @@ pipeline {
         DOCKERHUB_CREDS = credentials('cdkbot_dockerhub')
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
-        REGISTRY_URL = 'upload.rocks.canonical.com:5000'
+        REGISTRY_PULL_URL = 'rocks.canonical.com'
+        REGISTRY_PUSH_URL = 'upload.rocks.canonical.com:5000'
         REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ quay.io/'
     }
     options {
@@ -97,9 +98,9 @@ pipeline {
                     for arch in \${ARCHES}
                     do
                         echo "Building cdk-addons snap for arch \${arch}."
-                	wget -O build/kubectl https://storage.googleapis.com/kubernetes-release/release/${kube_version}/bin/linux/\${arch}/kubectl
-                	chmod +x build/kubectl
-                	sed 's/KUBE_VERSION/${kube_ersion}/g' cdk-addons.yaml > build/snapcraft.yaml
+                        wget -O build/kubectl https://storage.googleapis.com/kubernetes-release/release/${kube_version}/bin/linux/\${arch}/kubectl
+                        chmod +x build/kubectl
+                        sed 's/KUBE_VERSION/${kube_ersion}/g' cdk-addons.yaml > build/snapcraft.yaml
                         if [ "\${arch}" = "ppc64le" ]
                         then
                           sed -i "s/KUBE_ARCH/ppc64el/g" build/snapcraft.yaml
@@ -176,8 +177,8 @@ pipeline {
                     ALL_IMAGES=\$(echo "\${ALL_IMAGES}" | xargs -n1 | sort -u | xargs)
 
                     # We pull images from staging and push to our production location
-                    PROD_PREFIX=${env.REGISTRY_URL}/cdk
-                    STAGING_PREFIX=${env.REGISTRY_URL}/staging/cdk
+                    PROD_PREFIX=${env.REGISTRY_PUSH_URL}/cdk
+                    STAGING_PREFIX=${env.REGISTRY_PULL_URL}/staging/cdk
 
                     for i in \${ALL_IMAGES}
                     do

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -23,7 +23,7 @@ pipeline {
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
         REGISTRY_URL = 'upload.rocks.canonical.com:5000'
-        REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ quay.io/'
+        REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ nvcr.io/ quay.io/'
     }
     options {
         ansiColor('xterm')

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -94,7 +94,7 @@ pipeline {
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep
-                    ARCHES="amd64"
+                    ARCHES="amd64 arm64 ppc64le s390x"
                     for arch in \${ARCHES}
                     do
                         echo "Building cdk-addons snap for arch \${arch}."
@@ -182,6 +182,7 @@ pipeline {
                     # Login to increase rate limit for dockerhub
                     which docker && docker login -u ${env.DOCKERHUB_CREDS_USR} -p ${env.DOCKERHUB_CREDS_PSW}
 
+                    ALL_IMAGES=""
                     for i in \${ALL_IMAGES}
                     do
                         # Skip images that we already host
@@ -236,12 +237,12 @@ pipeline {
             steps {
                 script {
                     if(params.dry_run) {
-                        echo "Dry run; would have pushed cdk-addons/*.snap to ${params.channels}"
+                        echo "Dry run; would have uploaded cdk-addons/*.snap to ${params.channels}"
                     } else {
-                        sh "snapcraft push cdk-addons/cdk-addons_${kube_ersion}_amd64.snap --release ${params.channels}"
-                        sh "snapcraft push cdk-addons/cdk-addons_${kube_ersion}_arm64.snap --release ${params.channels}"
-                        sh "snapcraft push cdk-addons/cdk-addons_${kube_ersion}_ppc64el.snap --release ${params.channels}"
-                        sh "snapcraft push cdk-addons/cdk-addons_${kube_ersion}_s390x.snap --release ${params.channels}"
+                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_amd64.snap --release ${params.channels}"
+                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_arm64.snap --release ${params.channels}"
+                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_ppc64el.snap --release ${params.channels}"
+                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_s390x.snap --release ${params.channels}"
                     }
                 }
             }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -91,7 +91,8 @@ pipeline {
             steps {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
-                    # workaround issue where motd-news-config is needed for arm64 snap env
+                    # motd-news-config is broken on some workers, but it is needed by ubuntu-server
+                    # for non-intel snap builds. force install it with default config.
                     sudo apt-get -o DPkg::Options::=--force-confdef -y install motd-news-config
 
                     cd cdk-addons

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -94,7 +94,7 @@ pipeline {
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep
-                    ARCHES="amd64 arm64 ppc64le s390x"
+                    ARCHES="amd64"
                     for arch in \${ARCHES}
                     do
                         echo "Building cdk-addons snap for arch \${arch}."
@@ -177,7 +177,7 @@ pipeline {
                     ALL_IMAGES=\$(echo "\${ALL_IMAGES}" | xargs -n1 | sort -u | xargs)
 
                     # All CK images are stored under ./cdk in our registry
-                    TAG_PREFIX=${env.REGISTRY_URL}/cdk
+                    TAG_PREFIX=${env.REGISTRY_URL}/staging/cdk
 
                     # Login to increase rate limit for dockerhub
                     which docker && docker login -u ${env.DOCKERHUB_CREDS_USR} -p ${env.DOCKERHUB_CREDS_PSW}

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -92,7 +92,7 @@ pipeline {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
                     # workaround issue where motd-news-config is needed for arm64 snap env
-                    sudo apt install motd-news-config -y
+                    sudo apt-get -o DPkg::Options::=--force-confdef -y install motd-news-config
 
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -185,7 +185,6 @@ pipeline {
                     # Login to increase rate limit for dockerhub
                     which docker && docker login -u ${env.DOCKERHUB_CREDS_USR} -p ${env.DOCKERHUB_CREDS_PSW}
 
-                    ALL_IMAGES=""
                     for i in \${ALL_IMAGES}
                     do
                         # Skip images that we already host

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -91,10 +91,6 @@ pipeline {
             steps {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
                 sh """
-                    # motd-news-config is broken on some workers, but it is needed by ubuntu-server
-                    # for non-intel snap builds. force install it with default config.
-                    sudo apt-get -o DPkg::Options::=--force-confdef -y install motd-news-config || true
-
                     cd cdk-addons
                     make KUBE_VERSION=${kube_version} prep
                     ARCHES="amd64 arm64 ppc64le s390x"

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -155,7 +155,7 @@ pipeline {
                 sh "sudo lxc launch ubuntu:20.04 image-processor"
                 lxd_exec("image-processor", "sleep 10")
                 lxd_exec("image-processor", "apt update")
-                lxd_exec("image-processor", "apt install containerd -y")
+                lxd_exec("image-processor", "apt install containerd motd-news-config -y")
             }
         }
         stage('Process Images'){

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -22,7 +22,7 @@ pipeline {
         PATH = "${utils.cipaths}"
         GITHUB_CREDS = credentials('cdkbot_github')
         REGISTRY_CREDS = credentials('canonical_registry')
-        REGISTRY_URL = 'upload.rocks.canonical.com:443'
+        REGISTRY_URL = 'upload.rocks.canonical.com:5000'
         REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ quay.io/'
     }
     options {

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -152,7 +152,7 @@ pipeline {
         }
         stage('Setup LXD container for ctr'){
             steps {
-                sh "sudo lxc launch ubuntu:18.04 image-processor"
+                sh "sudo lxc launch ubuntu:20.04 image-processor"
                 lxd_exec("image-processor", "sleep 10")
                 lxd_exec("image-processor", "apt update")
                 lxd_exec("image-processor", "apt install containerd -y")


### PR DESCRIPTION
To prevent dockerhub rate limits, we're splitting the upstream image pull logic into a new job that runs less frequently than our cdk-addons build job.  That job will pull upstream images and tag/push them to a rocks/staging area.

This PR changes the origin for all upstream images to rocks/staging, which means we can drop our docker login bits. Our staging area should *always* contain the images that cdk-addons needs, so i removed the error handling around pull/tag. If we have a problem there, we want this build job to fail until we figure out what's missing in staging.

Finally, I bumped up the image-processor lxc container to use a focal image (why not?) and updated the `snapcraft` commands to use `upload` instead of the deprecated `push`.