### PR TITLE
Remove pip-tools dependency from MicroK8s builds

### DIFF
--- a/jobs/microk8s/tox.ini
+++ b/jobs/microk8s/tox.ini
@@ -5,8 +5,6 @@ toxworkdir= {env:TOX_WORK_DIR:/var/lib/jenkins/.microk8s}
 temp_dir={toxworkdir}/.tmp
 
 [testenv]
-deps =
-     pip-tools
 commands =
      pip-sync {toxinidir}/requirements.txt
      {posargs:test}


### PR DESCRIPTION
Getting the following error:
````
01:48:24 ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/var/lib/jenkins/.tox/py38/lib/python3.8/site-packages/wheel-0.37.0.dist-info/METADATA'
01:48:24 
01:48:24 WARNING: You are using pip version 21.2.3; however, version 21.2.4 is available.
01:48:24 You should consider upgrading via the '/var/lib/jenkins/.tox/py38/bin/python -m pip install --upgrade pip' command.
01:48:24 
01:48:24 =================================== log end ====================================
01:48:24 ERROR: could not install deps [pip >= 20.1, pip-tools]; v = InvocationError("/var/lib/jenkins/.tox/py38/bin/python -m pip install 'pip >= 20.1' pip-tools", 1)
01:48:24 ___________________________________ summary ____________________________________
01:48:24 ERROR:   py38: could not install deps [pip >= 20.1, pip-tools]; v = InvocationError("/var/lib/jenkins/.tox/py38/bin/python -m pip install 'pip >= 20.1' pip-tools", 1)
````

Not sure what pip-tools is needed for.