### PR TITLE
ensure infra job can do whatever it needs with dpkg

### DIFF
--- a/jobs/infra.yaml
+++ b/jobs/infra.yaml
@@ -22,7 +22,7 @@
     properties:
       - block-on-build-release
       - build-discarder:
-          num-to-keep: 1
+          num-to-keep: 3
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/infra"
@@ -31,8 +31,9 @@
           rm -rf /var/lib/jenkins/slaves/*/workspace/validate*
 
           # infra job needs exclusive dpkg access to keep pkgs updated; kill
-          # and clean up if any dpkg procs are running.
-          sudo pkill -9 -e -f ^/usr/bin/dpkg || true
+          # and clean up if any dpkg procs/locks are found.
+          sudo pkill -9 -e -f ^/usr/bin/dpkg && sleep 5 || true
+          sudo fuser -v -k /var/cache/debconf/config.dat && sleep 5 || true
           sudo dpkg --configure -a --force-confdef --force-confnew
 
           sudo apt update
@@ -67,7 +68,7 @@
     properties:
       - block-on-build-release
       - build-discarder:
-          num-to-keep: 1
+          num-to-keep: 3
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/infra"


### PR DESCRIPTION
give some time for child pids to die if we need to kill dpkg; also kill anything holding the debconf lock since we need that for `dpkg --configure`; and for crying out loud, keep 3 builds so we have some history on what was cleaned up recently.

Failure without this PR:
```
10:14:03 + sudo pkill -9 -e -f ^/usr/bin/dpkg
10:14:04 dpkg killed (pid 4170289)
10:14:09 + sudo dpkg --configure -a --force-confdef --force-confnew
10:14:09 Setting up docker.io (20.10.7-0ubuntu5~20.04.1) ...
10:14:09 debconf: DbDriver "config": /var/cache/debconf/config.dat is locked by another process: Resource temporarily unavailable
10:14:09 dpkg: error processing package docker.io (--configure):
10:14:09  installed docker.io package post-installation script subprocess returned error exit status 1
10:14:09 Processing triggers for initramfs-tools (0.136ubuntu6.6) ...
10:14:10 update-initramfs: Generating /boot/initrd.img-5.4.0-89-generic
10:14:45 Processing triggers for man-db (2.9.1-1) ...
10:15:00 Errors were encountered while processing:
10:15:00  docker.io
10:15:01 Build step 'Execute shell' marked build as failure
```

Success with this PR:
```
10:24:21 + sudo pkill -9 -e -f ^/usr/bin/dpkg
10:24:21 dpkg killed (pid 3461259)
10:24:21 + sleep 5
10:24:26 + sudo fuser -v -k /var/cache/debconf/config.dat
10:24:26 + true
10:24:26 + sudo dpkg --configure -a --force-confdef --force-confnew
10:24:26 Setting up docker.io (20.10.7-0ubuntu5~20.04.1) ...
...
10:24:48 + sudo apt update
...
```