### PR TITLE
Fix Cinder test and add Octavia test for OpenStack

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -350,7 +350,7 @@ def skip_by_model(request, model):
 
 @pytest.fixture
 def log_dir(request):
-    """ Fixture directory for storing arbitrary test logs. """
+    """Fixture directory for storing arbitrary test logs."""
     path = os.path.join(
         "logs", request.module.__name__, request.node.name.replace("/", "_")
     )
@@ -400,10 +400,10 @@ async def addons_model(request):
     await model.disconnect()
 
 
-@pytest.fixture
-def cloud(request):
-    cloud_name = request.config.getoption("--cloud")
-    return cloud_name.split("/")[0]
+@pytest.fixture(scope="module")
+async def cloud(model):
+    config = await model.get_config()
+    return config["type"].value
 
 
 @pytest.fixture(autouse=True)

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -418,25 +418,30 @@ def skip_by_cloud(request, cloud):
 async def openstack_integrator(model):
     if "openstack-integrator" in model.applications:
         log("openstack-integrator already deployed")
-        return
-    log("deploying openstack-integrator")
-    series = "focal"
-    await model.deploy(
-        "cs:~containers/openstack-integrator",
-        num_units=1,
-        series=series,
-        trust=True,
-    )
-
-    try:
-        log("adding relations")
-        await model.add_relation("openstack-integrator:clients", "kubernetes-master")
-        await model.add_relation("openstack-integrator:clients", "kubernetes-worker")
-        await model.wait_for_idle()
         yield
-    finally:
-        # cleanup
-        await model.applications["openstack-integrator"].destroy()
+    else:
+        log("deploying openstack-integrator")
+        series = "focal"
+        await model.deploy(
+            "cs:~containers/openstack-integrator",
+            num_units=1,
+            series=series,
+            trust=True,
+        )
+
+        try:
+            log("adding relations")
+            await model.add_relation(
+                "openstack-integrator:clients", "kubernetes-master"
+            )
+            await model.add_relation(
+                "openstack-integrator:clients", "kubernetes-worker"
+            )
+            await model.wait_for_idle(timeout=20 * 60)
+            yield
+        finally:
+            # cleanup
+            await model.applications["openstack-integrator"].destroy()
 
 
 # def pytest_itemcollected(item):

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -87,7 +87,7 @@ def apply_profile(model_name):
 
 
 def asyncify(f):
-    """ Convert a blocking function into a coroutine """
+    """Convert a blocking function into a coroutine"""
 
     async def wrapper(*args, **kwargs):
         loop = asyncio.get_event_loop()
@@ -583,11 +583,7 @@ async def get_svc_ingress(model, svc_name):
     for attempt in range(60):
         ingress_address = await kubectl(
             model,
-            "get",
-            "svc",
-            svc_name,
-            "-o",
-            "jsonpath={.status.loadBalancer.ingress[0].ip}",
+            f"get svc {svc_name} -o jsonpath={{.status.loadBalancer.ingress[0].ip}}",
         ).stdout
         log.info(f"Ingress address: {ingress_address}")
         if ingress_address != "":

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -576,3 +576,25 @@ async def get_ipv6_addr(unit):
             if addr.version == 6:
                 return str(addr)
     return None
+
+
+async def get_svc_ingress(model, svc_name):
+    log.info(f"Waiting for ingress address for {svc_name}")
+    for attempt in range(60):
+        ingress_address = await kubectl(
+            model,
+            "get",
+            "svc",
+            svc_name,
+            "-o",
+            "jsonpath={.status.loadBalancer.ingress[0].ip}",
+        ).stdout
+        log.info(f"Ingress address: {ingress_address}")
+        if ingress_address != "":
+            return ingress_address
+        else:
+            await asyncio.sleep(2)
+    else:
+        raise TimeoutError(
+            f"Timed out waiting for {svc_name} to have an ingress address"
+        )

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -581,10 +581,12 @@ async def get_ipv6_addr(unit):
 async def get_svc_ingress(model, svc_name):
     log.info(f"Waiting for ingress address for {svc_name}")
     for attempt in range(60):
-        ingress_address = await kubectl(
+        result = await kubectl(
             model,
             f"get svc {svc_name} -o jsonpath={{.status.loadBalancer.ingress[0].ip}}",
-        ).stdout
+        )
+        assert result.code == 0
+        ingress_address = result.stdout
         log.info(f"Ingress address: {ingress_address}")
         if ingress_address != "":
             return ingress_address

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -578,9 +578,9 @@ async def get_ipv6_addr(unit):
     return None
 
 
-async def get_svc_ingress(model, svc_name):
+async def get_svc_ingress(model, svc_name, timeout=2 * 60):
     log.info(f"Waiting for ingress address for {svc_name}")
