### PR TITLE
update snap-eks jobs with arch/dry-run params

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -92,15 +92,15 @@
       - string:
           name: ARCH
           default: 'amd64'
-          description: snap eks architecture to build/promote
+          description: eks snap architecture to build/promote
       - string:
           name: VERSION
           default: '1.21.1'
-          description: snap eks version to build/promote
+          description: eks snap version to build/promote
       - bool:
           name: DRY_RUN
           default: false
-          description: dry run build
+          description: if checked, only report what would be built/promoted
     properties:
       - build-discarder:
           num-to-keep: 7

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -72,21 +72,35 @@
       - run-venv:
           JOB_SPEC_DIR: "jobs/build-snaps"
           COMMAND: |
+            IS_DRY_RUN=""
+            if [[ $DRY_RUN = "true" ]]; then
+              IS_DRY_RUN="--dry-run"
+            fi
+
             snapcraft logout
             snapcraft login --with /var/lib/jenkins/.config/snapcraft/snapcraft-cpc.cfg
 
-            python jobs/build-snaps/build-eks-snaps.py build \
+            python jobs/build-snaps/build-eks-snaps.py build $IS_DRY_RUN \
+                 --arch $ARCH \
                  --version $VERSION \
                  --snap kubelet \
                  --snap kubectl \
                  --snap kube-proxy \
                  --snap kubernetes-test
-            python jobs/build-snaps/build-eks-snaps.py push --version $VERSION
+            python jobs/build-snaps/build-eks-snaps.py push $IS_DRY_RUN --version $VERSION
     parameters:
+      - string:
+          name: ARCH
+          default: 'amd64'
+          description: snap eks architecture to build/promote
       - string:
           name: VERSION
           default: '1.21.1'
           description: snap eks version to build/promote
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: dry run build
     properties:
       - build-discarder:
           num-to-keep: 7

