### PR TITLE
MicroK8s charm Jenkins Jobs

### DIFF
--- a/jobs/build-microk8s-charm.yaml
+++ b/jobs/build-microk8s-charm.yaml
@@ -54,3 +54,84 @@
 
           git clone https://github.com/charmed-kubernetes/jenkins.git -b master jenkins
           bash -eux jenkins/jobs/microk8s/charms/build.sh
+
+- job:
+    name: 'release-microk8s-charm'
+    description: |
+      Run integration tests on the MicroK8s charm and release to stable.
+    project-type: freestyle
+    node: runner-amd64
+    wrappers:
+      - ansicolor
+      - timestamps
+      - workspace-cleanup
+      - credentials-binding:
+          - file:
+              credential-id: JUJUCONTROLLERS_SERVERSTACK
+              variable: JUJUCONTROLLERS
+          - file:
+              credential-id: JUJUACCOUNTS_SERVERSTACK
+              variable: JUJUACCOUNTS
+    parameters:
+      - string:
+          name: REPOSITORY
+          default: "https://github.com/canonical/charm-microk8s.git"
+          description: |
+            Source repository for MicroK8s charm tests.
+      - string:
+          name: BRANCH
+          default: "master"
+          description: |
+            Branch from which to run the MicroK8s charm tests.
+      - string:
+          name: CHARM_NAME
+          default: "microk8s"
+          description: |
+            MicroK8s charm to release.
+      - string:
+          name: FROM_CHANNEL
+          default: "latest/edge"
+          description: |
+            Integration tests will be run against this channel. Must be in `track/risk` or `track/risk/branch` format.
+      - string:
+          name: TO_CHANNEL
+          default: "latest/stable"
+          description: |
+            After tests pass, charm will be pushed to this channel. Must be in `track/risk` or `track/risk/branch` format.
+      - string:
+          name: CLUSTER_SIZE
+          default: "3"
+          description: |
+            Cluster size for integration tests.
+      - string:
+          name: SNAP_CHANNELS
+          default: "1.20 1.21 1.22"
+          description: |
+            MicroK8s snap channels to test (space or comma separated).
+      - bool:
+          name: SKIP_TESTS
+          default: "false"
+          description: |
+            Skip tests before running release (NOT RECOMMENDED).
+      - bool:
+          name: SKIP_RELEASE
+          default: "false"
+          description: |
+            Skip releasing to TO_CHANNEL after tests succeed.
+    properties:
+      - build-discarder:
+          num-to-keep: 3
+      - build-blocker:
+          use-build-blocker: true
+          blocking-jobs:
+            - "infra.*"
+          block-level: 'NODE'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eux
+          set -o allexport
+          [[ -f $WORKSPACE/.env ]] && source $WORKSPACE/.env
+          set +o allexport
+          git clone https://github.com/charmed-kubernetes/jenkins.git -b master jenkins
+          bash -eux jenkins/jobs/microk8s/charms/release.sh

--- a/jobs/build-microk8s-charm.yaml
+++ b/jobs/build-microk8s-charm.yaml
@@ -3,7 +3,7 @@
 - job:
     name: 'build-microk8s-charm'
     description: |
-      Build MicroK8s charm and upload revision to CharmHub.
+      Build MicroK8s charm, upload revision to CharmHub and release to edge.
     project-type: freestyle
     node: runner-amd64
     wrappers:
@@ -13,10 +13,10 @@
       - credentials-binding:
           - file:
               credential-id: JUJUCONTROLLERS_SERVERSTACK
-              variable: JUJUCONTROLLERS_SERVERSTACK
+              variable: JUJUCONTROLLERS
           - file:
               credential-id: JUJUACCOUNTS_SERVERSTACK
-              variable: JUJUACCOUNTS_SERVERSTACK
+              variable: JUJUACCOUNTS
     parameters:
       - string:
           name: REPOSITORY
@@ -28,6 +28,11 @@
           default: "master"
           description: |
             Branch from which to build the MicroK8s charm.
+      - bool:
+          name: RELEASE_TO_EDGE
+          default: "true"
+          description: |
+            Release charm to edge channel.
     properties:
       - build-discarder:
           num-to-keep: 3
@@ -36,11 +41,9 @@
           blocking-jobs:
             - "infra.*"
           block-level: 'NODE'
