### PR TITLE
Fix timed out tests not showing tracebacks, use SIGINT

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -128,6 +128,7 @@ function test::execute
     declare -n is_pass=$1
     timeout -s INT 3h pytest \
         --html="report.html" \
+        --full-trace \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \
         --model "$JUJU_MODEL" \

--- a/ci.bash
+++ b/ci.bash
@@ -126,7 +126,7 @@ function kv::get
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 3h pytest \
+    timeout -s INT 3h pytest \
         --html="report.html" \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \

--- a/jobs/release/bugfix-upgrade-spec
+++ b/jobs/release/bugfix-upgrade-spec
@@ -19,6 +19,7 @@ function test::execute
 {
     declare -n is_pass=$1
     timeout -s INT 3h pytest \
+                --full-trace \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/release/bugfix-upgrade-spec
+++ b/jobs/release/bugfix-upgrade-spec
@@ -18,7 +18,7 @@ set -x
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 3h pytest \
+    timeout -s INT 3h pytest \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/validate/aws-iam-spec
+++ b/jobs/validate/aws-iam-spec
@@ -15,6 +15,7 @@ function test::execute
     declare -n is_pass=$1
 
     timeout -s INT 2h pytest \
+                --full-trace \
                 jobs/integration/test_aws_iam.py \
                 --cloud "$JUJU_CLOUD" \
                 --model "$JUJU_MODEL" \

--- a/jobs/validate/aws-iam-spec
+++ b/jobs/validate/aws-iam-spec
@@ -14,7 +14,7 @@ function test::execute
 {
     declare -n is_pass=$1
 
-    timeout 2h pytest \
+    timeout -s INT 2h pytest \
                 jobs/integration/test_aws_iam.py \
                 --cloud "$JUJU_CLOUD" \
                 --model "$JUJU_MODEL" \

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -69,7 +69,7 @@ juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" \
 timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 
 pushd jenkins
-TOX_WORK_DIR=.tox timeout 3h tox -e py36 -- pytest \
+TOX_WORK_DIR=.tox timeout -s INT 3h tox -e py36 -- pytest \
     jobs/integration/validation.py \
     --cloud localhost \
     --model $JUJU_MODEL \

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -70,6 +70,7 @@ timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 
 pushd jenkins
 TOX_WORK_DIR=.tox timeout -s INT 3h tox -e py36 -- pytest \
+    --full-trace \
     jobs/integration/validation.py \
     --cloud localhost \
     --model $JUJU_MODEL \

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -67,6 +67,7 @@ timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 
 pushd jenkins
 timeout -s INT 3h tox --workdir .tox -e py38 -- pytest \
+    --full-trace \
     jobs/integration/validation.py \
     --cloud localhost \
     --model $JUJU_MODEL \

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -66,7 +66,7 @@ juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" \
 timeout 45m juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 
 pushd jenkins
-timeout 3h tox --workdir .tox -e py38 -- pytest \
+timeout -s INT 3h tox --workdir .tox -e py38 -- pytest \
     jobs/integration/validation.py \
     --cloud localhost \
     --model $JUJU_MODEL \

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -55,7 +55,7 @@ function juju::deploy::after
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 2h pytest \
+    timeout -s INT 2h pytest \
         --html="report.html" \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -57,6 +57,7 @@ function test::execute
     declare -n is_pass=$1
     timeout -s INT 2h pytest \
         --html="report.html" \
+        --full-trace \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \
         --model "$JUJU_MODEL" \

--- a/jobs/validate/series-upgrade-spec
+++ b/jobs/validate/series-upgrade-spec
@@ -13,7 +13,7 @@ set -x
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 2h pytest \
+    timeout -s INT 2h pytest \
                 jobs/integration/validation.py \
                 --is-series-upgrade \
                 --cloud "$JUJU_CLOUD" \

--- a/jobs/validate/series-upgrade-spec
+++ b/jobs/validate/series-upgrade-spec
@@ -14,6 +14,7 @@ function test::execute
 {
     declare -n is_pass=$1
     timeout -s INT 2h pytest \
+                --full-trace \
                 jobs/integration/validation.py \
                 --is-series-upgrade \
                 --cloud "$JUJU_CLOUD" \

--- a/jobs/validate/snapd-upgrade-spec
+++ b/jobs/validate/snapd-upgrade-spec
@@ -12,7 +12,7 @@ set -x
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 4h pytest \
+    timeout -s INT 4h pytest \
                 jobs/integration/validation.py \
                 --cloud "$JUJU_CLOUD" \
                 --model "$JUJU_MODEL" \

--- a/jobs/validate/snapd-upgrade-spec
+++ b/jobs/validate/snapd-upgrade-spec
@@ -13,6 +13,7 @@ function test::execute
 {
     declare -n is_pass=$1
     timeout -s INT 4h pytest \
+                --full-trace \
                 jobs/integration/validation.py \
                 --cloud "$JUJU_CLOUD" \
                 --model "$JUJU_MODEL" \

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -67,6 +67,7 @@ function test::execute
     declare -n is_pass=$1
     timeout -s INT 2h pytest \
         --html="report.html" \
+        --full-trace \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \
         --model "$JUJU_MODEL" \

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -65,7 +65,7 @@ function juju::deploy::after
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 2h pytest \
+    timeout -s INT 2h pytest \
         --html="report.html" \
         jobs/integration/validation.py \
         --cloud "$JUJU_CLOUD" \

--- a/jobs/validate/upgrade-arm64-spec
+++ b/jobs/validate/upgrade-arm64-spec
@@ -64,6 +64,7 @@ function test::execute
 {
     declare -n is_pass=$1
     timeout -s INT 3h pytest \
+                --full-trace \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/validate/upgrade-arm64-spec
+++ b/jobs/validate/upgrade-arm64-spec
@@ -63,7 +63,7 @@ EOF
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 3h pytest \
+    timeout -s INT 3h pytest \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/validate/upgrade-spec
+++ b/jobs/validate/upgrade-spec
@@ -19,6 +19,7 @@ function test::execute
 {
     declare -n is_pass=$1
     timeout -s INT 3h pytest \
+                --full-trace \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/validate/upgrade-spec
+++ b/jobs/validate/upgrade-spec
@@ -18,7 +18,7 @@ set -x
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 3h pytest \
+    timeout -s INT 3h pytest \
                 jobs/integration/validation.py \
                 --is-upgrade \
                 --upgrade-snap-channel "$SNAP_VERSION_UPGRADE_TO" \

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -75,7 +75,7 @@ function juju::wait
 function test::execute
 {
     declare -n is_pass=$1
-    timeout 2h pytest \
+    timeout -s INT 2h pytest \
         --html="report.html" \
         jobs/integration/validation.py::test_encryption_at_rest \
         --cloud "$JUJU_CLOUD" \

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -77,6 +77,7 @@ function test::execute
     declare -n is_pass=$1
     timeout -s INT 2h pytest \
         --html="report.html" \
+        --full-trace \
         jobs/integration/validation.py::test_encryption_at_rest \
         --cloud "$JUJU_CLOUD" \
         --model "$JUJU_MODEL" \


### PR DESCRIPTION
If we send SIGINT when a timeout occurs, that will raise a KeyboardInterrupt exception in the Python code and show us a traceback. That should help us see exactly where tests are getting stuck.