### PR TITLE
Validation fixes

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -181,15 +181,12 @@ async def model(request, tools):
         await upgrade_snaps(model, upgrade_snap_channel, tools)
     if request.config.getoption("--snapd-upgrade"):
         snapd_channel = request.config.getoption("--snapd-channel")
-        await model.deploy("ch:charmed-kubernetes")
         await log_snap_versions(model, prefix="Before")
-        await tools.juju_wait()
         for unit in model.units.values():
             if unit.dead:
                 continue
             await unit.run(f"sudo snap refresh core --{snapd_channel}")
             await unit.run(f"sudo snap refresh snapd --{snapd_channel}")
-        await tools.juju_wait()
         await log_snap_versions(model, prefix="After")
     yield model
     await model.disconnect()

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2334,10 +2334,7 @@ async def test_nfs(model, tools):
 async def test_ceph(model, tools):
     # setup
     series = os.environ["SERIES"]
-    if series == "xenial":
-        pytest.skip("Ceph not supported fully on xenial")
-    snap_ver = os.environ["SNAP_VERSION"].split("/")[0]
-    check_cephfs = snap_ver not in ("1.15", "1.16")
+    check_cephfs = True
     ceph_config = {}
     if check_cephfs and series == "bionic":
         log("adding cloud:train to k8s-control-plane")
@@ -2379,7 +2376,6 @@ async def test_ceph(model, tools):
     await model.add_relation("ceph-mon", "ceph-osd")
     if check_cephfs:
         await model.add_relation("ceph-mon", "ceph-fs")
-    await model.add_relation("ceph-mon:admin", "kubernetes-control-plane")
     await model.add_relation("ceph-mon:client", "kubernetes-control-plane")
     log("waiting...")
     await tools.juju_wait()

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -318,7 +318,7 @@ async def test_rbac(model):
     await run_until_success(worker, cmd + " 2>&1 | grep Forbidden")
 
 
-@pytest.mark.clouds(["ec2"])
+@pytest.mark.clouds(["ec2", "vsphere"])
 async def test_microbot(model, tools):
     """Validate the microbot action"""
     unit = model.applications["kubernetes-worker"].units[0]
@@ -2419,8 +2419,8 @@ async def test_ceph(model, tools):
 async def test_series_upgrade(model, tools):
     if not tools.is_series_upgrade:
         pytest.skip("No series upgrade argument found")
-    control_plane = model.applications["kubernetes-control-plane"].units[0]
-    old_series = control_plane.machine.series
+    worker = model.applications["kubernetes-worker"].units[0]
+    old_series = worker.machine.series
     try:
         new_series = SERIES_ORDER[SERIES_ORDER.index(old_series) + 1]
     except IndexError:

--- a/jobs/validate/snapd-upgrade-spec
+++ b/jobs/validate/snapd-upgrade-spec
@@ -3,7 +3,9 @@
 
 set -x
 
-# Init
+###############################################################################
+# INITIALIZE
+###############################################################################
 : "${WORKSPACE:=$(pwd)}"
 
 . "$WORKSPACE/ci.bash"
@@ -28,7 +30,10 @@ function test::execute
     fi
 }
 
-# Setup Environment
+
+###############################################################################
+# ENV
+###############################################################################
 SNAP_VERSION=${1:-1.24/edge}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
@@ -41,19 +46,8 @@ ARCH=${4:-amd64}
 JOB_NAME_CUSTOM="validate-ck-snapd-upgrade-$SERIES-$SNAP_VERSION"
 JOB_ID=$(identifier)
 
-compile::env
-log_name_custom=$(echo "$JOB_NAME_CUSTOM" | tr '/' '-')
-{
-    build_starttime=$(timestamp)
-    kv::set "build_starttime" "$build_starttime"
 
-    juju::bootstrap
-
-    test::execute result
-    deploy_endtime=$(timestamp)
-    kv::set "deploy_endtime" "$deploy_endtime"
-
-    test::report "$result" "$build_starttime" "$deploy_endtime"
-    test::capture
-
-} 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee "ci.log"
+###############################################################################
+# START
+###############################################################################
+ci::run


### PR DESCRIPTION
Couple validation fixes:

- pick a better charm from which to gleen unit series for the series-upgrade test
- make the snapd-upgrade job more like others (using `ci::run`)
- let microbot run on vsphere (no reason for that test to be ec2-only)
- don't use the ceph-admin relation any more (k-c-p has been refactored to only use ceph-client)