### PR TITLE
juju 2.9.7 (starting in 2.9.4) no longer needs the async event loops passed to Model()

### DIFF
--- a/jobs/integration/charm/test_easyrsa.py
+++ b/jobs/integration/charm/test_easyrsa.py
@@ -68,7 +68,7 @@ async def get_relation_data(controller, model, tools):
     return relation_data
 
 
-async def test_easyrsa_installed(deploy, event_loop):
+async def test_easyrsa_installed(deploy):
     """Test that EasyRSA software is installed."""
     controller, model = deploy
     await deploy_easyrsa(controller, model.info.name)
@@ -90,7 +90,7 @@ async def test_easyrsa_installed(deploy, event_loop):
     assert "Easy-RSA" in output
 
 
-async def test_ca(deploy, event_loop):
+async def test_ca(deploy):
     controller, model = deploy
     await deploy_easyrsa(controller, model.info.name)
     easyrsa = model.applications["easyrsa"]
@@ -138,7 +138,7 @@ async def test_ca(deploy, event_loop):
     assert ca_cert == installed_ca
 
 
-async def test_client(deploy, event_loop, tools):
+async def test_client(deploy, tools):
     """Test that the client certificate and key can be created."""
     controller, model = deploy
     relation_data = await get_relation_data(controller, model, tools)
@@ -146,7 +146,7 @@ async def test_client(deploy, event_loop, tools):
     assert validate_key(relation_data["client.key"])
 
 
-async def test_server(deploy, event_loop, tools):
+async def test_server(deploy, tools):
     """Test that the server certificate and key can be created."""
     controller, model = deploy
     relation_data = await get_relation_data(controller, model, tools)

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -164,8 +164,8 @@ async def tools(request):
 
 
 @pytest.fixture(scope="module")
-async def model(request, event_loop, tools):
-    model = Model(event_loop)
+async def model(request, tools):
+    model = Model()
     await model.connect(tools.connection)
     if request.config.getoption("--is-upgrade"):
         upgrade_snap_channel = request.config.getoption("--upgrade-snap-channel")
@@ -232,7 +232,7 @@ async def k8s_model(model, tools):
             "--no-switch",
         )
         created_k8s_model = True
-        k8s_model = Model(model.loop)
+        k8s_model = Model()
         await k8s_model.connect(tools.k8s_connection)
         yield k8s_model
     finally:

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
 log_cli = 1
 log_cli_level = INFO
 log_cli_format = %(message)s
+asyncio_mode = auto


### PR DESCRIPTION
This resulted in a breaking change in our integration tests

Removing the event_loop from the model, showed the module level fixture was no longer needed.  But `event_loop` is a now a function based pytest fixture as a part of `pytest-asyncio`.  

By setting `asyncio_mode = auto` in pytest.ini, all fixtures can now `await` things automatically.

Here's the [breaking change in libjuju](https://github.com/juju/python-libjuju/commit/e5b1993eba0e466a38d593732bf62df8f90739c3)