### PR TITLE
Fix missing model in mk8s release to stable script

### DIFF
--- a/jobs/microk8s/release-to-stable.py
+++ b/jobs/microk8s/release-to-stable.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
             )
 
         candidate_snap = Microk8sSnap(
-            source_track, source_channel, juju_unit, juju_controller
+            source_track, source_channel, juju_unit, juju_controller, juju_model
         )
         if not candidate_snap.released:
             # Nothing to release

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -41,8 +41,8 @@ class Microk8sSnap:
         click.echo("Callling {}".format(cmd))
         revisions_list = run(cmd, stdout=PIPE, stderr=STDOUT)
         revisions_list = revisions_list.stdout.decode("utf-8").split("\n")
-        click.echo(revisions_list)
-        click.echo("Searching for {}".format(channel_patern))
+        click.echo("Got revisions list with size {}".format(len(revisions_list)))
+        click.echo("Searching for {} in revisions list".format(channel_patern))
         for revision in revisions_list:
             if channel_patern in revision:
                 revision_info_str = revision


### PR DESCRIPTION
On the stable job I was was not passing the juju_model, this PR fixes this.

Also toning down the logs by not printing all the revisions fetched.
