### PR TITLE
Send an email notification on MicroK8s release failures

### DIFF
--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -35,6 +35,7 @@ pipeline {
         K8STEAMCI_GPG_PUB    = credentials('deb-gpg-public')
         K8STEAMCI_GPG_PRIVATE= credentials('deb-gpg-private')
         K8STEAMCI_GPG_KEY    = credentials('deb-gpg-key')
+        NOTIFY_EMAIL         = credentials('microk8s_notify_email')
 
     }
     options {
@@ -125,6 +126,11 @@ pipeline {
                                     """
                                 } catch (err) {
                                     unstable("${job_name[channel]} completed with errors.")
+                                    emailext(
+                                             body: 'You can do this. Stay strong!', 
+                                             to: env.NOTIFY_EMAIL, 
+                                             subject: "${job_name[channel]} completed with errors."
+                                    )
                                 } finally {
                                     sh destroy_controller(juju_controller)
                                 }

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -127,9 +127,9 @@ pipeline {
                                 } catch (err) {
                                     unstable("${job_name[channel]} completed with errors.")
                                     emailext(
-                                             body: 'You can do this. Stay strong!', 
-                                             to: env.NOTIFY_EMAIL, 
-                                             subject: "${job_name[channel]} completed with errors."
+                                             to: env.NOTIFY_EMAIL,
+                                             subject: "Job '${JOB_NAME}' (${BUILD_NUMBER}) had an on stage ${job_name[channel]}",
+                                             body: "Please go to ${BUILD_URL} and verify the build"
                                     )
                                 } finally {
                                     sh destroy_controller(juju_controller)


### PR DESCRIPTION
Get a list of emails from a secret (`microk8s_notify_email`) and inform the recipients of job failures.