### PR TITLE
upload eks snaps from within the build container

### DIFF
--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -22,13 +22,13 @@ pipeline {
         timestamps()
     }
     stages {
-        stage('Setup User') {
+        stage('Verify User') {
             /* Do this early; we want to fail fast if we don't have valid creds. */
             steps {
                 sh """
-                    snapcraft logout
                     snapcraft login --with /var/lib/jenkins/.config/snapcraft/snapcraft-cpc.cfg
                     snapcraft whoami
+                    snapcraft logout
                 """
             }
         }
@@ -83,6 +83,9 @@ pipeline {
                         echo "Copying \${EKS_SNAP} into container."
                         sudo lxc file push \${EKS_SNAP} ${lxc_name}/ -p -r
                     done
+
+                    # we'll upload from within the container; put creds in place
+                    sudo lxc file push /var/lib/jenkins/.config/snapcraft/snapcraft-cpc.cfg ${lxc_name}/snapcraft-cpc.cfg
                 """
             }
         }
@@ -104,33 +107,26 @@ pipeline {
                 """
             }
         }
-        stage('Fetch Snaps'){
-            steps {
-                sh """
-                    BUILD_ARCH=\$(dpkg --print-architecture)
-                    for snap in ${CK_SNAPS}
-                    do
-                        EKS_SNAP="\${snap}${EKS_SUFFIX}"
-                        BUILT_SNAP="\${EKS_SNAP}_${kube_ersion}_\${BUILD_ARCH}.snap"
-
-                        echo "Fetching \${BUILT_SNAP}."
-                        sudo lxc file pull ${lxc_name}/\${EKS_SNAP}/\${BUILT_SNAP} .
-                    done
-                """
-            }
-        }
-        stage('Push Snaps'){
+        stage('Upload Snaps'){
             steps {
                 script {
                     if(params.dry_run) {
-                        echo "Dry run; would have uploaded *.snap to ${params.channels}"
-                        sh "ls *eks*.snap"
+                        echo "Dry run; would have uploaded snaps to ${params.channels}"
                     } else {
                         sh """
-                            for snap in \$(ls *eks*.snap)
+                            BUILD_ARCH=\$(dpkg --print-architecture)
+
+                            sudo lxc shell ${lxc_name} -- bash -c "snapcraft login --with /snapcraft-cpc.cfg"
+                            for snap in ${CK_SNAPS}
                             do
-                                snapcraft -d upload \${snap} --release ${params.channels}
+                                EKS_SNAP="\${snap}${EKS_SUFFIX}"
+                                BUILT_SNAP="\${EKS_SNAP}_${kube_ersion}_\${BUILD_ARCH}.snap"
+
+                                echo "Uploading \${BUILT_SNAP}."
+                                sudo lxc shell ${lxc_name} -- bash -c \
+                                    "snapcraft -d upload /\${EKS_SNAP}/\${BUILT_SNAP} --release ${params.channels}"
                             done
+                            sudo lxc shell ${lxc_name} -- bash -c "snapcraft logout"
                         """
                     }
                 }
@@ -147,7 +143,6 @@ pipeline {
                 . \${WORKSPACE}/cilib.sh
 
                 ci_lxc_delete ${lxc_name}
-                snapcraft logout
             """
         }
     }

--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -57,6 +57,12 @@ pipeline {
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
                                -e "s/^base: .*/base: ${EKS_BASE}/" snapcraft.yaml
                         cd -
+
+                        # if we don't have any base defined at this point, add one
+                        grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml
+
+                        echo "Prepared the following snapcraft.yaml:"
+                        cat snapcraft.yaml
                     done
                 """
             }

--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -56,13 +56,13 @@ pipeline {
                         cd \${EKS_SNAP}
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
                                -e "s/^base: .*/base: ${EKS_BASE}/" snapcraft.yaml
-                        cd -
 
                         # if we don't have any base defined at this point, add one
                         grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml
 
                         echo "Prepared the following snapcraft.yaml:"
                         cat snapcraft.yaml
+                        cd -
                     done
                 """
             }


### PR DESCRIPTION
Jenkins has snap creds for k8s and snap creds for cpc.  If build jobs for both happen to overlap, one of those jobs is doomed.  That's because we do things like `snapcraft [login|logout]` at the jenkins worker layer, which potentially affects snap store auth/tokens for all concurrent jobs on that worker.

This PR mitigates that by moving the snapcraft bits that require authn *inside* the isolated build container.

Drive-by to ensure we at least have *some* `base:` declaration; recent snapcraft versions won't build without it.