### PR TITLE
tips-n-debug for hung cdk-addons jobs

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -10,6 +10,11 @@
       The full version of the cdk-addons snap is tied to the upstream k8s tag used during the build.
       Explicitly set this with the `k8s_tag` parameter, or this job will determine it using the
       `version` parameter and the contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
+
+      If all `build-release-cdk-addons-$arch-$ver` jobs appear to stall during snap upload, check
+      for a revision for which the auto-approver has hung by logging into
+      https://dashboard.snapcraft.io/snaps/cdk-addons/ with cdkbot@gmail ubuntu lastpass creds
+      and manually rejecting the review for the oldest hung revision.
     project-type: pipeline
     pipeline-scm:
       scm:

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -265,10 +265,10 @@ pipeline {
                     if(params.dry_run) {
                         echo "Dry run; would have uploaded cdk-addons/*.snap to ${params.channels}"
                     } else {
-                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_amd64.snap --release ${params.channels}"
-                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_arm64.snap --release ${params.channels}"
-                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_ppc64el.snap --release ${params.channels}"
-                        sh "snapcraft upload cdk-addons/cdk-addons_${kube_ersion}_s390x.snap --release ${params.channels}"
+                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_amd64.snap --release ${params.channels}"
+                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_arm64.snap --release ${params.channels}"
+                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_ppc64el.snap --release ${params.channels}"
+                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_s390x.snap --release ${params.channels}"
                     }
                 }
             }


### PR DESCRIPTION
During 1.22, we noticed all `build-release-cdkaddons-$arch-$ver` jobs hanging during `snapcraft upload`. Add a debug flag to that invocation to try and get more info about the hang.

Also update the job description as at least *some* means of documenting how to fix this if it happens again.