### PR TITLE
Specify the right arch when we are not on amd64

### DIFF
--- a/jobs/release-microk8s/spec.yml
+++ b/jobs/release-microk8s/spec.yml
@@ -29,7 +29,7 @@ plan:
         if [ "$ARCH" == "amd64" ]; then
            juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "mem=16G root-disk=80G arch=$ARCH cores=8" ubuntu
         else
-           juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "instance-type=$INSTANCE_TYPE root-disk=80G" ubuntu
+           juju deploy -m "$JUJU_CONTROLLER":"$JUJU_MODEL" --constraints "instance-type=$INSTANCE_TYPE arch=$ARCH root-disk=80G" ubuntu
         fi
 
         juju-wait -e "$JUJU_CONTROLLER":"$JUJU_MODEL" -w


### PR DESCRIPTION
With the switch to charmhub.io deploying the ubuntu charm started failing with:
```
07:42:37 2022-03-24 at 05:42:37 | INFO + juju deploy -m release-microk8s-beta-arm64:release-microk8s-beta-model --constraints 'instance-type=a1.2xlarge root-disk=80G' ubuntu
07:42:40 2022-03-24 at 05:42:40 | INFO Located charm "ubuntu" in charm-hub, revision 19
07:42:40 2022-03-24 at 05:42:40 | INFO Deploying "ubuntu" from charm-hub charm "ubuntu", revision 19 in channel stable
07:42:45 2022-03-24 at 05:42:45 | INFO ERROR cannot add application "ubuntu": invalid AWS instance type "a1.2xlarge" and arch "amd64" specified
```

This PR addresses this issue by setting the right arch as a deployment constraint.