### PR TITLE
update cncf conformance job

### DIFF
--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -2,22 +2,8 @@
 # https://github.com/cncf/k8s-conformance
 #
 
-# - job:
-#     name: 'conformance-s390x'
-#     description: |
-#       CNCF Conformance testing for Kubernetes on s390x.
-
-#       Please see https://git.io/fNwXY for more information.
-#     project-type: freestyle
-#     scm:
-#       - k8s-jenkins-jenkaas
-#     properties:
-#       - build-discarder:
-#           num-to-keep: 7
-
-
 - job:
-    name: 'conformance'
+    name: 'conformance-cncf-ck'
     node: runner-amd64
     description: |
       CNCF Conformance testing for Kubernetes.
@@ -28,10 +14,12 @@
       - k8s-jenkins-jenkaas
     properties:
       - build-discarder:
-          num-to-keep: 4
+          num-to-keep: 7
     wrappers:
       - default-job-wrapper
       - ci-creds
+    triggers:
+      - timed: "@weekly"
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/cncf-conformance"

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -16,10 +16,27 @@ set -x
 ###############################################################################
 function juju::bootstrap::before
 {
-    rm -rf sonobuoy.*
-    wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v"$SONOBUOY_VERSION"/sonobuoy_"$SONOBUOY_VERSION"_linux_amd64.tar.gz
-    tar xvf sonobuoy_"$SONOBUOY_VERSION"_linux_amd64.tar.gz
-    rm -rf sonobuoy_"$SONOBUOY_VERSION"_linux_amd64.tar.gz
+    rm -rf sonobuoy*
+    SB_FILE="sonobuoy_${SONOBUOY_VERSION}_linux_${ARCH}.tar.gz"
+    wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/${SB_FILE}
+    tar xvf ${SB_FILE}
+    rm -f ${SB_FILE}
+    ./sonobuoy version || exit 1
+}
+
+function juju::deploy::overlay
+{
+    cat <<EOF > overlay.yaml
+series: $SERIES
+applications:
+  kubernetes-master:
+    options:
+      channel: $SNAP_VERSION
+      allow-privileged: 'true'
+  kubernetes-worker:
+    options:
+      channel: $SNAP_VERSION
+EOF
 }
 
 function test::execute
@@ -27,43 +44,82 @@ function test::execute
     declare -n is_pass=$1
 
     mkdir -p $HOME/.kube
-    juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master/0:config $HOME/.kube/
-    export RBAC_ENABLED=$(kubectl api-versions | grep \"rbac.authorization.k8s.io/v1beta1\" -c)
+    juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master/leader:config $HOME/.kube/
+    export RBAC_ENABLED=$(kubectl api-versions | grep "rbac.authorization.k8s.io/v1" -c)
     kubectl version
-    ./sonobuoy version
     ./sonobuoy run --mode=certified-conformance --wait 2>&1
     ret=$?
     is_pass="True"
     if (( $ret > 0 )); then
         is_pass="False"
     fi
-    if which juju-crashdump; then
-        juju-crashdump -s -a debug-layer -a config -m "$JUJU_CONTROLLER:$JUJU_MODEL"
-    fi
-    tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* *_sonobuoy*tar.gz
 }
 
 function test::capture
 {
+    # Get artifacts into s3 asap
     ./sonobuoy retrieve
+    if which juju-crashdump; then
+        juju-crashdump -s -a debug-layer -a config -m "$JUJU_CONTROLLER:$JUJU_MODEL"
+    fi
+    tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* *_sonobuoy*tar.gz || true
     python bin/s3 cp "artifacts.tar.gz" artifacts.tar.gz || true
+
+    echo "@@@ CAPTURE RESULTS @@@"
+    echo "@"
+    echo "@  http://jenkaas.s3-website-us-east-1.amazonaws.com/$JOB_ID/artifacts.tar.gz"
+    echo "@"
+    echo "@@@"
+
+    # We cant auto-create a PR upstream, but we can setup a branch
+    # in our fork to make the manual PR process easier.
+    PR_BRANCH=${K8S_VERSION}-ck
+    PROJECT_DIR=v${K8S_VERSION}/cdk
+    git config --global user.email 'cdkbot@juju.solutions'
+    git config --global user.name 'cdkbot'
+    tar xvf *_sonobuoy*.tar.gz plugins/e2e/results/global/e2e.log plugins/e2e/results/global/junit_01.xml
+
+    if git ls-remote --exit-code --heads https://github.com/charmed-kubernetes/k8s-conformance.git ${PR_BRANCH}
+    then
+        git clone https://github.com/charmed-kubernetes/k8s-conformance.git --branch ${PR_BRANCH} --depth 1
+    else
+        git clone https://github.com/charmed-kubernetes/k8s-conformance.git --depth 1
+        pushd k8s-conformance
+        git checkout -b ${PR_BRANCH}
+        popd
+    fi
+
+    pushd k8s-conformance
+    # if we dont have a project dir yet, prime one with known good cdk contents
+    test -d ${PROJECT_DIR} || cp -a v1.23/cdk ${PROJECT_DIR}
+    mv ../plugins/e2e/results/global/* ${PROJECT_DIR}
+    sed -i -e "s/version: .*/version: ${K8S_VERSION}/" ${PROJECT_DIR}/PRODUCT.yaml
+    git add ${PROJECT_DIR}
+    git commit -am "Conformance results for v${K8S_VERSION}/cdk"
+    git push https://${CDKBOT_GH_USR}:${CDKBOT_GH_PSW}@github.com/charmed-kubernetes/k8s-conformance.git --all
+    popd
+
+    rm -rf k8s-conformance
 }
 
 
 ###############################################################################
 # ENV
 ###############################################################################
