### PR TITLE
update sync / cdk-addons jobs

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -21,7 +21,7 @@
           default: '{arch}'
       - string:
           name: build_node
-          default: 'runner-{arch}'
+          default: 'runner-amd64-bigdisk'
       - string:
           name: version
           default: '{version}'

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -240,14 +240,14 @@ pipeline {
     post {
         always {
             sh "echo Disk usage before cleanup"
-            sh "df -h"
+            sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
             sh "sudo lxc delete -f image-processor"
             sh "sudo rm -rf cdk-addons/build"
             sh "docker image prune -a --filter \"until=24h\" --force"
             sh "docker container prune --filter \"until=24h\" --force"
             sh "snapcraft logout"
             sh "echo Disk usage after cleanup"
-            sh "df -h"
+            sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
         }
     }
 }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -159,8 +159,6 @@ pipeline {
         stage('Process Images'){
             steps {
                 sh """
-                    echo "THIS IS HOW BIG"
-                    df -h
                     # Keys from the bundle_image_file used to identify images per release
                     STATIC_KEY=v${params.version}-static:
                     UPSTREAM_KEY=${kube_version}-upstream:
@@ -241,14 +239,14 @@ pipeline {
     }
     post {
         always {
-            sh "echo THIS IS HOW BIG"
+            sh "echo Disk usage before cleanup"
             sh "df -h"
             sh "sudo lxc delete -f image-processor"
             sh "sudo rm -rf cdk-addons/build"
             sh "docker image prune -a --filter \"until=24h\" --force"
             sh "docker container prune --filter \"until=24h\" --force"
             sh "snapcraft logout"
-            sh "echo THIS IS HOW BIG"
+            sh "echo Disk usage after cleanup"
             sh "df -h"
         }
     }

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -159,6 +159,8 @@ pipeline {
         stage('Process Images'){
             steps {
                 sh """
+                    echo "THIS IS HOW BIG"
+                    df -h
                     # Keys from the bundle_image_file used to identify images per release
                     STATIC_KEY=v${params.version}-static:
                     UPSTREAM_KEY=${kube_version}-upstream:
@@ -239,11 +241,15 @@ pipeline {
     }
     post {
         always {
+            sh "echo THIS IS HOW BIG"
+            sh "df -h"
             sh "sudo lxc delete -f image-processor"
             sh "sudo rm -rf cdk-addons/build"
             sh "docker image prune -a --filter \"until=24h\" --force"
             sh "docker container prune --filter \"until=24h\" --force"
             sh "snapcraft logout"
+            sh "echo THIS IS HOW BIG"
+            sh "df -h"
         }
     }
 }

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -13,10 +13,10 @@
     parameters:
       - string:
           name: build_node
-          default: 'runner-amd64'
+          default: 'runner-amd64-bigdisk'
       - string:
           name: version
-          default: '1.20'
+          default: '1.21'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'master'), then process the image list for this `version`.

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -198,10 +198,14 @@ pipeline {
     }
     post {
         always {
+            sh "echo Disk usage before cleanup"
+            sh "df -h"
             sh "sudo lxc delete -f ${lxc_name}"
             sh "sudo rm -rf cdk-addons/build"
             sh "docker image prune -a --filter \"until=24h\" --force"
             sh "docker container prune --filter \"until=24h\" --force"
+            sh "echo Disk usage after cleanup"
+            sh "df -h"
         }
     }
 }

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -199,13 +199,13 @@ pipeline {
     post {
         always {
             sh "echo Disk usage before cleanup"
-            sh "df -h"
+            sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
             sh "sudo lxc delete -f ${lxc_name}"
             sh "sudo rm -rf cdk-addons/build"
             sh "docker image prune -a --filter \"until=24h\" --force"
             sh "docker container prune --filter \"until=24h\" --force"
             sh "echo Disk usage after cleanup"
-            sh "df -h"
+            sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
         }
     }
 }


### PR DESCRIPTION
Syncing images takes a lot (25G) of disk.  Add debug to monitor this disk usage, and set the appropriate jobs to use our `bigdisk` machines.

Drive-by update to the sync-oci job to set the default k8s version to 1.21.