### PR TITLE
use juju candidate for CI

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -133,7 +133,7 @@
         - jenkins
         - adhoc
     - name: upgrade juju
-      command: "snap refresh juju --channel latest/stable"
+      command: "snap refresh juju --channel latest/candidate"
       ignore_errors: yes
       tags:
         - jenkins
@@ -151,7 +151,7 @@
         - "aws-cli --classic"
         - "charm --classic --edge"
         - "go --classic --stable"
-        - "juju --classic --stable"
+        - "juju --classic --candidate"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
         - "kubectl --classic"

--- a/jobs/validate-offline/playbook.yml
+++ b/jobs/validate-offline/playbook.yml
@@ -27,7 +27,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel latest/stable"
+        - "juju --classic --channel latest/candidate"
         - "juju-wait --classic"
         - "lxd"
       tags:

--- a/jobs/validate/playbooks/single-system.yml
+++ b/jobs/validate/playbooks/single-system.yml
@@ -34,7 +34,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --stable"
+        - "juju --classic --candidate"
         - "juju-wait --classic"
         - "juju-crashdump --classic --edge"
         - "lxd"


### PR DESCRIPTION
Juju --stable is problematic (atm, it bootstraps units that can't be killed).  Use --candidate instead; this has the added benefit of K8s catching issues with juju snaps before they go stable.