### PR TITLE
1.21 update for arc conformance

### DIFF
--- a/jobs/arc-conformance.yaml
+++ b/jobs/arc-conformance.yaml
@@ -16,10 +16,16 @@
     parameters:
       - string:
           name: CK_VERSION
-          default: '1.20'
+          default: '1.21'
           description: |
-            CK version to deploy. This will be used to set the snap channel
+            CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.
+      - string:
+          name: CK_CHANNEL
+          default: 'stable'
+          description: |
+            CK channel to deploy. This will be used to set the snap and
+            charm channels used during deployment.
     properties:
       - build-discarder:
           num-to-keep: 4

--- a/jobs/arc-conformance/conformance-spec
+++ b/jobs/arc-conformance/conformance-spec
@@ -108,6 +108,10 @@ function test::capture
             is_pass="False"
         else
             echo "Passed conformance; uploading results to azure storageaccount"
+            # we need the storage account key before upload
+            set +x
+            source /var/lib/jenkins/.local/share/juju/azure-arc.sh
+            set -x
             az storage blob upload -c canonical-testresults --account-name canonicalarcsa \
                 --account-key ${STORAGE_ACCOUNT_KEY} -f ${SB_TAR} -n ${SB_TAR}
             az storage blob upload -c canonical-testresults --account-name canonicalarcsa \

--- a/jobs/arc-conformance/conformance-spec
+++ b/jobs/arc-conformance/conformance-spec
@@ -128,11 +128,11 @@ function test::capture
 SONOBUOY_VERSION=0.20.0
 CLUSTER_NAME=azure-arc-ci
 CLUSTER_REGION=eastus
-SNAP_VERSION=${CK_VERSION}/stable
+SNAP_VERSION=${CK_VERSION}/${CK_CHANNEL}
 # NB: bootstrap azure with bionic until juju-2.9
 SERIES=bionic
 JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
-JUJU_DEPLOY_CHANNEL=stable
+JUJU_DEPLOY_CHANNEL=${CK_CHANNEL}
 JUJU_CLOUD=azure/eastus
 JUJU_CONTROLLER=validate-$(identifier::short)
 JUJU_MODEL=validate-ck-arc


### PR DESCRIPTION
Update the default CK version in our arc-conformance test.  It's also nice to be able to test pre-releases, so add a channel param.

Test with this branch has passed: https://jenkins.canonical.com/k8s/job/arc-conformance/116/console