### PR TITLE
handle building in py3.8 and py3.9 environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ ogc-plugins-juju>=1.0.39
 ogc-plugins-runner>=1.0.24
 ogc>=1.0.1
 requests
-pynacl==1.1.2
+pynacl==1.2.0
 pymacaroons
 pyyaml>=5.1.2
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -312,7 +312,7 @@ pymacaroons==0.13.0
     #   surl
 pymdown-extensions==8.1.1
     # via mkdocs-material
-pynacl==1.1.2
+pynacl==1.2.0
     # via
     #   -r requirements.in
     #   macaroonbakery
@@ -483,7 +483,8 @@ wcwidth==0.2.5
     # via
     #   prettytable
     #   prompt-toolkit
-websockets==7.0
+websockets==7.0 ; python_version<"3.9"
+websockets==8.0 ; python_version>="3.9"
     # via juju
 wheel==0.36.2
     # via -r requirements.in


### PR DESCRIPTION
Apply requirements.txt constraints depending on whether your in a < py39 or >=py39 environment