### PR TITLE
Update default tracks for MicroK8s charm tests

### DIFF
--- a/jobs/build-microk8s-charm.yaml
+++ b/jobs/build-microk8s-charm.yaml
@@ -105,7 +105,7 @@
             Cluster size for integration tests.
       - string:
           name: SNAP_CHANNELS
-          default: "1.20 1.21 1.22"
+          default: "1.21 1.22 1.23"
           description: |
             MicroK8s snap channels to test (space or comma separated).
       - bool:


### PR DESCRIPTION
## Summary

MicroK8s 1.23 is out, update the default snap tracks that we are testing with the MicroK8s charm