### PR TITLE
Fail charm builds only after attempting to build each one

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -711,7 +711,7 @@ class BuildEntity:
             charmcraft_script = (
                 "#!/bin/bash -eux\n"
                 f"source {Path(__file__).parent / 'charmcraft-lib.sh'}\n"
-                f"ci_charmcraft_pack {lxc} {repository} {self.branch} {self.opts.get('subdir','')}\n"
+                f"ci_charmcraft_pack {lxc} {repository} {self.branch} {self.opts.get('subdir', '')}\n"
                 f"ci_charmcraft_copy {lxc} {self.dst_path}\n"
             )
             ret = script(charmcraft_script, echo=self.echo)
@@ -984,7 +984,12 @@ def build(
             entity.echo("Stopping")
 
     if any(failed_entities):
-        raise BuildException("Encountered Charm Build Failure")
+        count = len(failed_entities)
+        plural = "s" if count > 1 else ""
+        raise SystemExit(
+            f"Encountered {count} Charm Build Failure{plural}:\n\t"
+            + ", ".join(ch.name for ch in failed_entities)
+        )
 
     build_env.save()
 

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import os
+import traceback
 from io import BytesIO
 import zipfile
 from pathlib import Path
@@ -976,15 +977,14 @@ def build(
             entity.push()
             entity.attach_resources()
             entity.promote(to_channel=to_channel)
-        except Exception as build_exc:
-            failed_entities.append((entity, build_exc))
+        except Exception:
+            entity.echo(traceback.format_exc())
+            failed_entities.append(entity)
         finally:
             entity.echo("Stopping")
 
-    for idx, (entity, build_exc) in enumerate(failed_entities):
-        entity.echo("Encountered failure")
-        if len(failed_entities) - idx == 1:
-            raise build_exc
+    if any(failed_entities):
+        raise BuildException("Encountered Charm Build Failure")
 
     build_env.save()
 

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -303,7 +303,7 @@ def test_build_entity_charm_build(
 
     # Operator Charms, fail build without charmcraft container
     del os.environ["charmcraft_lxc"]
-    with pytest.raises(SystemExit):
+    with pytest.raises(charms.BuildException):
         charm_entity.charm_build()
 
 


### PR DESCRIPTION
Rather than raise a `SystemExit` which bypasses any exception handling, use `BuildException` which can be caught.  After all the charms are built -- raise the last exception to cease the build process.