### PR TITLE
new sync-oci-images job

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -33,10 +33,12 @@
       - build-blocker:
           use-build-blocker: true
           blocking-jobs:
+            - "build-release-cdk-addons.*"
             - "bundle-.*"
+            - "release-microk8s.*"
+            - "sync-oci-images.*"
             - "validate-ck.*"
             - "validate-charm.*"
-            - "release-microk8s.*"
             - "validate-kubeflow.*"
           block-level: 'GLOBAL'
 

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -9,7 +9,7 @@
     pipeline-scm:
       scm:
         - k8s-jenkins-jenkaas
-      script-path: jobs/build-snaps/build-release-cdk-addons.groovy
+      script-path: jobs/sync-oci-images/sync-oci-images.groovy
     parameters:
       - string:
           name: build_node

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -19,9 +19,9 @@
     parameters:
       - string:
           name: version
-          default: '{version}'
+          default: '1.20'
           description: |
-            Version to build and release. This job will clone the master or
+            CK version to process. This job will clone the master or
             cdk-addons release-`version` branch, then process the image list for the
             specified `version`.
       - string:

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -1,0 +1,41 @@
+# Tags and pushes upstream oci images to rocks staging area.
+
+- job:
+    name: 'sync-oci-images'
+    node: runner-amd64
+    description: |
+      Builds, releases and promotes cdk-addons for supported k8s versions on {arch} to the snapstore.
+      Container images required by CDK are known during the build, so this job also tags and pushes
+      those to the Canonical image registry.
+
+      The full version of the cdk-addons snap is tied to the upstream k8s tag used during the build.
+      Explicitly set this with the `k8s_tag` parameter, or this job will determine it using the
+      `version` parameter and the contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
+    project-type: pipeline
+    pipeline-scm:
+      scm:
+        - k8s-jenkins-jenkaas
+      script-path: jobs/build-snaps/build-release-cdk-addons.groovy
+    parameters:
+      - string:
+          name: version
+          default: '{version}'
+          description: |
+            Version to build and release. This job will clone the master or
+            cdk-addons release-`version` branch, then process the image list for the
+            specified `version`.
+      - string:
+          name: k8s_tag
+          default: ''
+          description: |
+            Source tag from https://github.com/kubernetes/kubernetes. If not specified,
+            the tag will be set to https://dl.k8s.io/release/[stable|latest]-`version`.txt.
+      - bool:
+          name: dry_run
+          default: false
+          description: only report what would be pushed to github / rocks.
+    properties:
+      - build-discarder:
+          num-to-keep: 7
+    triggers:
+        - timed: "@daily"

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -4,19 +4,16 @@
     name: 'sync-oci-images'
     node: runner-amd64
     description: |
-      Builds, releases and promotes cdk-addons for supported k8s versions on {arch} to the snapstore.
-      Container images required by CDK are known during the build, so this job also tags and pushes
-      those to the Canonical image registry.
-
-      The full version of the cdk-addons snap is tied to the upstream k8s tag used during the build.
-      Explicitly set this with the `k8s_tag` parameter, or this job will determine it using the
-      `version` parameter and the contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
+      Tags and pushes container images needed by Charmed Kubernetes to the rocks registry.
     project-type: pipeline
     pipeline-scm:
       scm:
         - k8s-jenkins-jenkaas
       script-path: jobs/build-snaps/build-release-cdk-addons.groovy
     parameters:
+      - string:
+          name: build_node
+          default: 'runner-amd64'
       - string:
           name: version
           default: '1.20'

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -4,7 +4,7 @@
     name: 'sync-oci-images'
     node: runner-amd64
     description: |
-      Tags and pushes container images needed by Charmed Kubernetes to the rocks registry.
+      Tags and pushes container images needed by Charmed Kubernetes to the rocks staging area.
     project-type: pipeline
     pipeline-scm:
       scm:
@@ -18,9 +18,8 @@
           name: version
           default: '1.20'
           description: |
