### PR TITLE
default charm branch to an empty string if argument not provided

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -114,8 +114,13 @@
               IS_FORCE="--force"
             fi
 
+            WITH_CHARM_BRANCH=""
+            if [[ -n ${CHARM_BRANCH:-} ]]; then
+              WITH_CHARM_BRANCH="--charm-branch $CHARM_BRANCH"
+            fi 
+           
             rm -rf "$WORKSPACE/charms" || true
-
+            
             # Cleanup old charmcraft containers
             ci_lxc_delete "${JOB_NAME}"
             
@@ -123,10 +128,9 @@
             export charmcraft_lxc="${JOB_NAME}-${BUILD_NUMBER}"
             trap 'ci_lxc_delete $charmcraft_lxc' EXIT
             ci_charmcraft_launch $charmcraft_lxc
-
+            
             tox -e py38 -- python jobs/build-charms/charms.py build \
               --charm-list "$CHARM_LIST" \
-              --charm-branch "$CHARM_BRANCH" \
               --to-channel "$TO_CHANNEL" \
               --resource-spec "$RESOURCE_SPEC" \
               --filter-by-tag "$FILTER_BY_TAG" \
@@ -134,8 +138,9 @@
               --layer-list "$LAYER_LIST" \
               --layer-branch "$LAYER_BRANCH" \
               --store "$CHARM_STORE" \
+              $WITH_CHARM_BRANCH \
               $IS_FORCE
-
+            
             tox -e py38 -- python jobs/build-charms/charms.py build-bundles \
                 --to-channel "$TO_CHANNEL" \
                 --bundle-list "$BUNDLE_LIST" \

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -887,7 +887,7 @@ def cli():
     "--charm-branch",
     required=True,
     help="Git branch to build charm from",
-    default="master",
+    default="",
 )
 @click.option(
     "--layer-branch",

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -166,7 +166,7 @@
             The layer git branch to checkout prior to building
       - string:
           name: CHARM_BRANCH
-          default: 'master'
+          default: ''
           description: |
             The charm git branch to checkout prior to building
       - string:


### PR DESCRIPTION
this lets the nightly builds run against the github default branch (main or master) when `CHARM_BRANCH` is an empty environment variable