### PR TITLE
fix channel map issues

### DIFF
--- a/cilib/snapapi.py
+++ b/cilib/snapapi.py
@@ -24,6 +24,7 @@ class SnapStore:
 
     def max_rev(self, arch, track):
         """Returns max revision for snap by arch/track"""
+        print(self.channel_map)
         for channel in self.channel_map["channel-map"]:
             if channel["channel"] == track and channel["architecture"] == arch:
                 return int(channel["revision"])

--- a/cilib/snapapi.py
+++ b/cilib/snapapi.py
@@ -1,9 +1,7 @@
 import sh
 import re
-import operator
 import semver
 import json
-from pprint import pprint, pformat
 from cilib.run import capture
 from functools import cached_property
 
@@ -24,7 +22,8 @@ class SnapStore:
 
     def max_rev(self, arch, track):
         """Returns max revision for snap by arch/track"""
-        print(self.channel_map)
+        if "channel-map" not in self.channel_map:
+            print(f"Invalid channel map: {self.channel_map}")
         for channel in self.channel_map["channel-map"]:
             if channel["channel"] == track and channel["architecture"] == arch:
                 return int(channel["revision"])
@@ -76,7 +75,6 @@ def revisions(snap, version_filter_track, arch="amd64", exclude_pre=False):
     re_comp = re.compile("[ \t+]{2,}")
     revision_list = sh.snapcraft.revisions(snap, "--arch", arch, _err_to_out=True)
     revision_list = revision_list.stdout.decode().splitlines()[1:]
-    revision_parsed = {}
 
     revisions_to_process = []
     for line in revision_list:

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -277,7 +277,7 @@
         owner: jenkins
         group: jenkins
         mode: 0644
-        force: no
+        force: yes
       tags:
         - jenkins
     - name: create juju dir

--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -24,7 +24,7 @@
 
       Then upload the launchpad_creds file to the launchpad_creds credential in Jenkins.
 
-      If the job fails to retrive snap channel information, you may need to
+      If the job fails to retrieve snap channel information (e.g., you get an "invalid channel map" error), you may need to
       update surl-creds:
 
       sudo snap install surl

--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -108,6 +108,7 @@
 
 - job:
     name: 'sync-ppas'
+    disabled: true
     node: runner-cloud
     description: |
       Syncs all ppas

--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -22,7 +22,17 @@
       ...
       >>> exit()
 
-      Then upload the launchpad_creds file to the launchpad_creds credential on Jenkins.
+      Then upload the launchpad_creds file to the launchpad_creds credential in Jenkins.
+
+      If the job fails to retrive snap channel information, you may need to
+      update surl-creds:
+
+      sudo snap install surl
+      surl -e cdkbot@gmail.com -s production -a production-creds
+      # above creds are in LastPass
+
+      Then upload ~/snap/surl/common/production-creds.surl to the surl-creds credential
+      in Jenkins.
     project-type: freestyle
     scm:
       - k8s-jenkins-jenkaas

--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -24,8 +24,8 @@
 
       Then upload the launchpad_creds file to the launchpad_creds credential in Jenkins.
 
-      If the job fails to retrieve snap channel information (e.g., you get an "invalid channel map" error), you may need to
-      update surl-creds:
+      If the job fails to retrieve snap channel information (e.g., you get an
+      "invalid channel map" error), you may need to update surl-creds:
 
       sudo snap install surl
       surl -e cdkbot@gmail.com -s production -a production-creds


### PR DESCRIPTION
surl-creds had expired.  Add a note for how to update these and print debug info if the channel-map appears invalid.  These credentials need to be force-written when infra jobs run, otherwise the playbook will not overwrite the creds file if one already exists.

Drive by to disable the sync-ppas job, since we no longer support k8s deb packages.

Edit: also fixed some lint errors in snapapi.py