### PR TITLE
Tweaks for 1.23 stable release

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -7,7 +7,7 @@ JOBS_PATH = Path("jobs")
 
 # Current supported STABLE K8s MAJOR.MINOR release
 # This should be updated whenever a new CK major.minor is GA
-K8S_STABLE_VERSION = "1.22"
+K8S_STABLE_VERSION = "1.23"
 
 # Next MAJOR.MINOR
 # This controls whether or not we build pre-release snaps in our channels.

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -54,7 +54,7 @@ function test::capture
 # ENV
 ###############################################################################
 SONOBUOY_VERSION=0.20.0
-SNAP_VERSION=${1:-1.22/stable}
+SNAP_VERSION=${1:-1.23/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-stable}

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -26,8 +26,8 @@
           JOB_SPEC_DIR: "jobs/release"
       - run-env:
           COMMAND: |
-            parallel --timeout 200% --ungroup bash jobs/validate/spec {1} {2} {3} {4} ::: 1.22/stable ::: focal bionic ::: beta ::: arm64 amd64
-            parallel --timeout 200% --ungroup bash jobs/validate/upgrade-spec {1} {2} {3} {4} {5} ::: 1.21/stable 1.20/stable ::: focal bionic ::: beta ::: arm64 amd64 ::: 1.22/stable
+            parallel --timeout 200% --ungroup bash jobs/validate/spec {1} {2} {3} {4} ::: 1.23/stable ::: focal bionic ::: beta ::: arm64 amd64
+            parallel --timeout 200% --ungroup bash jobs/validate/upgrade-spec {1} {2} {3} {4} {5} ::: 1.22/stable 1.21/stable ::: focal bionic ::: beta ::: arm64 amd64 ::: 1.23/stable
 
 - job:
     name: 'validate-charm-bugfix'
@@ -54,9 +54,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.23/candidate
             - 1.22/candidate
             - 1.21/candidate
-            - 1.20/candidate
       - axis:
           type: user-defined
           name: series
@@ -94,8 +94,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.22/stable
             - 1.21/stable
-            - 1.20/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/release/bugfix-spec
+++ b/jobs/release/bugfix-spec
@@ -13,7 +13,7 @@ set -x
 
 # Setup Environment
 
-SNAP_VERSION=${1:-1.22/stable}
+SNAP_VERSION=${1:-1.23/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-candidate}

--- a/jobs/release/bugfix-upgrade-spec
+++ b/jobs/release/bugfix-upgrade-spec
@@ -37,10 +37,10 @@ function test::execute
 ###############################################################################
 # ENV
 ###############################################################################
-SNAP_VERSION_UPGRADE_TO=${5:-1.22/stable}
+SNAP_VERSION_UPGRADE_TO=${5:-1.23/stable}
 export SNAP_VERSION_UPGRADE_TO
 
-SNAP_VERSION=${1:-1.21/stable}
+SNAP_VERSION=${1:-1.22/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-stable}

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -192,9 +192,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.23/stable
             - 1.22/stable
             - 1.21/stable
-            - 1.20/stable
       - axis:
           type: user-defined
           name: series
@@ -348,7 +348,7 @@
            type: user-defined
            name: snap_version
            values:
-             - 1.22/stable
+             - 1.23/stable
       - axis:
            type: user-defined
            name: series
@@ -388,7 +388,7 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.22/stable
+            - 1.23/stable
       - axis:
           type: user-defined
           name: series


### PR DESCRIPTION
Set K8S_STABLE to 1.23, and update jobs to use 1.23/stable and 1.23/candidate where appropriate.