-
     publishers:
       - archive:
           artifacts: '*.charm'
-
     builders:
       - shell: |
           #!/bin/bash
@@ -49,46 +52,5 @@
           [[ -f $WORKSPACE/.env ]] && source $WORKSPACE/.env
           set +o allexport
 
-          function cleanup() {
-            set +e
-            run 'charmcraft logout'
-            juju destroy-model $JUJU_MODEL -y --timeout 1m --force
-            rm -rf $JUJU_DATA
-            set -e
-          }
-          trap cleanup EXIT
-
-          export JUJU_DATA=$PWD/data
-          export JUJU_MODEL=build-microk8s-charm-${BUILD_NUMBER}
-          mkdir -p $JUJU_DATA
-          cp $JUJUACCOUNTS_SERVERSTACK $JUJU_DATA/accounts.yaml
-          cp $JUJUCONTROLLERS_SERVERSTACK $JUJU_DATA/controllers.yaml
-
-          export PROXY=http://squid.internal:3128
-
-          juju add-model $JUJU_MODEL
-          juju model-config http-proxy=$PROXY https-proxy=$PROXY ftp-proxy=$PROXY no-proxy=10.0.0.0/8,192.168.0.0/16,127.0.0.1
-
-          juju deploy ubuntu --constraints 'cores=8 mem=4G root-disk=20G allocate-public-ip=true'
-          juju-wait -e $JUJU_MODEL -w
-
-          function run() {
-            juju ssh ubuntu/leader -- $@
-          }
-
-          run 'sudo snap install lxd'
-          run 'sudo lxd init --auto'
-          run 'sudo usermod -a -G lxd ubuntu'
-          run 'sudo snap install charmcraft --classic'
-          run 'mkdir -p snap/charmcraft/common/config'
-
-          # TODO: update when charmcraft supports non-interactive logins
-          # juju scp $CHARMCRAFT_CREDENTIALS ubuntu/leader:snap/charmcraft/common/config/charmcraft.credentials
-          run 'charmcraft login'
-
-          run 'charmcraft whoami'
-          run "git clone ${REPOSITORY} -b ${BRANCH} charm"
-          run 'cd charm && charmcraft build -v'
-          run 'cd charm && charmcraft upload *.charm'
-
-          juju scp 'ubuntu/leader:charm/*.charm' ./
+          git clone https://github.com/charmed-kubernetes/jenkins.git -b master jenkins
+          bash -eux jenkins/jobs/microk8s/charms/build.sh

