### PR TITLE
Update validate-charm-bugfix to cover edge snaps

### DIFF
--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -54,7 +54,9 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.20/stable
+            - 1.20/edge
+            - 1.19/edge
+            - 1.18/edge
       - axis:
           type: user-defined
           name: series


### PR DESCRIPTION
We need test coverage of 1.20/edge, 1.19/edge, 1.18/edge cdk-addons snaps on candidate/stable charms. None of the existing validation jobs appear to cover this, so, I propose updating validate-charm-bugfix to do it so this happens normally as part of the bugfix release process.