### PR TITLE
report what images are used in a ck release

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -236,8 +236,7 @@ pipeline {
                     # Commit what we know about our images
                     cd bundle
                     REPORT_FILE=container-images/${kube_version}.txt
-                    REPORT_IMAGES=\$(echo "\${REPORT_IMAGES}" | xargs -n1 | sort -u)
-                    echo \${REPORT_IMAGES} > \${REPORT_FILE}
+                    echo \${REPORT_IMAGES} | xargs -n1 | sort -u > \${REPORT_FILE}
                     git pull origin master
                     git add \${REPORT_FILE}
                     if git status | grep -qi "nothing to commit"

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -132,6 +132,7 @@ pipeline {
                     sort -o ${bundle_image_file} ${bundle_image_file}
 
                     cd bundle
+                    git pull origin master
                     if git status | grep -qi "nothing to commit"
                     then
                         echo "No image changes; nothing to commit"
@@ -233,11 +234,11 @@ pipeline {
                     done
 
                     # Commit what we know about our images
+                    cd bundle
                     REPORT_FILE=container-images/${kube_version}.txt
                     REPORT_IMAGES=\$(echo "\${REPORT_IMAGES}" | xargs -n1 | sort -u)
-
-                    cd bundle
                     echo \${REPORT_IMAGES} > \${REPORT_FILE}
+                    git pull origin master
                     git add \${REPORT_FILE}
                     if git status | grep -qi "nothing to commit"
                     then

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -252,6 +252,9 @@ pipeline {
                         fi
                     fi
                     cd -
+
+                    echo "All images known to this builder:"
+                    sudo lxc exec image-processor -- ctr image ls
                 """
             }
         }


### PR DESCRIPTION
We have a [list of container images](https://github.com/charmed-kubernetes/bundle/blob/master/container-images.txt) that gets processed/updated during `build-cdk-addons`.  It serves our build jobs well, but it isn't very human-readable -- `static` and `upstream` lines need to be combined, image names come directly from upstream templates, and items like `{{ arch }}` aren't expanded.

During each build, we end up massaging images into a format that would be way easier for humans to grok. This PR adds these to a per-release text file that gets committed [to the same repo](https://github.com/charmed-kubernetes/bundle/tree/master/container-images).

Drive-by to quiet the extreme log noise when pulling/pushing images.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1891530 by making it easier to call out image changes in release notes.