--- a/jobs/microk8s/charms/build.sh
+++ b/jobs/microk8s/charms/build.sh
@@ -1,0 +1,86 @@
+#!/bin/bash -eux
+
+## Requirements
+## - Juju (>= 2.9)
+## - LXD (initialized)
+
+## Configuration
+## - REPOSITORY: Repository to pull the MicroK8s charm code from
+## - TAG: Tag to checkout
+## - RELEASE_TO_EDGE: Release uploaded revision to CharmHub edge
+## - JOB_NAME: from jenkins
+## - BUILD_NUMBER: from jenkins
+
+## Secrets
+## - JUJUCONTROLLERS: controllers.yaml configuration file for Juju
+## - JUJUACCOUNTS: accounts.yaml configuration file for Juju
+
+# Cleanup old containers
+container_prefix="${JOB_NAME}"
+old_containers=$(sudo lxc list -c n -f csv "${container_prefix}" | xargs)
+if [[ ! -z $old_containers ]]; then
+  echo Removing old containers, $old_containers
+  sudo lxc delete --force $old_containers
+fi
+
+# Configure cleanup routine
+container="${container_prefix}-${BUILD_NUMBER}"
+function cleanup() {
+  set +e
+  sudo lxc shell $container -- bash -c 'charmcraft logout'
+  sudo lxc delete $container --force
+  juju destroy-model $JUJU_MODEL -y --timeout 1m --force
+  rm -rf $JUJU_DATA
+  set -e
+}
+trap cleanup EXIT
+
+# Launch local LXD container to publish to charmcraft
+sudo lxc launch ubuntu:20.04 $container
+timeout 5m bash -c "
+  until sudo lxc shell $container -- bash -c 'snap install charmcraft --classic'; do
+    sleep 3
+  done
+"
+
+# TODO: update when charmcraft supports non-interactive logins
+# sudo lxc file push $CHARMCRAFT_CREDENTIALS $container/charmcraft.credentials
+# sudo lxc shell $container -- bash -c 'mkdir -p ~/snap/charmcraft/common/config/charmcraft.credentials'
+# sudo lxc shell $container -- bash -c 'cp charmcraft.credentials ~/snap/charmcraft/common/config/charmcraft.credentials'
+sudo lxc shell $container -- bash -c 'charmcraft login'
+sudo lxc shell $container -- bash -c 'charmcraft whoami'
+
+# Spawn a new ubuntu instance on the Juju controller to run the build
+export JUJU_DATA=$PWD/data
+export JUJU_MODEL=${JOB_NAME}-${BUILD_NUMBER}
+mkdir -p $JUJU_DATA
+cp $JUJUACCOUNTS $JUJU_DATA/accounts.yaml
+cp $JUJUCONTROLLERS $JUJU_DATA/controllers.yaml
+export PROXY=http://squid.internal:3128
+juju add-model $JUJU_MODEL
+juju model-config http-proxy=$PROXY https-proxy=$PROXY ftp-proxy=$PROXY no-proxy=10.0.0.0/8,192.168.0.0/16,127.0.0.1
+juju deploy ubuntu --constraints 'cores=8 mem=4G root-disk=20G allocate-public-ip=true'
+juju-wait -e $JUJU_MODEL -w
+
+# Install LXD and Charmcraft into builder machine
+juju ssh ubuntu/leader -- 'sudo snap install lxd'
+juju ssh ubuntu/leader -- 'sudo lxd init --auto'
+juju ssh ubuntu/leader -- 'sudo usermod -a -G lxd ubuntu'
+juju ssh ubuntu/leader -- 'sudo snap install charmcraft --classic'
+
+# Build charm and fetch
+juju ssh ubuntu/leader -- "git clone ${REPOSITORY} -b ${BRANCH} charm"
+juju ssh ubuntu/leader -- 'cd charm && charmcraft build -v'
+juju scp 'ubuntu/leader:charm/*.charm' ./microk8s.charm
+
+# Push charm to LXD container and upload to CharmHub
+sudo lxc file push ./microk8s.charm $container/microk8s.charm
+sudo lxc shell $container -- bash -c 'charmcraft upload /microk8s.charm'
+
+# Release to edge
+charm=$(unzip -p ./microk8s.charm metadata.yaml | grep "name:" | cut -f2 -d:)
+revision=$(sudo lxc shell $container -- bash -c "charmcraft revisions $charm 2>&1 | grep "^[0-9]" | head -1 | cut -f1 -d' '")
+if [[ $RELEASE_TO_EDGE == 'true' ]]; then
+  echo Release revision $revision of charm $charm to edge
+  sudo lxc shell $container -- bash -c "charmcraft release $charm --revision $revision --channel edge"
+fi

