### PR TITLE
temp workaround lp:1969645

### DIFF
--- a/cilib.sh
+++ b/cilib.sh
@@ -32,6 +32,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/arc-conformance/conformance-spec
+++ b/jobs/arc-conformance/conformance-spec
@@ -74,6 +74,7 @@ applications:
     options:
       channel: $SNAP_VERSION
       allow-privileged: 'true'
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -33,6 +33,7 @@ applications:
     options:
       channel: $SNAP_VERSION
       allow-privileged: 'true'
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -53,6 +53,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION
@@ -71,6 +72,7 @@ applications:
     options:
       channel: $SNAP_VERSION
       service-cidr: "10.152.183.0/24,fd00:c00b:2::/112"
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -27,6 +27,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -32,6 +32,7 @@ applications:
       channel: $SNAP_VERSION
       enable-metrics: false
       enable-dashboard-addons: false
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       ingress: false

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -22,6 +22,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/validate/nvidia-spec
+++ b/jobs/validate/nvidia-spec
@@ -18,6 +18,7 @@ applications:
     constraints: cores=2 mem=8G root-disk=16G
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     constraints: instance-type=p2.xlarge
     options:

--- a/jobs/validate/spec-arm64
+++ b/jobs/validate/spec-arm64
@@ -48,6 +48,7 @@ applications:
     constraints: $constraints
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     constraints: $constraints
     options:

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -22,6 +22,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/jobs/validate/upgrade-arm64-spec
+++ b/jobs/validate/upgrade-arm64-spec
@@ -49,6 +49,7 @@ applications:
     constraints: $constraints
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     constraints: $constraints
     options:

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -33,6 +33,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION

--- a/juju.bash
+++ b/juju.bash
@@ -55,6 +55,7 @@ applications:
   kubernetes-control-plane:
     options:
       channel: $SNAP_VERSION
+      controller-manager-extra-args: 'feature-gates=RotateKubeletServerCertificate=true,LegacyServiceAccountTokenNoAutoGeneration=false'
   kubernetes-worker:
     options:
       channel: $SNAP_VERSION


### PR DESCRIPTION
Our CI can't currently create k8s clouds.  Until [lp1969645](https://bugs.launchpad.net/juju/+bug/1969645) is resolved, employ the workaround in our `k8s-control-plane` charm options.