### PR TITLE
Build and attach CNI resources for kubernetes-master charm

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -16,6 +16,10 @@
   flannel-amd64: '{out_path}/flannel-amd64.tar.gz'
   flannel-arm64: '{out_path}/flannel-arm64.tar.gz'
   flannel-s390x: '{out_path}/flannel-s390x.tar.gz'
+'cs:~containers/kubernetes-master':
+  cni-amd64: '{out_path}/cni-amd64.tgz'
+  cni-arm64: '{out_path}/cni-arm64.tgz'
+  cni-s390x: '{out_path}/cni-s390x.tgz'
 'cs:~containers/kubernetes-worker':
   cni-amd64: '{out_path}/cni-amd64.tgz'
   cni-arm64: '{out_path}/cni-arm64.tgz'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -55,6 +55,7 @@
 - kubernetes-master:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-master.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-master.git'
+    build-resources: "cd {out_path}; bash {src_path}/build-cni-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'kubernetes-master']
 - kubernetes-worker:


### PR DESCRIPTION
Kubernetes-master is gaining new CNI resources. CI needs to know to build and attach them.

This is needed for kubelets on masters.