### PR TITLE
fix up test_ceph

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -476,7 +476,7 @@ async def test_network_policies(model, tools):
 
     await retry_async_with_timeout(
         verify_deleted,
-        (unit, "ns", "netpolicy"),
+        (unit, "ns", ["netpolicy"]),
         timeout_msg="Unable to remove the namespace netpolicy",
     )
 
@@ -755,7 +755,7 @@ async def test_gpu_support(model, tools):
         # nvidia should not be running
         await retry_async_with_timeout(
             verify_deleted,
-            (master_unit, "ds", "nvidia-device-plugin-daemonset", "-n kube-system"),
+            (master_unit, "ds", ["nvidia-device-plugin-daemonset"], "-n kube-system"),
             timeout_msg="nvidia-device-plugin-daemonset is setup without nvidia hardware",
         )
     else:
@@ -781,7 +781,7 @@ async def test_gpu_support(model, tools):
         )
         await retry_async_with_timeout(
             verify_deleted,
-            (master_unit, "po", "nvidia-smi", "-n default"),
+            (master_unit, "po", ["nvidia-smi"], "-n default"),
             timeout_msg="Cleaning of nvidia-smi pod failed",
         )
         # Run the cuda addition
@@ -1177,7 +1177,7 @@ async def test_toggle_metrics(model, tools):
         else:
             await retry_async_with_timeout(
                 verify_deleted,
-                (unit, "svc", "metrics-server", "-n kube-system"),
+                (unit, "svc", ["metrics-server"], "-n kube-system"),
                 timeout_msg="metrics-server svc still exists after timeout",
             )
 

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2353,6 +2353,7 @@ async def test_ceph(model, tools):
     if check_cephfs:
         await validate_storage_class(model, "cephfs", "Ceph")
     # cleanup
+    log("removing ceph applications")
     tasks = {
         model.applications["ceph-mon"].destroy(),
         model.applications["ceph-osd"].destroy(),


### PR DESCRIPTION
`test_ceph` was failing on 1.22 because we needed cephcsi v3.3.  That landed with:

https://github.com/charmed-kubernetes/cdk-addons/pull/204

The test itself also has issues -- specifically when trying to verify that pods were deleted.  We checked for `"error" in output.results.get("Stdout", ""):`, and nowadays, that always matches because we have this tidbit in stdout:

```
...
"--handle-volume-inuse-error=false"
...
```

Refactor `verify_deleted` to be more like `verify_[completed|ready]` and utilize the `find_entitites` function.