### PR TITLE
set model defaults to auto retry hooks

### DIFF
--- a/jobs/bundles/test-all
+++ b/jobs/bundles/test-all
@@ -77,7 +77,7 @@ function juju::bootstrap
          --model-default test-mode=true \
          --model-default resource-tags=owner=k8sci \
          --model-default image-stream=daily \
-         --model-default automatically-retry-hooks=false \
+         --model-default automatically-retry-hooks=true \
          --model-default logging-config="<root>=DEBUG"
 }
 

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -33,7 +33,7 @@ function juju::bootstrap
       --model-default test-mode=true \
       --model-default resource-tags=owner=k8sci \
       --model-default image-stream=daily \
-      --model-default automatically-retry-hooks=false \
+      --model-default automatically-retry-hooks=true \
       --model-default logging-config="<root>=DEBUG" \
       --model-default vpc-id=$vpc_id
 

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -58,7 +58,7 @@ juju bootstrap localhost/localhost \
     --model-default juju-http-proxy=http://squid.internal:3128 \
     --model-default juju-https-proxy=http://squid.internal:3128 \
     --model-default juju-no-proxy=localhost,127.0.0.1,::1,10.23.105.0/24 \
-    --model-default automatically-retry-hooks=false
+    --model-default automatically-retry-hooks=true
 
 juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" \
     --channel $JUJU_DEPLOY_CHANNEL \

--- a/jobs/validate/spec-arm64
+++ b/jobs/validate/spec-arm64
@@ -27,7 +27,7 @@ function juju::bootstrap
          --model-default test-mode=true \
          --model-default resource-tags=owner=k8sci \
          --model-default image-stream=daily \
-         --model-default automatically-retry-hooks=false
+         --model-default automatically-retry-hooks=true
 }
 
 function juju::deploy

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -28,7 +28,7 @@ function juju::bootstrap
       --model-default test-mode=true \
       --model-default resource-tags=owner=k8sci \
       --model-default image-stream=daily \
-      --model-default automatically-retry-hooks=false \
+      --model-default automatically-retry-hooks=true \
       --model-default logging-config="<root>=DEBUG" \
       --model-default vpc-id=$vpc_id
 }

--- a/jobs/validate/upgrade-arm64-spec
+++ b/jobs/validate/upgrade-arm64-spec
@@ -27,7 +27,7 @@ function juju::bootstrap
          --bootstrap-constraints "$constraints" \
          --model-default test-mode=true \
          --model-default resource-tags=owner=k8sci \
-         --model-default automatically-retry-hooks=false \
+         --model-default automatically-retry-hooks=true \
          --model-default image-stream=daily
 }
 

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -21,7 +21,7 @@ set -x
 #          --model-default resource-tags=owner=k8sci \
 #          --model-default image-stream=daily \
 #          --model-default vpc-id=vpc-0e4f11d0d4e9ba35f \
-#          --model-default automatically-retry-hooks=false \
+#          --model-default automatically-retry-hooks=true \
 #          --config vpc-id=vpc-0e4f11d0d4e9ba35f
 # }
 

--- a/juju.bash
+++ b/juju.bash
@@ -27,7 +27,7 @@ function juju::bootstrap
          --model-default test-mode=true \
          --model-default resource-tags=owner=k8sci \
          --model-default image-stream=daily \
-         --model-default automatically-retry-hooks=false \
+         --model-default automatically-retry-hooks=true \
          --model-default logging-config="<root>=DEBUG" \
          $extra_args
 


### PR DESCRIPTION
Our [CI reports](http://jenkaas.s3-website-us-east-1.amazonaws.com/) are littered with yellow nightly jobs; some of these can be attributed to charmstore/snapstore failures (e.g 503 errors when trying to pull a snap). We currently fail a test with "yellow" status even if things outside our control (snap/charmstore) are down because we have "auto-retry-hooks" turned off in our CI models.

This PR proposes we enable retry-hooks to get around transient network issues with the assumption that SQA is our release gate -- they test with `auto-retry-hooks=false`. This will enable us to easily see if our tests are failing *with* a hook-retry (via our nightly job status of red/yellow/green), yet still let SQA hold a release for a failure that might be a legit issue only surfaced when `auto-retry-hooks=false`.

Without this, our CI report is so yellow that we've lost confidence in it. I think our daily CI should tolerate external failures. The risk here is that we deliberately turned this option off to better match SQA's env, but in hindsight, I think this has led to us ignoring CI failures with the mindset of "eh, probably a network error; let's see how tomorrow goes".  But then tomorrow comes and we fail differently and rinse/repeat.