-SONOBUOY_VERSION=0.20.0
-SNAP_VERSION=${1:-1.23/stable}
-SERIES=${2:-focal}
-JUJU_DEPLOY_BUNDLE=cs:~containers/charmed-kubernetes
-JUJU_DEPLOY_CHANNEL=${3:-stable}
 JUJU_CLOUD=aws/us-east-1
-JUJU_CONTROLLER=validate-$(identifier::short)
-JUJU_MODEL=validate-ck
-ARCH=${4:-amd64}
-JOB_NAME_CUSTOM="validate-ck-conformance-$SERIES-$SNAP_VERSION"
+JUJU_CONTROLLER=cncf-ck-$(identifier::short)
+JUJU_DEPLOY_BUNDLE=charmed-kubernetes
+JUJU_DEPLOY_CHANNEL=stable
+JUJU_MODEL=cncf-ck
+
+ARCH=amd64
+K8S_VERSION=1.23
+SERIES=focal
+SNAP_VERSION=${K8S_VERSION}/stable
+SONOBUOY_VERSION=0.56.3
+
 JOB_ID=$(identifier)
+JOB_NAME_CUSTOM="cncf-ck-${SERIES}-${SNAP_VERSION}"
 
 
 ###############################################################################

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -47,7 +47,7 @@ function test::execute
     juju scp -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-master/leader:config $HOME/.kube/
     export RBAC_ENABLED=$(kubectl api-versions | grep "rbac.authorization.k8s.io/v1" -c)
     kubectl version
-    ./sonobuoy run --mode=certified-conformance --wait 2>&1
+    timeout -s INT 3h ./sonobuoy run --mode=certified-conformance --wait 2>&1
     ret=$?
     is_pass="True"
     if (( $ret > 0 )); then

--- a/jobs/cncf-conformance/readme.md
+++ b/jobs/cncf-conformance/readme.md
@@ -1,65 +1,14 @@
 # Name
 
 - **Job**: `cncf-conformance.yaml`
-- **Project Name**: `k8s-conformance`
+- **Project Name**: `conformance-cncf-ck`
 
 # Description
 
 Runs CNCF Conformance testing against releases of Kubernetes. These tests are
-the baseline for downstream testing and releasing of CDK. These tests must pass
+the baseline for downstream testing and releasing of CK. These tests must pass
 before the process of releasing to beta, candidate, and finally stable can
 occur.
-
-# Parameters
-
-- **version_overlay**: Juju bundle file containing the snap revision/track to test against.
-- **sonobuoy_version**: Version of Sonobuoy to download and run, this performs the actual conformance test.
-- **model**: Juju model
-- **controller**: Cloud (Or controller model if exists in CI) to run against
-- **k8sver**: List of stable k8s versions to test against
-- **cloud**: List of clouds to test against (ie. `['aws','google']`)
-- **bundle_channel**: Bundle channel to use for deployment
-
-# Usage
-
-## Adding new release
-
-In the `job-group` under `jobs` add an additional item with the k8s version, snap overlay revision, and clouds to test against:
-
-```
-- job-group:
-    name: '{name}-tests'
-    k8sver:
-      - 'v1.12.x':
-          version_overlay: '1.12-edge-overlay.yaml'
-      - 'v1.11.x':
-          version_overlay: '1.11-edge-overlay.yaml'
-      - 'v1.10.x':
-          version_overlay: '1.10-edge-overlay.yaml'
-    jobs:
-      - '{name}-tests-{k8sver}-{cloud}':
-          cloud: ['aws', 'google']
-```
-
-An example of the overlay:
-```
-applications:
-  kubernetes-master:
-    charm: cs:~containers/kubernetes-master
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 2
-    options:
-      channel: 1.12/edge
-  kubernetes-worker:
-    charm: cs:~containers/kubernetes-worker
-    constraints: cores=4 mem=4G root-disk=16G
-    expose: true
-    num_units: 3
-    options:
-      channel: 1.12/edge
-```
-
-
 
 # References
 


### PR DESCRIPTION
- new job name to group all our conformance jobs together
- run weekly
- sonobuoy needs allow-privileged; make sure that's set in the overlay
- capture the sonobuoy tarball in our results
- push what we know to our cncf fork to ease upstream PR creation
- use latest sonobuoy version (0.56.3 atm)

Note: We'll need to configure the `conformance-cncf-ck` job and switch the scm branch to `main` after merge.