### PR TITLE
add k-n-b layer

### DIFF
--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -164,6 +164,10 @@
     downstream: "charmed-kubernetes/layer-kubernetes-master-worker-base"
     upstream: "https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base.git"
     tags: ['k8s']
+- layer:kubernetes-node-base:
+    downstream: "charmed-kubernetes/layer-kubernetes-node-base"
+    upstream: "https://github.com/charmed-kubernetes/layer-kubernetes-node-base.git"
+    tags: ['k8s']
 - layer:leadership:
     downstream: "charmed-kubernetes/layer-leadership.git"
     upstream: "https://git.launchpad.net/layer-leadership"


### PR DESCRIPTION
Add the new `kubernetes-node-base` layer. Once we're sure we'll never have to build charms for < 1.24, we can remove the `kubernetes-master-worker-base` stanza.