### PR TITLE
Switch over all charms publishing to charmhub rather than charmstore

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -123,10 +123,12 @@
               --layer-index  "$LAYER_INDEX" \
               --layer-list "$LAYER_LIST" \
               --layer-branch "$LAYER_BRANCH" \
+              --store "$CHARM_STORE" \ 
               $IS_FORCE
 
             tox -e py38 -- python jobs/build-charms/charms.py build-bundles \
                 --to-channel "$TO_CHANNEL" \
                 --bundle-list "$BUNDLE_LIST" \
                 --bundle-branch "$BUNDLE_BRANCH" \
+                --store "$CHARM_STORE" \ 
                 --filter-by-tag "$FILTER_BY_TAG"

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -836,7 +836,7 @@ class BundleBuildEntity(BuildEntity):
 
     def bundle_build(self, to_channel):
         if not self.opts.get("skip-build"):
-            cmd = f"{self.src_path}/bundle -o {self.dst_path} -c {to_channel} {self.opts['fragments']}"
+            cmd = f"{self.src_path}/bundle -n {self.name} -o {self.dst_path} -c {to_channel} {self.opts['fragments']}"
             self.echo(f"Running {cmd}")
             cmd_ok(cmd, echo=self.echo)
         else:

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -97,9 +97,9 @@ class CharmcraftCmd(_WrappedCmd):
         except sh.ErrorReturnCode:
             self._echo(f"Failed to pack bundle in {kwargs.get('_cwd')}")
             raise
-        (entity,) = re.findall(r"^Created '(\S+)'", ret.stdout.decode(), re.MULTILINE)
+        (entity,) = re.findall(r"Created '(\S+)'", ret.stdout.decode(), re.MULTILINE)
         entity = Path(entity)
-        self._echo(f"Packing Bundle :: {entity.name:^35}")
+        self._echo(f"Packed Bundle :: {entity.name:^35}")
         return entity
 
 
@@ -850,19 +850,19 @@ class BundleBuildEntity(BuildEntity):
             # If we're building for charmhub, it needs to be packed
             dst_path = Path(self.dst_path)
             charmcraft_yaml = dst_path / "charmcraft.yaml"
-            contents = {
-                "type": "bundle",
-                "parts": {
-                    "bundle": {
-                        "prime": [
-                            str(_.relative_to(dst_path))
-                            for _ in dst_path.glob("**/*")
-                            if _.is_file()
-                        ]
-                    }
-                },
-            }
             if not charmcraft_yaml.exists():
+                contents = {
+                    "type": "bundle",
+                    "parts": {
+                        "bundle": {
+                            "prime": [
+                                str(_.relative_to(dst_path))
+                                for _ in dst_path.glob("**/*")
+                                if _.is_file()
+                            ]
+                        }
+                    },
+                }
                 with charmcraft_yaml.open("w") as fp:
                     yaml.safe_dump(contents, fp)
             self.dst_path = str(CharmcraftCmd(self).pack(_cwd=dst_path))

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -592,6 +592,7 @@ class BuildEntity:
             except (KeyError, TypeError):
                 self.echo(f"Failed to find in charmhub.io \n{refreshed}")
                 return None
+            self.echo(f"Downloading {fname} from {url}")
             resp = requests.get(url, stream=True)
             if resp.ok:
                 yaml_file = zipfile.Path(BytesIO(resp.content)) / fname
@@ -909,7 +910,7 @@ def cli():
     "--store",
     type=click.Choice(["cs", "ch"], case_sensitive=False),
     help="Publish to Charmstore (cs) or Charmhub (ch) if the resource-spec doesn't specify.",
