### PR TITLE
Build kubernetes-control-plane and publish to ch, removing k8s master

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -52,19 +52,12 @@
     downstream: 'charmed-kubernetes/charm-kubernetes-e2e.git'
     namespace: 'containers'
     tags: ['k8s', 'kubernetes-e2e']
-- kubernetes-master:
-    upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git"
-    downstream: 'charmed-kubernetes/charm-kubernetes-control-plane.git'
-    build-resources: "cd {out_path}; bash {src_path}/build-cni-resources.sh"
-    namespace: 'containers'
-    tags: ['k8s', 'kubernetes-master']
 - kubernetes-control-plane:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-control-plane.git'
     build-resources: "cd {out_path}; bash {src_path}/build-cni-resources.sh"
     namespace: 'containers'
-    tags: ['k8s', 'kubernetes-master', 'kubernetes-control-plane']
-    branch: 'inclusive-naming/rename-charm'
+    tags: ['k8s', 'kubernetes-control-plane']
     store: 'ch'
 - kubernetes-worker:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-worker.git"


### PR DESCRIPTION
Do not pull until charm-kubernetes-control-plane PR#197 is merged
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/197