### PR TITLE
ignore errors in default_gh_branch (not all layers comes from gh)

### DIFF
--- a/cilib/models/repos/charms.py
+++ b/cilib/models/repos/charms.py
@@ -28,7 +28,15 @@ class CharmRepoModel(DebugMixin):
         return BaseRepoModel(repo=self.repo, git_user=self.git_user, name=self.name)
 
     def default_gh_branch(self, remote):
-        return default_gh_branch(remote, auth=(self.git_user, self.password))
+        """Determine the default GitHub branch for a repo.
+
+        If the branch name cannot be determined, return 'master'.
+        """
+        # NB: ignore errors since not all CK layer repos come from github
+        branch = default_gh_branch(
+            remote, ignore_errors=True, auth=(self.git_user, self.password)
+        )
+        return branch or "master"
 
     @classmethod
     def load_repos(cls, repos):

--- a/tests/unit/sync_upstream/test_sync.py
+++ b/tests/unit/sync_upstream/test_sync.py
@@ -26,3 +26,11 @@ def test_sync_default_branch(mock_default_gh, mock_base, sync):
         assert name in ["clone", "remote_add", "fetch", "checkout", "merge", "push"]
         if ref := kwargs.get("ref"):
             assert ref == "test-main"
+
+
+@mock.patch("sync.CharmRepoModel.base", new_callable=mock.PropertyMock)
+@mock.patch("sync.default_gh_branch", return_value=None)
+def test_sync_no_default_branch(mock_default_gh, mock_base, sync):
+    """Tests the repo default branch helper which runs when syncing forks."""
+    result = sync.CharmRepoModel.default_gh_branch(mock_base, remote="test-repo")
+    assert result == "master"


### PR DESCRIPTION
Follow-on to #814.

Not all our layer repos come from GitHub (e.g. `layer-apt`, `layer-snap`, etc).  Ignore errors in `default_gh_branch()`.  If we can't figure out a default branch name, set it to `master`.