### PR TITLE
Be exact on the name of the microk8s test branch we search for

### DIFF
--- a/jobs/microk8s/executors/juju.py
+++ b/jobs/microk8s/executors/juju.py
@@ -34,7 +34,7 @@ class JujuExecutor(ExecutorInterface):
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git {}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/executors/juju.py
+++ b/jobs/microk8s/executors/juju.py
@@ -34,7 +34,9 @@ class JujuExecutor(ExecutorInterface):
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(
+                track
+            ).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -25,7 +25,9 @@ class LocalExecutor(ExecutorInterface):
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(
+                track
+            ).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -25,7 +25,7 @@ class LocalExecutor(ExecutorInterface):
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git {}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/executors/testflinger.py
+++ b/jobs/microk8s/executors/testflinger.py
@@ -51,7 +51,9 @@ test_data:
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(
+                track
+            ).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/executors/testflinger.py
+++ b/jobs/microk8s/executors/testflinger.py
@@ -51,7 +51,7 @@ test_data:
     def has_tests_for_track(self, track):
         cmd = (
             "git ls-remote --exit-code "
-            "--heads https://github.com/ubuntu/microk8s.git {}".format(track).split()
+            "--heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(track).split()
         )
         run(cmd, check=True, stdout=PIPE, stderr=STDOUT)
 

--- a/jobs/microk8s/update-gh-branches-and-lp-builders.py
+++ b/jobs/microk8s/update-gh-branches-and-lp-builders.py
@@ -36,7 +36,7 @@ def is_latest(release):
 
 def gh_branch_exists(branch):
     """Return true if the branch is already available on the repository"""
-    cmd = "git ls-remote --exit-code --heads https://github.com/ubuntu/microk8s.git {}".format(
+    cmd = "git ls-remote --exit-code --heads https://github.com/ubuntu/microk8s.git refs/heads/{}".format(
         branch
     ).split()
     try:


### PR DESCRIPTION
MicroK8s tests are taken from a branch that matches the release track, eg for 1.21 tests are taken from branch 1.21. The issue fixed by this PR is that we match any branch that ends with /1.21 with is not right. We need to be exact.
