### PR TITLE
Fix pre-release microk8s tags

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -32,5 +32,5 @@ def get_tracks(all=False):
 
 snap_name = "microk8s"
 people_name = "microk8s-dev"
-cachedir = os.getenv("WORKSPACE") + "/cache"
+cachedir = os.getenv("WORKSPACE", default="/var/tmp/") + "/cache"
 creds = os.getenv("LPCREDS")

--- a/jobs/microk8s/utils.py
+++ b/jobs/microk8s/utils.py
@@ -67,7 +67,7 @@ def get_latest_pre_release(track, patch):
     release_names = []
     for release in releases:
         if release["tag_name"].startswith(search_version):
-            release_names.append(release["name"][1:])
+            release_names.append(release["tag_name"][1:])
 
     if len(release_names) > 0:
         max_release = release_names[0]

--- a/jobs/microk8s/utils.py
+++ b/jobs/microk8s/utils.py
@@ -59,12 +59,14 @@ def get_latest_pre_release(track, patch):
     """
     releases = get_gh_releases()
     if not releases:
+        print("No releases gathered from GH")
         return None
 
     search_version = "v{}.0-{}".format(track, patch)
+    print("Searching on GH releases for a tag starting with:", search_version)
     release_names = []
     for release in releases:
-        if release["name"].startswith(search_version):
+        if release["tag_name"].startswith(search_version):
             release_names.append(release["name"][1:])
 
     if len(release_names) > 0:


### PR DESCRIPTION
It seems the "name" field in https://api.github.com/repos/kubernetes/kubernetes/releases changed to include a "Kubernetes" at the beginning. We switch "to tag_name" with this PR to get the release tag name.
