### PR TITLE
Lessen sync-oci-images disk requirements

### DIFF
--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -69,8 +69,8 @@ pipeline {
                         git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
                     fi
 
-                    echo "Getting bundle from old-ci-images branch."
-                    git clone https://github.com/charmed-kubernetes/bundle.git --branch old-ci-images --depth 1
+                    echo "Getting bundle from master branch."
+                    git clone https://github.com/charmed-kubernetes/bundle.git --branch master --depth 1
                 """
             }
         }

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -151,11 +151,11 @@ pipeline {
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms
+                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms
+                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
                             fi
                         fi
 
@@ -178,11 +178,11 @@ pipeline {
                         else
                             sudo lxc exec ${lxc_name} -- ctr image tag \${i} \${TAG_PREFIX}/\${RAW_IMAGE}
                             # simple retry if initial push fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
+                            if ! sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             then
                                 echo "Retrying push"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
+                                sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             fi
                         fi
 
@@ -238,11 +238,11 @@ pipeline {
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms
+                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms
+                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
                             fi
                         fi
 
@@ -265,11 +265,11 @@ pipeline {
                         else
                             sudo lxc exec ${lxc_name} -- ctr image tag \${i} \${TAG_PREFIX}/\${RAW_IMAGE}
                             # simple retry if initial push fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
+                            if ! sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             then
                                 echo "Retrying push"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
+                                sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             fi
                         fi
 

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -68,8 +68,10 @@ pipeline {
                         echo "Getting cdk-addons from master branch."
                         git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
                     fi
+
+                    echo "Getting bundle from old-ci-images branch."
+                    git clone https://github.com/charmed-kubernetes/bundle.git --branch old-ci-images --depth 1
                 """
-                sh "git clone https://github.com/charmed-kubernetes/bundle.git"
             }
         }
         stage('Build image list'){

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -145,6 +145,7 @@ pipeline {
                             continue
                         fi
 
+                        # Pull
                         if ${params.dry_run}
                         then
                             echo "Dry run; would have pulled: \${i}"
@@ -183,6 +184,14 @@ pipeline {
                                 sleep 5
                                 sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
                             fi
+                        fi
+
+                        # Remove image now that we've pushed to keep our disk req low(ish)
+                        if ${params.dry_run}
+                        then
+                            echo "Dry run; would have removed: \${i} \${TAG_PREFIX}/\${RAW_IMAGE}"
+                        else
+                            sudo lxc exec ${lxc_name} -- ctr image rm \${i} \${TAG_PREFIX}/\${RAW_IMAGE}
                         fi
                     done
 
@@ -223,6 +232,7 @@ pipeline {
                             continue
                         fi
 
+                        # Pull
                         if ${params.dry_run}
                         then
                             echo "Dry run; would have pulled: \${i}"
@@ -261,6 +271,14 @@ pipeline {
                                 sleep 5
                                 sudo lxc exec ${lxc_name} -- ctr image push \${TAG_PREFIX}/\${RAW_IMAGE} --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}"
                             fi
+                        fi
+
+                        # Remove image now that we've pushed to keep our disk req low(ish)
+                        if ${params.dry_run}
+                        then
+                            echo "Dry run; would have removed: \${i} \${TAG_PREFIX}/\${RAW_IMAGE}"
+                        else
+                            sudo lxc exec ${lxc_name} -- ctr image rm \${i} \${TAG_PREFIX}/\${RAW_IMAGE}
                         fi
                     done
 


### PR DESCRIPTION
The sync-oci-images job pulls, tags, and pushes around 100 images per job.  This takes around 30G, which can fill up our worker root disks, especially if other jobs are running concurrently. There's no good reason to keep processed images around for the duration of the job -- we destroy the container used to fetch them at the end of the job anyway.

This PR removes an image as soon as we're done pushing it to rocks.  It also sends `ctr push/pull` output to `/dev/null` because the level of output is enormous, and even if a `pull/push` fails mid-way through an image, that info isn't useful.  We care about *what* image failed, not *when* it failed.