--- a/jobs/build-snaps/build-eks-snaps.py
+++ b/jobs/build-snaps/build-eks-snaps.py
@@ -34,7 +34,7 @@ def cli():
     "--build-path", required=True, default="release/snap", help="Path of snap builds"
 )
 @click.option(
-    "--version", required=True, default="1.14.8", help="Version of k8s to build"
+    "--version", required=True, default="1.19.8", help="Version of k8s to build"
 )
 @click.option(
     "--arch", required=True, default="amd64", help="Architecture to build against"
@@ -50,7 +50,7 @@ def build(snap, build_path, version, arch, dry_run):
         --snap kube-proxy \
         --snap kubelet \
         --snap kubernetes-test \
-        --version 1.14.8
+        --version 1.19.8
     """
     if not version.startswith("v"):
         version = f"v{version}"
@@ -97,7 +97,7 @@ def build(snap, build_path, version, arch, dry_run):
     default="release/snap/snap/build",
     help="Path of resulting snap builds",
 )
-@click.option("--version", required=True, default="1.14.8", help="k8s Version")
+@click.option("--version", required=True, default="1.19.8", help="k8s Version")
 @click.option("--dry-run", is_flag=True)
 def push(result_dir, version, dry_run):
     """Promote to a snapstore channel/track"""

--- a/jobs/build-snaps/build-eks-snaps.py
+++ b/jobs/build-snaps/build-eks-snaps.py
@@ -31,7 +31,7 @@ def cli():
 @cli.command()
 @click.option("--snap", required=True, multiple=True, help="Snaps to build")
 @click.option(
-    "--build-path", required=True, default="release/snap", help="Path of snap builds"
+    "--build-path", required=True, default="release", help="Path of snap builds"
 )
 @click.option(
     "--version", required=True, default="1.19.8", help="Version of k8s to build"

--- a/jobs/build-snaps/build-eks-snaps.py
+++ b/jobs/build-snaps/build-eks-snaps.py
@@ -15,7 +15,7 @@ from sh.contrib import git
 def _set_snap_alias(build_path, alias):
     click.echo(f"Setting new snap alias: {alias}")
     if build_path.exists():
-        snapcraft_yml = yaml.load(build_path.read_text())
+        snapcraft_yml = yaml.safe_load(build_path.read_text())
         if snapcraft_yml["name"] != alias:
             snapcraft_yml["name"] = alias
             build_path.write_text(

--- a/jobs/build-snaps/build-eks-snaps.py
+++ b/jobs/build-snaps/build-eks-snaps.py
@@ -31,16 +31,13 @@ def cli():
 @cli.command()
 @click.option("--snap", required=True, multiple=True, help="Snaps to build")
 @click.option(
-    "--build-path", required=True, default="release", help="Path of snap builds"
-)
-@click.option(
     "--version", required=True, default="1.21.1", help="Version of k8s to build"
 )
 @click.option(
     "--arch", required=True, default="amd64", help="Architecture to build against"
 )
 @click.option("--dry-run", is_flag=True)
-def build(snap, build_path, version, arch, dry_run):
+def build(snap, version, arch, dry_run):
     """ Build snaps
 
     Usage:
@@ -59,11 +56,11 @@ def build(snap, build_path, version, arch, dry_run):
     env["KUBE_ARCH"] = arch
     git.clone(
         "https://github.com/juju-solutions/release.git",
-        build_path,
+        "release",
         branch="rye/snaps",
         depth="1",
     )
-    build_path = Path(build_path) / "snap"
+    build_path = Path("release/snap")
     snap_alias = None
 
     for _snap in snap:
@@ -94,7 +91,7 @@ def build(snap, build_path, version, arch, dry_run):
 @click.option(
     "--result-dir",
     required=True,
-    default="release/snap/snap/build",
+    default="release/snap/build",
     help="Path of resulting snap builds",
 )
 @click.option("--version", required=True, default="1.21.1", help="k8s Version")
@@ -103,12 +100,12 @@ def push(result_dir, version, dry_run):
     """Promote to a snapstore channel/track"""
     for fname in glob.glob(f"{result_dir}/*.snap"):
         try:
-            click.echo(f"Running: snapcraft push {fname}")
+            click.echo(f"Running: snapcraft upload {fname}")
             if dry_run:
                 click.echo("dry-run only:")
-                click.echo(f"  > snapcraft push {fname}")
+                click.echo(f"  > snapcraft upload {fname}")
             else:
-                for line in sh.snapcraft.push(
+                for line in sh.snapcraft.upload(
                     fname,
                     "--release",
                     f"{version}/edge,{version}/beta,{version}/candidate,{version}/stable",

--- a/jobs/build-snaps/build-eks-snaps.py
+++ b/jobs/build-snaps/build-eks-snaps.py
@@ -34,7 +34,7 @@ def cli():
     "--build-path", required=True, default="release", help="Path of snap builds"
 )
 @click.option(
-    "--version", required=True, default="1.19.8", help="Version of k8s to build"
+    "--version", required=True, default="1.21.1", help="Version of k8s to build"
 )
 @click.option(
     "--arch", required=True, default="amd64", help="Architecture to build against"
@@ -50,7 +50,7 @@ def build(snap, build_path, version, arch, dry_run):
         --snap kube-proxy \
         --snap kubelet \
         --snap kubernetes-test \
-        --version 1.19.8
+        --version 1.21.1
     """
     if not version.startswith("v"):
         version = f"v{version}"
@@ -97,7 +97,7 @@ def build(snap, build_path, version, arch, dry_run):
     default="release/snap/snap/build",
     help="Path of resulting snap builds",
 )
-@click.option("--version", required=True, default="1.19.8", help="k8s Version")
+@click.option("--version", required=True, default="1.21.1", help="k8s Version")
 @click.option("--dry-run", is_flag=True)
 def push(result_dir, version, dry_run):
     """Promote to a snapstore channel/track"""


### PR DESCRIPTION
CPC has requested we build snaps for both amd64 and arm64.  Update the job with an arch param so we can set this per-run.

While we're here, update default version values to the latest that cpc has requested.