### PR TITLE
Stop building microk8s 1.20 and start building 1.24

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -18,10 +18,10 @@ def get_tracks(all=False):
     """
     return [
         "latest",
-        "1.20",
         "1.21",
         "1.22",
         "1.23",
+        "1.24",
     ]
 
 


### PR DESCRIPTION
K8s 1.20 is out of support plus dqlite is not supported in base core so we should not try to build this branch anymore.
