### PR TITLE
Remove k8s tag from github-runner charm spec

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -124,7 +124,7 @@
     upstream: https://github.com/charmed-kubernetes/github-runner-operator.git
     namespace: 'containers'
     downstream: 'charmed-kubernetes/github-runner-operator'
-    tags: ['k8s', 'github-runner']
+    tags: ['github-runner']
     store: 'ch'
 - aws-integrator:
     upstream: "https://github.com/juju-solutions/charm-aws-integrator.git"


### PR DESCRIPTION
The build-charms job fails when building a CK bugfix release candidate. It tries to build github-runner from a `stable` branch that doesn't exist on the repo.

I don't think github-runner should be part of our release process for CK. Including it would require us to maintain a `stable` branch and a track per CK release. Instead, we should aim to build and release github-runner independently like we do for pytest-operator and friends.

Removing the `k8s` tag from the github-runner charm spec will prevent it from being part of the CK release process. Unfortunately, it will also disable daily builds of github-runner. I figure we can address that in a later PR.