-    for attempt in range(60):
+    for attempt in range(timeout >> 2):
         result = await kubectl(
             model,
             f"get svc {svc_name} -o jsonpath={{.status.loadBalancer.ingress[0].ip}}",

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2422,14 +2422,14 @@ async def test_octavia(model, tools, openstack_integrator):
         )
         await kubectl(
             model,
-            "expose deployment microbot --type=LoadBalancer microbot --port=80 --target-port=80",
+            "expose deployment microbot --type=LoadBalancer --port=80 --target-port=80",
         )
         await retry_async_with_timeout(
             verify_ready,
             (unit, "pod,svc", ["microbot"]),
             timeout_msg="Timed out waiting for new microbot service",
         )
-        ingress_address = get_svc_ingress(model, "microbot")
+        ingress_address = await get_svc_ingress(model, "microbot")
         resp = await tools.requests.get(
             f"http://{ingress_address}",
             proxies={"http": None, "https": None},

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2414,16 +2414,10 @@ async def test_octavia(model, tools, openstack_integrator):
     assert action.status == "completed"
     try:
         # remove and replace the service with an LB type
-        await kubectl(model, "delete", "svc", "microbot")
+        await kubectl(model, "delete svc microbot")
         await kubectl(
             model,
-            "expose",
-            "deployment",
-            "microbot",
-            "--type=LoadBalancer",
-            "microbot",
-            "--port=80",
-            "--target-port=80",
+            "expose deployment microbot --type=LoadBalancer microbot --port=80 --target-port=80",
         )
         await retry_async_with_timeout(
             verify_ready,

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2429,7 +2429,7 @@ async def test_octavia(model, tools, openstack_integrator):
             (unit, "pod,svc", ["microbot"]),
             timeout_msg="Timed out waiting for new microbot service",
         )
-        ingress_address = await get_svc_ingress(model, "microbot")
+        ingress_address = await get_svc_ingress(model, "microbot", timeout=5 * 60)
         resp = await tools.requests.get(
             f"http://{ingress_address}",
             proxies={"http": None, "https": None},

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2398,13 +2398,6 @@ async def test_series_upgrade(model, tools):
 @pytest.mark.asyncio
 @pytest.mark.clouds(["openstack"])
 async def test_cinder(model, tools, openstack_integrator):
-    log("waiting for csi to settle")
-    unit = model.applications["kubernetes-master"].units[0]
-    await retry_async_with_timeout(
-        verify_ready,
-        (unit, "po", ["csi-cinder-controllerplugin-0"], "-n kube-system"),
-        timeout_msg="CSI pod not ready!",
-    )
     # create pod that writes to a pv from cinder
     await validate_storage_class(model, "cdk-cinder", "Cinder")
 
@@ -2412,13 +2405,6 @@ async def test_cinder(model, tools, openstack_integrator):
 @pytest.mark.asyncio
 @pytest.mark.clouds(["openstack"])
 async def test_octavia(model, tools, openstack_integrator):
-    log("waiting for cloud-controller-openstack to settle")
-    unit = model.applications["kubernetes-master"].units[0]
-    await retry_async_with_timeout(
-        verify_ready,
-        (unit, "po", ["cloud-controller-openstack-0"], "-n kube-system"),
-        timeout_msg="Cloud Controller OpenStack pod not ready!",
-    )
     # deploy microbot via action
     unit = model.applications["kubernetes-worker"].units[0]
     action = await unit.run_action("microbot", delete=True)

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -39,6 +39,7 @@ from .utils import (
     get_ipv6_addr,
     vault,
     vault_status,
+    get_svc_ingress,
 )
 import urllib.request
 from .logger import log
@@ -59,7 +60,7 @@ class AuditTimestampError(Exception):
 
 
 async def wait_for_process(model, arg):
-    """ Retry api_server_with_arg <checks> times with a 5 sec interval """
+    """Retry api_server_with_arg <checks> times with a 5 sec interval"""
     checks = 60
     ready = False
     while not ready:
@@ -73,7 +74,7 @@ async def wait_for_process(model, arg):
 
 
 async def wait_for_not_process(model, arg):
-    """ Retry api_server_with_arg <checks> times with a 5 sec interval """
+    """Retry api_server_with_arg <checks> times with a 5 sec interval"""
     checks = 60
     ready = False
     while not ready:
@@ -248,7 +249,7 @@ async def test_auth_file_propagation(model, tools):
 @pytest.mark.asyncio
 @pytest.mark.flaky(max_runs=5, min_passes=1)
 async def test_status_messages(model):
-    """ Validate that the status messages are correct. """
+    """Validate that the status messages are correct."""
     expected_messages = {
         "kubernetes-master": "Kubernetes master running.",
         "kubernetes-worker": "Kubernetes worker running.",
@@ -307,7 +308,7 @@ async def test_snap_versions(model):
 
 @pytest.mark.asyncio
 async def test_rbac(model):
-    """ When RBAC is enabled, validate kubelet creds cannot get ClusterRoles """
+    """When RBAC is enabled, validate kubelet creds cannot get ClusterRoles"""
     app = model.applications["kubernetes-master"]
     config = await app.get_config()
     if "RBAC" not in config["authorization-mode"]["value"]:
@@ -321,7 +322,7 @@ async def test_rbac(model):
 @pytest.mark.asyncio
 @pytest.mark.clouds(["aws"])
 async def test_microbot(model, tools):
-    """ Validate the microbot action """
+    """Validate the microbot action"""
     unit = model.applications["kubernetes-worker"].units[0]
     action = await unit.run_action("microbot", delete=True)
     await action.wait()
@@ -349,7 +350,7 @@ async def test_microbot(model, tools):
 @pytest.mark.clouds(["aws", "vsphere"])
 @backoff.on_exception(backoff.expo, TypeError, max_tries=5)
 async def test_dashboard(model, log_dir, tools):
-    """ Validate that the dashboard is operational """
+    """Validate that the dashboard is operational"""
     unit = model.applications["kubernetes-master"].units[0]
     with NamedTemporaryFile() as f:
         await scp_from(unit, "config", f.name, tools.controller_name, tools.connection)
@@ -416,7 +417,7 @@ async def test_dashboard(model, log_dir, tools):
 
 @pytest.mark.asyncio
 async def test_kubelet_anonymous_auth_disabled(model, tools):
-    """ Validate that kubelet has anonymous auth disabled """
+    """Validate that kubelet has anonymous auth disabled"""
 
     async def validate_unit(unit):
         await unit.run("open-port 10250")
@@ -463,7 +464,7 @@ async def test_kubelet_anonymous_auth_disabled(model, tools):
 @pytest.mark.asyncio
 @pytest.mark.skip_apps(["canal", "calico", "tigera-secure-ee"])
 async def test_network_policies(model, tools):
-    """ Apply network policy and use two busyboxes to validate it. """
+    """Apply network policy and use two busyboxes to validate it."""
     here = os.path.dirname(os.path.abspath(__file__))
     unit = model.applications["kubernetes-master"].units[0]
 
@@ -2399,7 +2400,7 @@ async def test_series_upgrade(model, tools):
 async def test_cinder(model, tools):
     # setup
     log("deploying openstack-integrator")
-    series = "bionic"
+    series = "focal"
     await model.deploy(
         "openstack-integrator",
         num_units=1,
@@ -2423,6 +2424,68 @@ async def test_cinder(model, tools):
     # create pod that writes to a pv from cinder
     await validate_storage_class(model, "cdk-cinder", "Cinder")
     # cleanup
+    await model.applications["openstack-integrator"].destroy()
+
+
+@pytest.mark.asyncio
+@pytest.mark.clouds(["openstack"])
+async def test_octavia(model, tools):
+    # setup
+    log("deploying openstack-integrator")
+    series = "focal"
+    await model.deploy(
+        "openstack-integrator",
+        num_units=1,
+        series=series,
+        trust=True,
+    )
+
+    log("adding relations")
+    await model.add_relation("openstack-integrator", "kubernetes-master")
+    await model.add_relation("openstack-integrator", "kubernetes-worker")
+    log("waiting...")
+    await tools.juju_wait()
+
+    log("waiting for cloud-controller-openstack to settle")
+    unit = model.applications["kubernetes-master"].units[0]
+    await retry_async_with_timeout(
+        verify_ready,
+        (unit, "po", ["cloud-controller-openstack-0"], "-n kube-system"),
+        timeout_msg="Cloud Controller OpenStack pod not ready!",
+    )
+    # deploy microbot via action
+    unit = model.applications["kubernetes-worker"].units[0]
+    action = await unit.run_action("microbot", delete=True)
+    await action.wait()
+    action = await unit.run_action("microbot", replicas=3)
+    await action.wait()
+    assert action.status == "completed"
+    # remove and replace the service with an LB type
+    await kubectl(model, "delete", "svc", "microbot")
+    await kubectl(
+        model,
+        "expose",
+        "deployment",
+        "microbot",
+        "--type=LoadBalancer",
+        "microbot",
+        "--port=80",
+        "--target-port=80",
+    )
+    await retry_async_with_timeout(
+        verify_ready,
+        (unit, "pod,svc", ["microbot"]),
+        timeout_msg="Unable to find microbot before timeout",
+    )
+    ingress_address = get_svc_ingress(model, "microbot")
+    resp = await tools.requests.get(
+        f"http://{ingress_address}",
+        proxies={"http": None, "https": None},
+    )
+    assert resp.status_code == 200
+    # cleanup
+    action = await unit.run_action("microbot", delete=True)
+    await action.wait()
     await model.applications["openstack-integrator"].destroy()
 
 


### PR DESCRIPTION
The filter for running tests on only specific clouds was driven by the `--cloud` param rather than the actual cloud the test is being run on, leading to tests being skipped if the cloud param wasn't given (defaulting to "aws").
    
This also adds a test for Octavia when running on OpenStack.