### PR TITLE
Better image reporting

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -184,12 +184,6 @@ pipeline {
 
                     for i in \${ALL_IMAGES}
                     do
-                        # Skip images that we already host
-                        if echo \${i} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
-                        then
-                            continue
-                        fi
-
                         # Set appropriate production/staging image name
                         RAW_IMAGE=\${i}
                         for repl in ${env.REGISTRY_REPLACE}
@@ -202,7 +196,15 @@ pipeline {
                         done
                         PROD_IMAGE=\${PROD_PREFIX}/\${RAW_IMAGE}
                         STAGING_IMAGE=\${STAGING_PREFIX}/\${RAW_IMAGE}
-                        REPORT_IMAGES="\${REPORT_IMAGES} \${RAW_IMAGE}"
+
+                        # Skip images that we already host; ensure report has rocks as the image prefix
+                        if echo \${RAW_IMAGE} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
+                        then
+                            REPORT_IMAGES="\${REPORT_IMAGES} \${RAW_IMAGE}"
+                            continue
+                        else
+                            REPORT_IMAGES="\${REPORT_IMAGES} rocks.canonical.com/\${RAW_IMAGE}"
+                        fi
 
                         if ${params.dry_run}
                         then

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -198,13 +198,13 @@ pipeline {
                         STAGING_IMAGE=\${STAGING_PREFIX}/\${RAW_IMAGE}
 
                         # Report yet skip pull/tag/push images that we already host in rocks.
-                        # Ensure all other images are included in the report.
                         if echo \${RAW_IMAGE} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
                         then
                             REPORT_IMAGES="\${REPORT_IMAGES} \${RAW_IMAGE}"
                             continue
                         else
-                            REPORT_IMAGES="\${REPORT_IMAGES} \${PROD_IMAGE}"
+                            # Add rocks/cdk prefix (cant use PROD_IMAGE because that would be upload.rocks.c.c)
+                            REPORT_IMAGES="\${REPORT_IMAGES} rocks.canonical.com/cdk/\${RAW_IMAGE}"
                         fi
 
                         if ${params.dry_run}

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -197,13 +197,14 @@ pipeline {
                         PROD_IMAGE=\${PROD_PREFIX}/\${RAW_IMAGE}
                         STAGING_IMAGE=\${STAGING_PREFIX}/\${RAW_IMAGE}
 
-                        # Skip images that we already host; ensure report has rocks as the image prefix
+                        # Report yet skip pull/tag/push images that we already host in rocks.
+                        # Ensure all other images are included in the report.
                         if echo \${RAW_IMAGE} | grep -qi -e 'rocks.canonical.com' -e 'image-registry.canonical.com'
                         then
                             REPORT_IMAGES="\${REPORT_IMAGES} \${RAW_IMAGE}"
                             continue
                         else
-                            REPORT_IMAGES="\${REPORT_IMAGES} rocks.canonical.com/\${RAW_IMAGE}"
+                            REPORT_IMAGES="\${REPORT_IMAGES} \${PROD_IMAGE}"
                         fi
 
                         if ${params.dry_run}


### PR DESCRIPTION
We skip processing images that we already host in rocks.  Unfortunately, this meant they weren't showing up in our images.txt files.  For example, note addon-resizer isn't in this list:

https://github.com/charmed-kubernetes/bundle/blob/master/container-images/v1.19.9.txt

This PR generates reported images *before* processing.  It also adds the full image path, e.g.:
```
rocks.canonical.com/cdk/cdkbot/microbot-amd64:latest
```
vs
```
cdkbot/microbot-amd64:latest
```

I opted to include the full path because i think it will be easier for folks to copy/paste usable URLs rather than having to prepend rocks/cdk to everything.