-    default="cs",
+    default="ch",
 )
 @click.option("--force", is_flag=True)
 def build(
@@ -1005,7 +1006,7 @@ def build(
     "--store",
     type=click.Choice(["cs", "ch"], case_sensitive=False),
     help="Charmstore (cs) or Charmhub (ch)",
-    default="cs",
+    default="ch",
 )
 def build_bundles(
     bundle_list, bundle_branch, filter_by_tag, bundle_repo, track, to_channel, store

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -209,6 +209,12 @@
       - string:
           name: CHARM_INTERFACES_DIR
           default: 'build/interfaces'
+      - string:
+          name: CHARM_STORE
+          default: 'ch'
+          description: |
+            Destination store for publishing charms.  Currently supports
+            charmstore and charmhub.
       - bool:
           name: FORCE
           default: false

--- a/jobs/includes/charm-bundles-list.inc
+++ b/jobs/includes/charm-bundles-list.inc
@@ -3,13 +3,18 @@
     fragments: 'k8s/cdk cni/flannel cri/containerd'
     namespace: containers/bundle
     tags: ['k8s', 'charmed-kubernetes']
+    store: 'ch'
 - kubernetes-core:
     fragments: 'k8s/core cni/flannel cri/containerd'
     namespace: containers/bundle
     tags: ['k8s', 'kubernetes-core']
-- kubeflow:
-    namespace: kubeflow-charmers
-    tags: ['general', 'kubeflow']
+    store: 'ch'
+
+##########################################################################
+# Removed since it's built by github CI actions
+# - kubeflow:
+#     namespace: kubeflow-charmers
+#     tags: ['general', 'kubeflow']
 
 ##########################################################################
 # EOL CNI flavored bundles in favor for deploying with overlays

--- a/jobs/includes/charm-bundles-list.inc
+++ b/jobs/includes/charm-bundles-list.inc
@@ -1,8 +1,4 @@
 # -*- mode:yaml; -*-
-- canonical-kubernetes:
-    fragments: 'k8s/cdk cni/flannel cri/containerd'
-    namespace: containers/bundle
-    tags: ['k8s', 'canonical-kubernetes']
 - charmed-kubernetes:
     fragments: 'k8s/cdk cni/flannel cri/containerd'
     namespace: containers/bundle
@@ -11,31 +7,44 @@
     fragments: 'k8s/core cni/flannel cri/containerd'
     namespace: containers/bundle
     tags: ['k8s', 'kubernetes-core']
-- kubernetes-calico:
-    fragments: 'k8s/cdk cni/calico cri/containerd'
-    namespace: containers/bundle
-    tags: ['k8s', 'kubernetes-calico']
-- canonical-kubernetes-canal:
-    fragments: 'k8s/cdk cni/canal cri/containerd'
-    namespace: containers/bundle
-    tags: ['k8s', 'canonical-kubernetes-canal']
-- kubernetes-tigera-secure-ee:
-    fragments: 'k8s/cdk cni/tigera-secure-ee cri/containerd'
-    namespace: containers/bundle
-    tags: ['k8s', 'kubernetes-tigera-secure-ee']
 - kubeflow:
     namespace: kubeflow-charmers
     tags: ['general', 'kubeflow']
-- metallb:
-    namespace: containers
-    downstream: charmed-kubernetes/metallb-operator.git
-    skip-build: true
-    subdir: "bundle"
-    tags: ['k8s', 'addons', 'metallb']
-- kubernetes-dashboard-bundle:
-    namespace: containers
-    downstream: charmed-kubernetes/kubernetes-dashboard-operator.git
-    skip-build: true
-    subdir: "bundles"
-    tags: ['k8s', 'addons', 'kubernetes-dashboard-bundle']
-    branch: "main"
+
+##########################################################################
+# EOL CNI flavored bundles in favor for deploying with overlays
+# - canonical-kubernetes:
+#     fragments: 'k8s/cdk cni/flannel cri/containerd'
+#     namespace: containers/bundle
+#     tags: ['k8s', 'canonical-kubernetes']
+# - kubernetes-calico:
+#     fragments: 'k8s/cdk cni/calico cri/containerd'
+#     namespace: containers/bundle
+#     tags: ['k8s', 'kubernetes-calico']
+# - canonical-kubernetes-canal:
+#     fragments: 'k8s/cdk cni/canal cri/containerd'
+#     namespace: containers/bundle
+#     tags: ['k8s', 'canonical-kubernetes-canal']
+# - kubernetes-tigera-secure-ee:
+#     fragments: 'k8s/cdk cni/tigera-secure-ee cri/containerd'
+#     namespace: containers/bundle
+#     tags: ['k8s', 'kubernetes-tigera-secure-ee']
+
+##########################################################################
+# EOL in favor of metallb-speaker and metallb-controller operators
+# - metallb:
+#     namespace: containers
+#     downstream: charmed-kubernetes/metallb-operator.git
+#     skip-build: true
+#     subdir: "bundle"
+#    tags: ['k8s', 'addons', 'metallb']
+
+##########################################################################
+# EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard
+# - kubernetes-dashboard-bundle:
+#     namespace: containers
+#     downstream: charmed-kubernetes/kubernetes-dashboard-operator.git
+#     skip-build: true
+#     subdir: "bundles"
+#     tags: ['k8s', 'addons', 'kubernetes-dashboard-bundle']
+#     branch: "main"

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -36,7 +36,7 @@
     downstream: 'charmed-kubernetes/layer-etcd.git'
     namespace: 'containers'
     tags: ['k8s', 'etcd']
-    store: 'ch'
+    store: 'cs'
 - flannel:
     upstream: "https://github.com/charmed-kubernetes/charm-flannel.git"
     downstream: 'charmed-kubernetes/charm-flannel.git'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -5,53 +5,63 @@
     build-resources: "cd {out_path}; bash {src_path}/build-calico-resource.sh"
     namespace: 'containers'
     tags: ['k8s', 'calico']
+    store: 'ch'
 - canal:
     upstream: "https://github.com/charmed-kubernetes/layer-canal.git"
     downstream: 'charmed-kubernetes/layer-canal.git'
     build-resources: "cd {out_path}; bash {src_path}/build-canal-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'canal']
+    store: 'ch'
 - containerd:
     upstream: "https://github.com/charmed-kubernetes/charm-containerd.git"
     downstream: 'charmed-kubernetes/charm-containerd.git'
     namespace: 'containers'
     tags: ['k8s', 'containerd']
+    store: 'ch'
 - docker:
     upstream: "https://github.com/charmed-kubernetes/charm-docker.git"
     downstream: 'charmed-kubernetes/charm-docker.git'
     namespace: 'containers'
     tags: ['k8s', 'docker']
+    store: 'ch'
 - easyrsa:
     upstream: "https://github.com/charmed-kubernetes/layer-easyrsa.git"
     downstream: 'charmed-kubernetes/layer-easyrsa.git'
     namespace: 'containers'
     tags: ['k8s', 'easyrsa']
+    store: 'ch'
 - etcd:
     upstream: "https://github.com/charmed-kubernetes/layer-etcd.git"
     downstream: 'charmed-kubernetes/layer-etcd.git'
     namespace: 'containers'
     tags: ['k8s', 'etcd']
+    store: 'ch'
 - flannel:
     upstream: "https://github.com/charmed-kubernetes/charm-flannel.git"
     downstream: 'charmed-kubernetes/charm-flannel.git'
     build-resources: "cd {out_path}; bash {src_path}/build-flannel-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'flannel']
+    store: 'ch'
 - kata:
     upstream: "https://github.com/charmed-kubernetes/charm-kata.git"
     downstream: 'charmed-kubernetes/charm-kata.git'
     namespace: 'containers'
     tags: ['k8s', 'containerd']
+    store: 'ch'
 - kubeapi-load-balancer:
     upstream: "https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer.git"
     downstream: 'charmed-kubernetes/charm-kubeapi-load-balancer.git'
     namespace: 'containers'
     tags: ['k8s', 'kubeapi-load-balancer']
+    store: 'ch'
 - kubernetes-e2e:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-e2e.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-e2e.git'
     namespace: 'containers'
     tags: ['k8s', 'kubernetes-e2e']
+    store: 'ch'
 - kubernetes-control-plane:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-control-plane.git'
@@ -65,101 +75,119 @@
     build-resources: "cd {out_path}; bash {src_path}/build-cni-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'kubernetes-worker']
+    store: 'ch'
 - tigera-secure-ee:
     upstream: "https://github.com/charmed-kubernetes/layer-tigera-secure-ee.git"
     downstream: 'charmed-kubernetes/layer-tigera-secure-ee.git'
     build-resources: "cd {out_path}; bash {src_path}/build-resources.sh"
     namespace: 'containers'
     tags: ['k8s', 'tigera-secure-ee']
+    store: 'ch'
 - keepalived:
     upstream: "https://github.com/charmed-kubernetes/charm-keepalived.git"
     downstream: 'charmed-kubernetes/charm-keepalived.git'
     namespace: 'containers'
     tags: ['general', 'keepalived', 'k8s']
     subdir: "src"
+    store: 'ch'
 - docker-registry:
     upstream: "https://github.com/CanonicalLtd/docker-registry-charm.git"
     downstream: 'charmed-kubernetes/docker-registry-charm.git'
     namespace: 'containers'
     tags: ['general', 'docker-registry', 'k8s']
+    store: 'ch'
 - aws-iam:
     upstream: "https://github.com/charmed-kubernetes/charm-aws-iam.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-aws-iam'
     tags: ['k8s', 'aws-iam']
+    store: 'ch'
 - azure-integrator:
     upstream: "https://github.com/juju-solutions/charm-azure-integrator.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-azure-integrator'
     tags: ['k8s', 'charm-azure-integrator']
+    store: 'ch'
 - gcp-integrator:
     upstream: "https://github.com/juju-solutions/charm-gcp-integrator.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-gcp-integrator'
     tags: ['k8s', 'charm-gcp-integrator']
+    store: 'ch'
 - aws-integrator:
     upstream: "https://github.com/juju-solutions/charm-aws-integrator.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-aws-integrator'
     tags: ['k8s', 'charm-aws-integrator']
+    store: 'ch'
 - openstack-integrator:
     upstream: "https://github.com/juju-solutions/charm-openstack-integrator.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-openstack-integrator'
     tags: ['k8s', 'charm-openstack-integrator']
+    store: 'ch'
 - vsphere-integrator:
     upstream: "https://github.com/juju-solutions/charm-vsphere-integrator.git"
     namespace: 'containers'
     downstream: 'charmed-kubernetes/charm-vsphere-integrator'
     tags: ['k8s', 'charm-vsphere-integrator']
+    store: 'ch'
 - metallb-controller:
     upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
     subdir: "charms/metallb-controller"
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
     tags: ["k8s", "metallb", "metallb-controller"]
+    store: 'ch'
 - metallb-speaker:
     upstream: "https://github.com/charmed-kubernetes/metallb-operator.git"
     subdir: "charms/metallb-speaker"
     namespace: "containers"
     downstream: "charmed-kubernetes/metallb-operator"
     tags: ["k8s", "metallb", "metallb-speaker"]
+    store: 'ch'
 - multus:
     upstream: "https://github.com/charmed-kubernetes/charm-multus.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-multus"
     tags: ["k8s", "multus"]
     build-resources: "cd {src_path}/net-attach-def-manager; ./build"
+    store: 'ch'
 - sriov-cni:
     upstream: "https://github.com/charmed-kubernetes/charm-sriov-cni.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-sriov-cni"
     tags: ["k8s", "sriov", "sriov-cni"]
     build-resources: "cd {src_path}/image; ./build"
+    store: 'ch'
 - sriov-network-device-plugin:
     upstream: "https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-sriov-network-device-plugin"
     tags: ["k8s", "sriov", "sriov-network-device-plugin"]
+    store: 'ch'
 - coredns:
     upstream: "https://github.com/charmed-kubernetes/charm-coredns.git"
     namespace: "containers"
     downstream: "charmed-kubernetes/charm-coredns"
     tags: ["k8s", "coredns"]
-- k8s-dashboard:
-    upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
-    subdir: "charms/kubernetes-dashboard"
-    namespace: "containers"
-    downstream: "charmed-kubernetes/kubernetes-dashboard-operator"
-    tags: ["k8s", "k8s-dashboard"]
-    branch: "main"
-- dashboard-metrics-scraper:
-    upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
-    subdir: "charms/dashboard-metrics-scraper"
-    namespace: "containers"
-    downstream: "charmed-kubernetes/kubernetes-dashboard-operator"
-    tags: ["k8s", "dashboard-metrics-scraper"]
-    branch: "main"
+    store: 'ch'
+
+# EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard
+# - k8s-dashboard:
+#     upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
+#     subdir: "charms/kubernetes-dashboard"
+#     namespace: "containers"
+#     downstream: "charmed-kubernetes/kubernetes-dashboard-operator"
+#     tags: ["k8s", "k8s-dashboard"]
+#     branch: "main"
+# - dashboard-metrics-scraper:
+#     upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
+#     subdir: "charms/dashboard-metrics-scraper"
+#     namespace: "containers"
+#     downstream: "charmed-kubernetes/kubernetes-dashboard-operator"
+#     tags: ["k8s", "dashboard-metrics-scraper"]
+#     branch: "main"
 
 # - nfs:
 #     upstream: "https://github.com/hyperbolic2346/nfs-charm.git"

--- a/tests/unit/build-charms/test_charms.py
+++ b/tests/unit/build-charms/test_charms.py
@@ -465,7 +465,7 @@ def test_bundle_build_entity_bundle_build(cmd_ok, charmcraft_cmd, bundle_environ
     )
     bundle_entity.bundle_build("edge")
     assert (bundle_environment.bundles_dir / "bundle.yaml").exists()
-    assert (bundle_environment.bundles_dir / "tests/test.yaml").exists()
+    assert (bundle_environment.bundles_dir / "tests" / "test.yaml").exists()
     cmd_ok.assert_not_called()
     shutil.rmtree(bundle_environment.bundles_dir)
 
@@ -476,7 +476,7 @@ def test_bundle_build_entity_bundle_build(cmd_ok, charmcraft_cmd, bundle_environ
     )
     bundle_entity.bundle_build("edge")
     assert not (bundle_environment.bundles_dir / "bundle.yaml").exists()
-    cmd = f"{K8S_CI_BUNDLE / 'bundle'} -o {bundle_environment.bundles_dir} -c edge k8s/core cni/flannel cri/containerd"
+    cmd = f"{K8S_CI_BUNDLE / 'bundle'} -n test-kubernetes -o {bundle_environment.bundles_dir} -c edge k8s/core cni/flannel cri/containerd"
     cmd_ok.assert_called_with(cmd, echo=bundle_entity.echo)
     cmd_ok.reset_mock()
 


### PR DESCRIPTION
waiting on 
* decision from @ca-scribner or @knkski to decided on kubeflow bundle
  * kubeflow pieces are no longer in use.  they may be removed
* `etcd` charm to be opened for publishing on https://charmhub.io/etcd
  * this won't be available until charmstore is excluded from pushes
  * continue to push `etcd` to the charmstore
* Merge with https://github.com/charmed-kubernetes/bundle/pull/817