### PR TITLE
Set root disk to 80GB for MicroK8s on ARM64

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -29,7 +29,7 @@ plan:
         if [ "$ARCH" == "amd64" ]; then
            juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "mem=16G root-disk=80G arch=$ARCH cores=8" ubuntu
         else
-           juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "instance-type=$INSTANCE_TYPE" ubuntu
+           juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "instance-type=$INSTANCE_TYPE root-disk=80G" ubuntu
         fi
 
         juju-wait -e "$JUJU_CONTROLLER":"$JUJU_MODEL" -w


### PR DESCRIPTION
Now that we run clustering tests the arm nodes we ask from aws have to have more storage so they accomodate multiple lxc containers at a time.