--- a/jobs/microk8s/charms/release.sh
+++ b/jobs/microk8s/charms/release.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -eux
+
+## Requirements
+## - Juju (>= 2.9)
+## - LXD (initialized)
+
+## Configuration
+## - REPOSITORY: Repository to pull the MicroK8s charm code from
+## - TAG: Tag to checkout
+## - CHARM_NAME: Charm name to test (microk8s)
+## - FROM_CHANNEL: Pull charm from this channel (latest/edge)
+## - TO_CHANNEL: After running tests, release revision to this channel (latest/stable)
+## - SKIP_TESTS: Do not run tests
+## - SKIP_RELEASE: Do not release
+## - JOB_NAME: from jenkins
+## - BUILD_NUMBER: from jenkins
+
+## Secrets
+## - JUJUCONTROLLERS: controllers.yaml configuration file for Juju
+## - JUJUACCOUNTS: accounts.yaml configuration file for Juju
+
+# Cleanup old containers
+container_prefix="${JOB_NAME}"
+old_containers=$(sudo lxc list -c n -f csv "${container_prefix}" | xargs)
+if [[ ! -z $old_containers ]]; then
+  echo Removing old containers, $old_containers
+  sudo lxc delete --force $old_containers
+fi
+
+# Configure cleanup routine
+container="${container_prefix}-${BUILD_NUMBER}"
+function cleanup() {
+  set +e
+  sudo lxc shell $container -- bash -c 'charmcraft logout'
+  sudo lxc delete $container --force
+  juju destroy-model $JUJU_MODEL -y --timeout 1m --force
+  rm -rf $JUJU_DATA
+  set -e
+}
+trap cleanup EXIT
+
+# Launch local LXD container to publish to charmcraft
+sudo lxc launch ubuntu:20.04 $container
+timeout 5m bash -c "
+  until sudo lxc shell $container -- bash -c 'snap install charmcraft --classic'; do
+    sleep 3
+  done
+"
+
+# TODO: update when charmcraft supports non-interactive logins
+# sudo lxc file push $CHARMCRAFT_CREDENTIALS $container/charmcraft.credentials
+# sudo lxc shell $container -- bash -c 'mkdir -p ~/snap/charmcraft/common/config/charmcraft.credentials'
+# sudo lxc shell $container -- bash -c 'cp charmcraft.credentials ~/snap/charmcraft/common/config/charmcraft.credentials'
+sudo lxc shell $container -- bash -c 'charmcraft login'
+sudo lxc shell $container -- bash -c 'charmcraft whoami'
+
+# Retrieve revision from CharmHub API. For reference:
+#
+# curl --silent https://api.charmhub.io/v1/charm/microk8s-testing/releases -b ./snap/charmcraft/common/config/charmcraft.credentials  | jq '.["channel-map"][] | {channel: .channel, revision: .revision}'
+# {
+#   "channel": "latest/edge",
+#   "revision": 9
+# }
+# {
+#   "channel": "latest/stable",
+#   "revision": 3
+# }
+revision=$(sudo lxc shell $container -- \
+  bash -c "curl https://api.charmhub.io/v1/charm/$CHARM_NAME/releases -b ~/snap/charmcraft/common/config/charmcraft.credentials" \
+    | jq -r ".[\"channel-map\"][] | select(.channel == \"$FROM_CHANNEL\") | .revision")
+
+# Run tests
+if [[ "$SKIP_TESTS" != 'true' ]]; then
+  export JUJU_DATA=$PWD/data
+  export JUJU_MODEL=${JOB_NAME}-${BUILD_NUMBER}
+  mkdir -p $JUJU_DATA
+  cp $JUJUACCOUNTS $JUJU_DATA/accounts.yaml
+  cp $JUJUCONTROLLERS $JUJU_DATA/controllers.yaml
+
+  export PROXY=http://squid.internal:3128
+  export NO_PROXY=10.0.0.0/8,192.168.0.0/16,127.0.0.1
+
+  juju add-model $JUJU_MODEL
+  juju model-config http-proxy=$PROXY https-proxy=$PROXY ftp-proxy=$PROXY no-proxy=$NO_PROXY
+
+  git clone $REPOSITORY -b $BRANCH microk8s-charm
+  cd microk8s-charm
+
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install tox
+
+  # workaround unneeded missing dependency charmcraft
+  ln -s /usr/bin/false charmcraft
+  export PATH=$PATH:$PWD
+
+  export MK8S_CHARM=$CHARM_NAME
+  export MK8S_CHARM_CHANNEL=$FROM_CHANNEL
+  export MK8S_CLUSTER_SIZE=$CLUSTER_SIZE
+  export MK8S_PROXY=$PROXY
+  export MK8S_NO_PROXY=$NO_PROXY
+  export MK8S_CONSTRAINTS='mem=2G cores=2 root-disk=20G'
+  export MK8S_SNAP_CHANNELS=$SNAP_CHANNELS
+
+  tox -e integration -- --model $JUJU_MODEL -n 3
+fi
+
+# Release
+if [[ "$SKIP_RELEASE" != 'true' ]]; then
+  sudo lxc shell $container -- bash -c "charmcraft release $CHARM_NAME --revision $revision --channel $TO_CHANNEL"
+fi


### PR DESCRIPTION
### Summary

Add Jenkins jobs for running integration tests for the MicroK8s charm and releasing to CharmHub.

Also builds on top of the job introduced in #739, so that all builds are automatically released to the edge channel. 

### Notes

This PR implies https://github.com/canonical/charm-microk8s/pull/12 