### PR TITLE
sub . for - in the job name so lxc can make a uniquely named container

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -7,7 +7,7 @@ def kube_ersion = null
 if (kube_version != "") {
     kube_ersion = kube_version.substring(1)
 }
-def lxc_name = "build-release-cdk-addons-"+env.BUILD_NUMBER
+def lxc_name = env.JOB_NAME.replaceAll('\\.', '-')+"-"+env.BUILD_NUMBER
 
 pipeline {
     agent {


### PR DESCRIPTION
I noticed cdk-addons 1.21 and 1.24 build at roughly the same time each night. If they overlap, one job will delete the lxc build container before the other job completes.

Fix this by making the lxc name unique.  Note, lxc doesn't like dots in the container name, and these jobs are named `foo-1.2x`; replace those dots with dashes.

Successful run from this branch:

https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-1.21/5/
```
...
09:23:20  + sudo lxc launch ubuntu:20.04 build-release-cdk-addons-1-21-5
09:23:20  Creating build-release-cdk-addons-1-21-5
...
```