### PR TITLE
Service endpoint unit print

### DIFF
--- a/jobs/integration/test_service_endpoints.py
+++ b/jobs/integration/test_service_endpoints.py
@@ -3,7 +3,7 @@ import pytest
 import requests
 import yaml
 from .utils import asyncify, retry_async_with_timeout
-from .logging import log
+from .logger import log
 
 
 def get_pod_yaml():
@@ -123,7 +123,7 @@ async def test_clusterip_service_endpoint(model):
             try:
                 assert "Hello Kubernetes!" in action.results.get("Stdout", "")
             except AssertionError as e:
-                log("connection on {unit} failed")
+                log(f"connection on {unit} failed")
                 raise e
 
     finally:

--- a/jobs/integration/test_service_endpoints.py
+++ b/jobs/integration/test_service_endpoints.py
@@ -119,9 +119,12 @@ async def test_clusterip_service_endpoint(model):
         worker = model.applications["kubernetes-worker"]
         nodes_lst = master.units + worker.units
         for unit in nodes_lst:
-            log(f"testing connection on {unit}")
             action = await unit.run(cmd)
-            assert "Hello Kubernetes!" in action.results.get("Stdout", "")
+            try:
+                assert "Hello Kubernetes!" in action.results.get("Stdout", "")
+            except AssertionError as e:
+                log("connection on {unit} failed")
+                raise e
 
     finally:
         await cleanup()

--- a/jobs/integration/test_service_endpoints.py
+++ b/jobs/integration/test_service_endpoints.py
@@ -3,6 +3,7 @@ import pytest
 import requests
 import yaml
 from .utils import asyncify, retry_async_with_timeout
+from .logging import log
 
 
 def get_pod_yaml():
@@ -118,6 +119,7 @@ async def test_clusterip_service_endpoint(model):
         worker = model.applications["kubernetes-worker"]
         nodes_lst = master.units + worker.units
         for unit in nodes_lst:
+            log(f"testing connection on {unit}")
             action = await unit.run(cmd)
             assert "Hello Kubernetes!" in action.results.get("Stdout", "")
 


### PR DESCRIPTION
During test_clusterip_service_endpoint log k8s unit failures.
    
Test_clusterip_service_endpoint tries to reach the hello world
container from each of the k8s master and workers, this patch
will print which unit is running the curl to help debug any
errors.