### PR TITLE
Optimize multiple charms being built by the same charmcraft container

### DIFF
--- a/cilib.sh
+++ b/cilib.sh
@@ -1,5 +1,10 @@
-#!/bin/bash
-set -eux
+#!/bin/bash -eux
+
+if [[ $0 == $BASH_SOURCE ]]; then
+  echo "$0 should be sourced";
+  exit
+fi
+echo "sourced ${BASH_SOURCE:-$0}"
 
 setup_env()
 {
@@ -111,4 +116,15 @@ ci_lxc_launch()
     sudo lxc launch ${lxc_image} ${lxc_container}
     sleep 10
     sudo lxc shell ${lxc_container} -- bash -c "apt-get update && apt-get install build-essential -y"
+}
+
+ci_lxc_delete()
+{
+    # Stop and delete containers matching a prefix
+    local lxc_container_prefix=$1
+    local existing_containers=$(sudo lxc list -c n -f csv "${lxc_container_prefix}" | xargs)
+    echo "Removing containers: ${existing_containers}"
+    set +e
+    sudo lxc delete --force "${existing_containers}"
+    set -e
 }

--- a/cilib.sh
+++ b/cilib.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash
+set -eux
 
 if [[ $0 == $BASH_SOURCE ]]; then
   echo "$0 should be sourced";

--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -105,6 +105,8 @@
             #!/bin/bash
             set -eux
 
+            . $WORKSPACE/cilib.sh
+            
             sudo chown -R jenkins:jenkins /var/lib/jenkins/.config/ || true
 
             IS_FORCE=""
@@ -113,6 +115,14 @@
             fi
 
             rm -rf "$WORKSPACE/charms" || true
+
+            # Cleanup old charmcraft containers
+            ci_lxc_delete "${JOB_NAME}"
+            
+            # Configure cleanup routine for exit
+            charmcraft_lxc="${JOB_NAME}-${BUILD_NUMBER}"
+            trap 'ci_lxc_delete $charmcraft_lxc' EXIT
+            ci_charmcraft_launch $charmcraft_lxc
 
             tox -e py38 -- python jobs/build-charms/charms.py build \
               --charm-list "$CHARM_LIST" \

--- a/jobs/build-charms/charmcraft-lib.sh
+++ b/jobs/build-charms/charmcraft-lib.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eux
+
+if [[ $0 == $BASH_SOURCE ]]; then
+  echo "$0 should be sourced";
+  exit
+fi
+echo "sourced ${BASH_SOURCE:-$0}"
+source $(dirname ${BASH_SOURCE:-$0})/../../cilib.sh
+
+ci_charmcraft_launch()
+{
+  # Launch local LXD container to publish to charmcraft
+  local charmcraft_lxc=$1
+  ci_lxc_launch ubuntu:20.04 $charmcraft_lxc
+  until sudo lxc shell $charmcraft_lxc -- bash -c 'snap install charmcraft --classic'; do
+    echo 'retrying charmcraft install in 3s...'
+    sleep 3
+  done
+}
+
+ci_charmcraft_pack()
+{
+  # Build charm
+  local charmcraft_lxc=$1
+  local repository=$2
+  local branch=$3
+  local subdir=${4:-.}
+  sudo lxc shell $charmcraft_lxc -- bash -c "rm -rf /root/*"
+  sudo lxc shell $charmcraft_lxc -- bash -c "git clone ${repository} -b ${branch} charm"
+  sudo lxc shell $charmcraft_lxc -- bash -c "cd charm/$subdir; cat version || git describe --dirty --always | tee version"
+  sudo lxc shell $charmcraft_lxc --env CHARMCRAFT_MANAGED_MODE=1 -- bash -c "cd charm; charmcraft pack -v -p $subdir"
+}
+
+ci_charmcraft_release()
+{
+  # Upload to CharmHub, and optionally release
+  local charmcraft=$1
+  local do_release_to_edge=${2:-}
+  local upload_args=$([[ $do_release_to_edge == 'true' ]] && echo ' --release edge')
+  sudo lxc shell $charmcraft --env CHARMCRAFT_AUTH="$CHARMCRAFT_AUTH" -- bash -c "cd charm; charmcraft upload *.charm $upload_args"
+}
+
+ci_charmcraft_copy()
+{
+  # Copy charm out of the container to a local directory
+  local charmcraft=$1
+  local copy_destination=$2
+  for charm in $(sudo lxc exec $charmcraft -- bash -c "ls /root/charm/*.charm"); do
+    echo "Pulling ${container}${charm} to ${copy_destination}"
+    sudo lxc file pull ${container}${charm} ${copy_destination}
+  done
+}

