### PR TITLE
add 1.22 to test matrix; adjust enums for proper snap builds

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -52,7 +52,7 @@ SNAP_K8S_TRACK_MAP = {
     "1.19": ["1.19/stable", "1.19/candidate", "1.19/beta", "1.19/edge"],
     "1.20": ["1.20/stable", "1.20/candidate", "1.20/beta", "1.20/edge"],
     "1.21": ["1.21/stable", "1.21/candidate", "1.21/beta", "1.21/edge"],
-    "1.22": ["1.22/edge"],
+    "1.22": ["1.22/candidate", "1.22/beta", "1.22/edge"],
 }
 
 # Deb k8s version <-> ppa mapping

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -10,7 +10,12 @@ JOBS_PATH = Path("jobs")
 K8S_STABLE_VERSION = "1.21"
 
 # Next MAJOR.MINOR
-K8S_NEXT_VERSION = "1.22"
+# This controls whether or not we build pre-release snaps in our channels.
+# Typically, this is K8S_STABLE_VERSION +1. However, when prepping the next
+# stable release, this will be +2. For example, 1.21 is currently stable and
+# we're working on the 1.22 GA. Set this value to '1.23' so we don't get
+# pre-release builds (e.g. 1.22.1-beta.0) in our 1.22/beta channels.
+K8S_NEXT_VERSION = "1.23"
 
 # Lowest K8S SEMVER to process, this is usually stable - 3
 K8S_STARTING_SEMVER = "1.18.0"

--- a/cilib/models/repos/test/test_snap_models.py
+++ b/cilib/models/repos/test/test_snap_models.py
@@ -19,4 +19,4 @@ def test_get_proper_tracks():
         "1.21/edge",
     ]
     repo_model.version = "1.22"
-    assert repo_model.tracks == ["1.22/edge"]
+    assert repo_model.tracks == ["1.22/candidate", "1.22/beta", "1.22/edge"]

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -94,7 +94,7 @@
 - project:
     name: build-release-snaps
     arch: ['amd64']
-    version: ['1.18', '1.19', '1.20', '1.21', '1.22']
+    version: ['1.19', '1.20', '1.21', '1.22']
     jobs:
       - 'build-release-cdk-addons-{arch}-{version}'
 

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -26,8 +26,8 @@
           JOB_SPEC_DIR: "jobs/release"
       - run-env:
           COMMAND: |
-            parallel --timeout 200% --ungroup bash jobs/validate/spec {1} {2} {3} {4} ::: 1.21/stable ::: focal bionic ::: beta ::: arm64 amd64
-            parallel --timeout 200% --ungroup bash jobs/validate/upgrade-spec {1} {2} {3} {4} {5} ::: 1.20/stable 1.19/stable 1.18/stable ::: focal bionic xenial ::: beta ::: arm64 amd64 ::: 1.21/stable
+            parallel --timeout 200% --ungroup bash jobs/validate/spec {1} {2} {3} {4} ::: 1.22/beta ::: focal bionic ::: beta ::: arm64 amd64
+            parallel --timeout 200% --ungroup bash jobs/validate/upgrade-spec {1} {2} {3} {4} {5} ::: 1.21/stable 1.20/stable 1.19/stable ::: focal bionic xenial ::: beta ::: arm64 amd64 ::: 1.22/beta
 
 - job:
     name: 'validate-charm-bugfix'
@@ -95,8 +95,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.21/stable
             - 1.20/stable
-            - 1.19/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/validate-offline/spec.yml
+++ b/jobs/validate-offline/spec.yml
@@ -1,7 +1,7 @@
 plan:
   - &BASE_JOB
     env:
-      - SNAP_VERSION=1.21/edge
+      - SNAP_VERSION=1.22/edge
       - JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
       - JUJU_DEPLOY_CHANNEL=edge
       - JUJU_CLOUD=aws/us-east-1

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -27,6 +27,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -79,6 +80,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -136,6 +138,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -243,8 +246,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.21/stable
             - 1.20/stable
-            - 1.19/stable
       - axis:
           type: user-defined
           name: series
@@ -295,8 +298,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.21/stable
             - 1.20/stable
-            - 1.19/stable
       - axis:
           type: user-defined
           name: series
@@ -429,6 +432,7 @@
            type: user-defined
            name: snap_version
            values:
+             - 1.22/edge
              - 1.21/edge
              - 1.20/edge
              - 1.19/edge
@@ -471,6 +475,7 @@
            type: user-defined
            name: snap_version
            values:
+             - 1.22/edge
              - 1.21/edge
              - 1.20/edge
              - 1.19/edge
@@ -516,6 +521,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -567,6 +573,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -609,6 +616,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -651,6 +659,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -694,6 +703,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -737,6 +747,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge
@@ -780,6 +791,7 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/edge
             - 1.21/edge
             - 1.20/edge
             - 1.19/edge

--- a/jobs/validate/upgrade-spec
+++ b/jobs/validate/upgrade-spec
@@ -37,10 +37,10 @@ function test::execute
 ###############################################################################
 # ENV
 ###############################################################################
-SNAP_VERSION_UPGRADE_TO=${5:-1.21/edge}
+SNAP_VERSION_UPGRADE_TO=${5:-1.22/edge}
 export SNAP_VERSION_UPGRADE_TO
 
-SNAP_VERSION=${1:-1.20/stable}
+SNAP_VERSION=${1:-1.21/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-stable}


### PR DESCRIPTION
- Start pushing 1.22 snaps to `beta` and `candidate` in preparation for GA and bugfix releases.
- Drop 1.18 from our test matrix (it is out of support)
- Add 1.22 to our test matrix
- For upgrade jobs, make sure we include 1.21/stable in the "upgrade-from" matrix