### PR TITLE
Remove calico-upgrade resource from canal charm

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -1,8 +1,6 @@
 'canal':
   calico: '{out_path}/calico-amd64.tar.gz'
   calico-arm64: '{out_path}/calico-arm64.tar.gz'
-  calico-upgrade: '{out_path}/calico-upgrade-amd64.tar.gz'
-  calico-upgrade-arm64: '{out_path}/calico-upgrade-arm64.tar.gz'
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
   flannel: '{out_path}/flannel-amd64.tar.gz'
   flannel-arm64: '{out_path}/flannel-arm64.tar.gz'


### PR DESCRIPTION
I believe this is needed to go with https://github.com/charmed-kubernetes/layer-canal/pull/67
