### PR TITLE
refresh snapd snap along with core in validate-snapd-upgrade

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -77,7 +77,7 @@ def pytest_addoption(parser):
         help="Charm channel to use (stable, candidate, beta, edge)",
     )
 
-    # Set when testing a different snap core channel
+    # Set when testing a different snapd/core channel
     parser.addoption(
         "--snapd-upgrade",
         action="store_true",
@@ -89,7 +89,7 @@ def pytest_addoption(parser):
         action="store",
         required=False,
         default="beta",
-        help="Snap channel to install snapcore from",
+        help="Snap channel to install snapd/core snaps from",
     )
 
     # Set when performing series upgrade tests
@@ -188,6 +188,7 @@ async def model(request, tools):
             if unit.dead:
                 continue
             await unit.run(f"sudo snap refresh core --{snapd_channel}")
+            await unit.run(f"sudo snap refresh snapd --{snapd_channel}")
         await tools.juju_wait()
         await log_snap_versions(model, prefix="After")
     yield model


### PR DESCRIPTION
The snapcore team periodically asks us to test new beta `core` snaps prior to them going stable.  We'd been doing this for a while, but recently questioned the value of that test considering all our k8s snaps are now based on `core18`.

We mentioned this to the team and got the following response:

> Now your snaps are interacting with snapd snap in almost the same way they were interacting with core snap before. So that is why I suggested testing when snapd snap goes to beta.

This PR refreshes both the `core` and `snapd` snaps during `validate-ck-snapd-upgrade` so we once again ensure new snapd/core snaps don't affect CK.