--- a/jobs/build-charms/charmcraft-lib.sh
+++ b/jobs/build-charms/charmcraft-lib.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash
+set -eux
 
 if [[ $0 == $BASH_SOURCE ]]; then
   echo "$0 should be sourced";

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -706,10 +706,11 @@ class BuildEntity:
             ret = CharmCmd(self).build(*args.split(), _cwd=self.src_path)
         elif lxc:
             self.echo(f"Building in container {lxc}")
+            repository = f"https://github.com/{self.downstream}"
             charmcraft_script = (
                 "#!/bin/bash -eux\n"
                 f"source {Path(__file__).parent / 'charmcraft-lib.sh'}\n"
-                f"ci_charmcraft_pack {lxc} https://github.com/{self.downstream} {self.branch} {self.opts.get('subdir','')}\n"
+                f"ci_charmcraft_pack {lxc} {repository} {self.branch} {self.opts.get('subdir','')}\n"
                 f"ci_charmcraft_copy {lxc} {self.dst_path}\n"
             )
             ret = script(charmcraft_script, echo=self.echo)

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -17,7 +17,6 @@ Usage:
   tox -e py36 -- python3 jobs/build-charms/charms.py --help
 """
 
-import contextlib
 import os
 from io import BytesIO
 import zipfile
@@ -29,6 +28,7 @@ from cilib.run import cmd_ok, capture, script
 from datetime import datetime
 from enum import Enum
 from retry.api import retry_call
+from types import SimpleNamespace
 
 from pathos.threading import ThreadPool
 from pprint import pformat
@@ -57,22 +57,6 @@ class LayerType(Enum):
 
     LAYER = 1
     INTERFACE = 2
-
-
-@contextlib.contextmanager
-def set_env(**envs):
-    """
-    Temporarily set the process environment variables.
-
-    :param unicode envs: Environment variables to set
-    """
-    old_environ = dict(os.environ)
-    os.environ.update(envs)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(old_environ)
 
 
 def _next_match(seq, predicate=lambda _: _, default=None):
@@ -702,6 +686,8 @@ class BuildEntity:
 
     def charm_build(self):
         """Perform a build against charm/bundle."""
+        lxc = os.environ.get("charmcraft_lxc")
+        ret = SimpleNamespace(ok=False)
         if "override-build" in self.opts:
             self.echo("Override build found, running in place of charm build.")
             ret = script(
@@ -718,17 +704,18 @@ class BuildEntity:
                 self.dst_path = str(self.build.build_dir / self.name)
             self.echo(f"Building with: charm build {args}")
             ret = CharmCmd(self).build(*args.split(), _cwd=self.src_path)
+        elif lxc:
+            self.echo(f"Building in container {lxc}")
+            charmcraft_script = (
+                "#!/bin/bash -eux\n"
+                f"source {Path(__file__).parent / 'charmcraft-lib.sh'}\n"
+                f"ci_charmcraft_pack {lxc} https://github.com/{self.downstream} {self.branch} {self.opts.get('subdir','')}\n"
+                f"ci_charmcraft_copy {lxc} {self.dst_path}\n"
+            )
+            ret = script(charmcraft_script, echo=self.echo)
         else:
-            charmcraft_script = Path("jobs") / "build-charms" / "charmcraft-build.sh"
-            self.echo(f"Building with: {charmcraft_script}")
-            repository = f"https://github.com/{self.downstream}"
-            with set_env(
-                REPOSITORY=repository,
-                BRANCH=self.branch,
-                SUBDIR=self.opts.get("subdir") or "",
-                COPY_CHARM=self.dst_path,
-            ):
-                ret = script(str(charmcraft_script), echo=self.echo)
+            self.echo("No 'charmcraft_lxc' container available")
+
         if not ret.ok:
             self.echo("Failed to build, aborting")
             raise SystemExit(f"Failed to build {self.name}")
@@ -982,6 +969,7 @@ def build(
                 entity.echo("Build forced.")
 
             entity.charm_build()
+
             entity.push()
             entity.attach_resources()
             entity.promote(to_channel=to_channel)


### PR DESCRIPTION
Rather than every charm being built in its own separate container, reuse the same container for every charmbuild, careful to clean up the working space before each build. 

Refactor so the origin build script `charmcraft-build.sh` can continue to be used by `build-microk8s-charm` job