### PR TITLE
Speed up cleanup of K8s models

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -284,6 +284,8 @@ async def k8s_model(model, tools):
                     "juju",
                     "destroy-model",
                     "--destroy-storage",
+                    "--force",
+                    "--no-wait",
                     "-y",
                     tools.k8s_connection,
                 )


### PR DESCRIPTION
Sometimes, Juju can wait an inordinate amount of time for Kubernetes to actually report that a resource has been removed, leading to 10+ minute model cleanup times, which tend to run up against timeouts. The combination of `--force` and `--no-wait` lets Juju proceed faster, and K8s will clean things up as expected eventually (or the cluster will be torn down anyway).

Fixes [lp:1931723][]

[lp:1931723]: https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1931723