### PR TITLE
Remove calico-upgrade resources from Calico charm

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -7,8 +7,6 @@
 'calico':
   calico: '{out_path}/calico-amd64.tar.gz'
   calico-arm64: '{out_path}/calico-arm64.tar.gz'
-  calico-upgrade: '{out_path}/calico-upgrade-amd64.tar.gz'
-  calico-upgrade-arm64: '{out_path}/calico-upgrade-arm64.tar.gz'
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
 'flannel':
   flannel-amd64: '{out_path}/flannel-amd64.tar.gz'


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/layer-calico/pull/79
