### PR TITLE
update cdk-addons jobs

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -1,20 +1,22 @@
 # Builds and releases latest snaps
 
 - job-template:
-    name: 'build-release-cdk-addons-{arch}-{version}'
+    name: 'build-release-cdk-addons-{version}'
     description: |
-      Builds, releases and promotes cdk-addons for supported k8s versions on {arch} to the snapstore.
-      Container images required by CDK are known during the build, so this job also tags and pushes
-      those to the Canonical image registry.
+      Builds and uploads cdk-addons for supported k8s versions to the snapstore.
+      Container images required by CK are known during the build, so this job
+      also tags and pushes those to the Canonical image registry.
 
-      The full version of the cdk-addons snap is tied to the upstream k8s tag used during the build.
-      Explicitly set this with the `k8s_tag` parameter, or this job will determine it using the
-      `version` parameter and the contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
+      The full version of the cdk-addons snap is tied to the upstream k8s tag
+      used during the build. Explicitly set this with the `k8s_tag` parameter,
+      or this job will determine it using the `version` parameter and the
+      contents of https://dl.k8s.io/release/[stable|latest]-`version`.txt.
 
-      If all `build-release-cdk-addons-$arch-$ver` jobs appear to stall during snap upload, check
-      for a revision for which the auto-approver has hung by logging into
-      https://dashboard.snapcraft.io/snaps/cdk-addons/ with cdkbot@gmail ubuntu lastpass creds
-      and manually rejecting the review for the oldest hung revision.
+      If all `build-release-cdk-addons-$ver` jobs appear to stall during snap
+      upload, check for a revision for which the auto-approver has hung by
+      logging into https://dashboard.snapcraft.io/snaps/cdk-addons/ with
+      cdkbot@gmail ubuntu lastpass creds. Manually reject the review for the
+      oldest hung revision.
     project-type: pipeline
     pipeline-scm:
       scm:
@@ -22,11 +24,8 @@
       script-path: jobs/build-snaps/build-release-cdk-addons.groovy
     parameters:
       - string:
-          name: arch
-          default: '{arch}'
-      - string:
           name: build_node
-          default: 'runner-amd64'
+          default: 'runner-{arch}'
       - string:
           name: version
           default: '{version}'
@@ -92,10 +91,10 @@
 
 - project:
     name: build-release-snaps
-    arch: ['amd64']
-    version: ['1.20', '1.21', '1.22', '1.23']
+    arch: 'amd64'
+    version: ['1.21', '1.22', '1.23', '1.24']
     jobs:
