### PR TITLE
Docker fixes

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -75,9 +75,6 @@
             snapcraft logout
             snapcraft login --with /var/lib/jenkins/.config/snapcraft/snapcraft-cpc.cfg
 
-            docker image prune -a --filter "until=24h" --force
-            docker container prune --filter "until=24h" --force
-
             python jobs/build-snaps/build-eks-snaps.py build \
                  --version $VERSION \
                  --snap kubelet \
@@ -85,9 +82,6 @@
                  --snap kube-proxy \
                  --snap kubernetes-test
             python jobs/build-snaps/build-eks-snaps.py push --version $VERSION
-
-            docker image prune -a --filter "until=24h" --force
-            docker container prune --filter "until=24h" --force
     parameters:
       - string:
           name: VERSION

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -279,8 +279,6 @@ pipeline {
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
             sh "sudo lxc delete -f image-processor"
             sh "sudo rm -rf cdk-addons/build"
-            sh "docker image prune -a --filter \"until=24h\" --force"
-            sh "docker container prune --filter \"until=24h\" --force"
             sh "snapcraft logout"
             sh "echo Disk usage after cleanup"
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -342,7 +342,8 @@
     - name: update jenkins user
       user:
         name: jenkins
-        groups: jenkins,docker,lxd
+        groups: docker,lxd
+        append: yes
       tags:
         - jenkins
     - name: setup lxd network

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -278,8 +278,6 @@ pipeline {
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
             sh "sudo lxc delete -f ${lxc_name}"
             sh "sudo rm -rf cdk-addons/build"
-            sh "docker image prune -a --filter \"until=24h\" --force"
-            sh "docker container prune --filter \"until=24h\" --force"
             sh "echo Disk usage after cleanup"
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
         }


### PR DESCRIPTION
Update the infra jobs to append required groups to the existing `jenkins` user.

Infra jobs call `docker prune` and run periodically throughout the day. We previously forced pruning on `build-snaps` and `sync-x` jobs to save disk space, but it's not required with our current jenkins workers since they have larger disks.