### PR TITLE
Remove 1.18 and 1.19 tracks from MicroK8s builds

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -18,8 +18,6 @@ def get_tracks(all=False):
     """
     return [
         "latest",
-        "1.18",
-        "1.19",
         "1.20",
         "1.21",
         "1.22",


### PR DESCRIPTION
---

Please make sure to open PR's against the correct code:

- For integration tests please make those changes in `jobs/integration`
- For MicroK8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`