-      - 'build-release-cdk-addons-{arch}-{version}'
+      - 'build-release-cdk-addons-{version}'
 
 - project:
     name: build-release-eks-snaps

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -253,6 +253,10 @@ pipeline {
                             sudo lxc shell ${lxc_name} -- bash -c "snapcraft login --with /snapcraft-creds"
                             for arch in ${env.ADDONS_ARCHES}
                             do
+                                if [ "\${arch}" = "ppc64le" ]
+                                then
+                                    arch="ppc64el"
+                                fi
                                 BUILT_SNAP="cdk-addons_${kube_ersion}_\${arch}.snap"
 
                                 echo "Uploading \${BUILT_SNAP}."

--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -8,9 +8,6 @@ if (kube_version != "") {
     kube_ersion = kube_version.substring(1)
 }
 def lxc_name = "build-release-cdk-addons-"+env.BUILD_NUMBER
-def lxd_exec(String container, String cmd) {
-    sh "sudo lxc exec ${container} -- bash -c '${cmd}'"
-}
 
 pipeline {
     agent {
@@ -33,12 +30,13 @@ pipeline {
     }
     stages {
         stage('Setup User') {
+            /* Do this early; we want to fail fast if we don't have valid creds. */
             steps {
                 sh "git config --global user.email 'cdkbot@juju.solutions'"
                 sh "git config --global user.name 'cdkbot'"
                 sh "snapcraft login --with /var/lib/jenkins/snapcraft-creds"
                 sh "snapcraft whoami"
-                sh "sudo chown jenkins:jenkins -R /var/lib/jenkins/.config/snapcraft"
+                sh "snapcraft logout"
             }
         }
         stage('Ensure valid K8s version'){
@@ -68,7 +66,7 @@ pipeline {
                         echo "Getting cdk-addons from \$ADDONS_BRANCH branch."
                         git clone https://github.com/charmed-kubernetes/cdk-addons.git --branch \$ADDONS_BRANCH --depth 1
                     else
-                        echo "Getting cdk-addons from master branch."
+                        echo "Getting cdk-addons from default branch."
                         git clone https://github.com/charmed-kubernetes/cdk-addons.git --depth 1
                         if [ "${kube_status}" = "stable" ]
                         then
@@ -88,6 +86,27 @@ pipeline {
                 sh "git clone https://github.com/charmed-kubernetes/bundle.git"
             }
         }
+        stage('Setup Build Container'){
+            steps {
+                /* override sh for this step:
+
+                 Needed because cilib.sh has some non POSIX bits.
+                 */
+                sh """#!/usr/bin/env bash
+                    . \${WORKSPACE}/cilib.sh
+
+                    ci_lxc_launch ubuntu:20.04 ${lxc_name}
+                    until sudo lxc shell ${lxc_name} -- bash -c "snap install snapcraft --classic"; do
+                        echo 'retrying snapcraft install in 3s...'
+                        sleep 3
+                    done
+                    sudo lxc shell ${lxc_name} -- bash -c "apt-get install containerd -y"
+
+                    # we'll upload snaps from within the container; put creds in place
+                    sudo lxc file push /var/lib/jenkins/snapcraft-creds ${lxc_name}/snapcraft-creds
+                """
+            }
+        }
         stage('Build cdk-addons and image list'){
             steps {
                 echo "Setting K8s version: ${kube_version} and K8s ersion: ${kube_ersion}"
@@ -97,31 +116,28 @@ pipeline {
                     UPSTREAM_KEY=${kube_version}-upstream:
                     UPSTREAM_LINE=\$(make KUBE_VERSION=${kube_version} prep upstream-images 2>/dev/null | grep ^\${UPSTREAM_KEY})
 
-                    # build snap
                     for arch in ${env.ADDONS_ARCHES}
                     do
-                        echo "Building cdk-addons snap for arch \${arch}."
+                        echo "Prepping cdk-addons (\${arch}) snap source."
                         wget -O build/kubectl https://storage.googleapis.com/kubernetes-release/release/${kube_version}/bin/linux/\${arch}/kubectl
                         chmod +x build/kubectl
                         sed 's/KUBE_VERSION/${kube_ersion}/g' cdk-addons.yaml > build/snapcraft.yaml
                         if [ "\${arch}" = "ppc64le" ]
                         then
-                          sed -i "s/KUBE_ARCH/ppc64el/g" build/snapcraft.yaml
-                          cd build
-                          SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft clean || exit 1
-                          SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft --target-arch=ppc64el || exit 1
-                          mv *.snap ..
-                          cd ..
-                        else
-                          sed -i "s/KUBE_ARCH/\${arch}/g" build/snapcraft.yaml
-                          cd build
-                          SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft clean || exit 1
-                          SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft --target-arch=\${arch} || exit 1
-                          mv *.snap ..
-                          cd ..
+                          arch="ppc64el"
                         fi
+                        sed -i "s/KUBE_ARCH/\${arch}/g" build/snapcraft.yaml
+
+                        echo "Copying cdk-addons (\${arch}) into container."
+                        sudo lxc shell ${lxc_name} -- bash -c "rm -rf /cdk-addons"
+                        sudo lxc file push . ${lxc_name}/ -p -r
+
+                        echo "Build cdk-addons (\${arch}) snap."
+                        sudo lxc shell ${lxc_name} -- bash -c \
+                            "cd /cdk-addons/build; SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft --target-arch=\${arch}"
+                        sudo lxc shell ${lxc_name} -- bash -c "mv /cdk-addons/build/*.snap /"
                     done
-                    cd ..
+                    cd -
 
                     echo "Updating bundle with upstream images."
                     if grep -q ^\${UPSTREAM_KEY} ${bundle_image_file}
@@ -148,14 +164,6 @@ pipeline {
                     fi
                     cd -
                 """
-            }
-        }
-        stage('Setup LXD container for ctr'){
-            steps {
-                sh "sudo lxc launch ubuntu:20.04 ${lxc_name}"
-                lxd_exec("${lxc_name}", "sleep 10")
-                lxd_exec("${lxc_name}", "apt update")
-                lxd_exec("${lxc_name}", "apt install containerd -y")
             }
         }
         stage('Process Images'){
@@ -262,16 +270,24 @@ pipeline {
                 """
             }
         }
-        stage('Push cdk-addons snap'){
+        stage('Upload Snaps'){
             steps {
                 script {
                     if(params.dry_run) {
                         echo "Dry run; would have uploaded cdk-addons/*.snap to ${params.channels}"
                     } else {
-                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_amd64.snap --release ${params.channels}"
-                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_arm64.snap --release ${params.channels}"
-                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_ppc64el.snap --release ${params.channels}"
-                        sh "snapcraft -d upload cdk-addons/cdk-addons_${kube_ersion}_s390x.snap --release ${params.channels}"
+                        sh """
+                            sudo lxc shell ${lxc_name} -- bash -c "snapcraft login --with /snapcraft-creds"
+                            for arch in ${env.ADDONS_ARCHES}
+                            do
+                                BUILT_SNAP="cdk-addons_${kube_ersion}_\${arch}.snap"
+
+                                echo "Uploading \${BUILT_SNAP}."
+                                sudo lxc shell ${lxc_name} -- bash -c \
+                                    "snapcraft -d upload /\${BUILT_SNAP} --release ${params.channels}"
+                            done
+                            sudo lxc shell ${lxc_name} -- bash -c "snapcraft logout"
+                        """
                     }
                 }
             }
@@ -281,9 +297,15 @@ pipeline {
         always {
             sh "echo Disk usage before cleanup"
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
-            sh "sudo lxc delete -f ${lxc_name}"
-            sh "sudo rm -rf cdk-addons/build"
-            sh "snapcraft logout"
+
+            /* override sh since cilib.sh has some non POSIX bits. */
+            sh """#!/usr/bin/env bash
+                . \${WORKSPACE}/cilib.sh
+
+                ci_lxc_delete ${lxc_name}
+                sudo rm -rf cdk-addons/build
+            """
+
             sh "echo Disk usage after cleanup"
             sh "df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm'"
         }


### PR DESCRIPTION
EKS snap builds are going smashingly well.   cdk-addons snap builds fail sometimes because when multiple snap-related jobs happen on the same jenkins worker, one `snapcraft logout` can affect the auth for all other jobs.

EKS doesn't have this problem because that job builds and uploads from within a lxc container.  This PR does the same for cdk-addons.

- update job description and supported versions
- drop arch param (all our arches are built on amd64)
- build snaps in container like we do for eks jobs
- upload snaps from within the build container