-            CK version to process. This job will clone the master or
-            cdk-addons release-`version` branch, then process the image list for the
-            specified `version`.
+            CK version. This job will clone the cdk-addons release-`version` branch if one
+            exists (otherwise 'master'), then process the image list for this `version`.
       - string:
           name: k8s_tag
           default: ''

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -1,0 +1,194 @@
+@Library('juju-pipeline@master') _
+
+def bundle_image_file = "./bundle/container-images.txt"
+def kube_status = "stable"
+def kube_version = params.k8s_tag
+def kube_ersion = null
+if (kube_version != "") {
+    kube_ersion = kube_version.substring(1)
+}
+def lxd_exec(String container, String cmd) {
+    sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
+}
+
+pipeline {
+    agent {
+        label "${params.build_node}"
+    }
+    /* XXX: Global $PATH setting doesn't translate properly in pipelines
+     https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh
+     */
+    environment {
+        PATH = "${utils.cipaths}"
+        DOCKERHUB_CREDS = credentials('cdkbot_dockerhub')
+        GITHUB_CREDS = credentials('cdkbot_github')
+        REGISTRY_CREDS = credentials('canonical_registry')
+        REGISTRY_URL = 'upload.rocks.canonical.com:5000'
+        REGISTRY_REPLACE = 'k8s.gcr.io/ us.gcr.io/ docker.io/library/ docker.io/ gcr.io/ nvcr.io/ quay.io/'
+    }
+    options {
+        ansiColor('xterm')
+        timestamps()
+    }
+    stages {
+        stage('Setup User') {
+            steps {
+                sh "git config --global user.email 'cdkbot@juju.solutions'"
+                sh "git config --global user.name 'cdkbot'"
+            }
+        }
+        stage('Ensure valid K8s version'){
+            when {
+                expression { kube_version == "" }
+            }
+            steps {
+                script {
+                    kube_version = sh(returnStdout: true, script: "curl -L https://dl.k8s.io/release/stable-${params.version}.txt").trim()
+                    if(kube_version.indexOf('Error') > 0) {
+                        kube_status = "latest"
+                        kube_version = sh(returnStdout: true, script: "curl -L https://dl.k8s.io/release/latest-${params.version}.txt").trim()
+                    }
+                    if(kube_version.indexOf('Error') > 0) {
+                        error("Could not determine K8s version for ${params.version}")
+                    }
+                    kube_ersion = kube_version.substring(1);
+                }
+            }
+        }
+        stage('Setup Source') {
+            steps {
+                sh """
+                    ADDONS_BRANCH=release-${params.version}
+                    if git ls-remote --exit-code --heads https://github.com/charmed-kubernetes/cdk-addons.git \$ADDONS_BRANCH
+                    then
+                        echo "Getting cdk-addons from \$ADDONS_BRANCH branch."
+                        git clone https://github.com/charmed-kubernetes/cdk-addons.git --branch \$ADDONS_BRANCH --depth 1
+                    else
+                        echo "Getting cdk-addons from master branch."
+                        git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
+                    fi
+                """
+                sh "git clone https://github.com/charmed-kubernetes/bundle.git"
+            }
+        }
+        stage('Build image list'){
+            steps {
+                echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
+                sh """
+                    echo "Processing upstream images."
+                    UPSTREAM_KEY=${kube_version}-upstream:
+                    UPSTREAM_LINE=\$(cd cdk-addons && make KUBE_VERSION=${kube_version} upstream-images 2>/dev/null | grep ^\${UPSTREAM_KEY})
+
+                    echo "Updating bundle with upstream images."
+                    if grep -q ^\${UPSTREAM_KEY} ${bundle_image_file}
+                    then
+                        sed -i -e "s|^\${UPSTREAM_KEY}.*|\${UPSTREAM_LINE}|g" ${bundle_image_file}
+                    else
+                        echo \${UPSTREAM_LINE} >> ${bundle_image_file}
+                    fi
+                    sort -o ${bundle_image_file} ${bundle_image_file}
+
+                    cd bundle
+                    if git status | grep -qi "nothing to commit"
+                    then
+                        echo "No image changes; nothing to commit"
+                    else
+                        git commit -am "Updating \${UPSTREAM_KEY} images"
+                        if ${params.dry_run}
+                        then
+                            echo "Dry run; would have updated ${bundle_image_file} with: \${UPSTREAM_LINE}"
+                        else
+                            git push https://${env.GITHUB_CREDS_USR}:${env.GITHUB_CREDS_PSW}@github.com/charmed-kubernetes/bundle.git
+                        fi
+                    fi
+                    cd -
+                """
+            }
+        }
+        stage('Setup LXD container for ctr'){
+            steps {
+                sh "sudo lxc launch ubuntu:20.04 image-processor"
+                lxd_exec("image-processor", "sleep 10")
+                lxd_exec("image-processor", "apt update")
+                lxd_exec("image-processor", "apt install containerd -y")
+            }
+        }
+        stage('Process Images'){
+            steps {
+                sh """
+                    # Keys from the bundle_image_file used to identify images per release
+                    STATIC_KEY=v${params.version}-static:
+                    UPSTREAM_KEY=${kube_version}-upstream:
+
+                    ALL_IMAGES=""
+                    ARCHES="amd64 arm64 ppc64le s390x"
+                    for arch in \${ARCHES}
+                    do
+                        ARCH_IMAGES=\$(grep -e \${STATIC_KEY} -e \${UPSTREAM_KEY} ${bundle_image_file} | sed -e "s|\${STATIC_KEY}||g" -e "s|\${UPSTREAM_KEY}||g" -e "s|{{ arch }}|\${arch}|g" -e "s|{{ multiarch_workaround }}||g")
+                        ALL_IMAGES="\${ALL_IMAGES} \${ARCH_IMAGES}"
+                    done
+
+                    # Clean up dupes by making a sortable list, uniq it, and turn it back to a string
+                    ALL_IMAGES=\$(echo "\${ALL_IMAGES}" | xargs -n1 | sort -u | xargs)
+
+                    # All CK images are staged under ./staging/cdk in our registry
+                    TAG_PREFIX=${env.REGISTRY_URL}/staging/cdk
+
+                    # Login to increase rate limit for dockerhub
+                    which docker && docker login -u ${env.DOCKERHUB_CREDS_USR} -p ${env.DOCKERHUB_CREDS_PSW}
+
+                    for i in \${ALL_IMAGES}
+                    do
+                        # Skip images that we already host
+                        if echo \${i} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
+                        then
+                            continue
+                        fi
+
+                        if ${params.dry_run}
+                        then
+                            echo "Dry run; would have pulled: \${i}"
+                        else
+                            sudo lxc exec image-processor -- ctr image pull \${i} --all-platforms
+                        fi
+
+                        # Massage image names
+                        RAW_IMAGE=\${i}
+                        for repl in ${env.REGISTRY_REPLACE}
+                        do
+                            if echo \${RAW_IMAGE} | grep -qi \${repl}
+                            then
+                                RAW_IMAGE=\$(echo \${RAW_IMAGE} | sed -e "s|\${repl}||g")
+                                break
+                            fi
+                        done
+
+                        # Tag and push
+                        if ${params.dry_run}
+                        then
+                            echo "Dry run; would have tagged: \${i}"
+                            echo "Dry run; would have pushed: \${TAG_PREFIX}/\${RAW_IMAGE}"
+                        else
+                            sudo lxc exec image-processor -- ctr image tag \${i} \${TAG_PREFIX}/\${RAW_IMAGE}
+                            sudo lxc exec image-processor -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
+                        fi
+                    done
+
+                    # Make sure this worker doesn't stay logged in to dockerhub
+                    which docker && docker logout
+
+                    echo "All images known to this builder:"
+                    sudo lxc exec image-processor -- ctr image ls
+                """
+            }
+        }
+    }
+    post {
+        always {
+            sh "sudo lxc delete -f image-processor"
+            sh "sudo rm -rf cdk-addons/build"
+            sh "docker image prune -a --filter \"until=24h\" --force"
+            sh "docker container prune --filter \"until=24h\" --force"
+        }
+    }
+}


### PR DESCRIPTION
New job to sync upstream repos with a staging area in rocks.c.c.  The staging area is used as the source of truth for our cdk-addons build jobs. The reason we split this into a separate job is to work around the dockerhub rate limit.  This job runs less frequently than build-cdk-addons so we stay under the 200 images / 6 hour limit.

I noticed a few build failures when infra jobs run with this job; apparently infra jobs restart lxd, which is catastrophic to our lxc image processing container in this and build-cdk-addons jobs. Fixed that by adding these jobs to the block list so infra will wait for these to complete before running.