### PR TITLE
remove the charm login task

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -6,7 +6,6 @@
   vars:
     s390x: "{{ lookup('env', 'S3LP3') }}"
     arm64: "{{ lookup('env', 'NEADER') }}"
-    ch_creds: "{{ lookup('env', 'CHARMCRAFT_AUTH') }}"
     columbo_version: 0.0.4
   tasks:
     - name: add golang ppa
@@ -444,7 +443,7 @@
       tags:
         - jenkins
     - name: login to charmhub
-      shell: "CHARMCRAFT_AUTH={{ ch_creds }} charmcraft login"
+      shell: "CHARMCRAFT_AUTH={{ lookup('env', 'CHARMCRAFT_AUTH') }} charmcraft login"
       tags:
         - jenkins
     - name: login to snapstore

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -6,7 +6,7 @@
   vars:
     s390x: "{{ lookup('env', 'S3LP3') }}"
     arm64: "{{ lookup('env', 'NEADER') }}"
-    ch_creds: "{{ lookup('env', 'charmcraft_creds') }}"
+    ch_creds: "{{ lookup('env', 'CHARMCRAFT_AUTH') }}"
     columbo_version: 0.0.4
   tasks:
     - name: add golang ppa
@@ -444,8 +444,7 @@
       tags:
         - jenkins
     - name: login to charmhub
-      command: "CHARMCRAFT_AUTH={{ ch_creds }} charmcraft login"
-      become: false
+      shell: "CHARMCRAFT_AUTH={{ ch_creds }} charmcraft login"
       tags:
         - jenkins
     - name: login to snapstore

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -442,10 +442,6 @@
         mode: 0644
       tags:
         - jenkins
-    - name: login to charmhub
-      shell: "CHARMCRAFT_AUTH={{ lookup('env', 'CHARMCRAFT_AUTH') }} charmcraft login"
-      tags:
-        - jenkins
     - name: login to snapstore
       command: "snapcraft login --with /var/lib/jenkins/snapcraft-creds"
       become: false

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -6,6 +6,7 @@
   vars:
     s390x: "{{ lookup('env', 'S3LP3') }}"
     arm64: "{{ lookup('env', 'NEADER') }}"
+    ch_creds: "{{ lookup('env', 'charmcraft_creds') }}"
     columbo_version: 0.0.4
   tasks:
     - name: add golang ppa
@@ -442,10 +443,9 @@
         mode: 0644
       tags:
         - jenkins
-    - name: login to charmstore
-      command: "charm login -B"
+    - name: login to charmhub
+      command: "CHARMCRAFT_AUTH={{ ch_creds }} charmcraft login"
       become: false
-      register: charmstore_login
       tags:
         - jenkins
     - name: login to snapstore


### PR DESCRIPTION
The store has transitioned over to charmhub.  There is no need to have a login task for infra jobs because we use the hub creds envvar any time we need to interact with charmhub.