### PR TITLE
Fixes for the release-microk8s-charm job

### DIFF
--- a/jobs/build-charms/charmcraft-lib.sh
+++ b/jobs/build-charms/charmcraft-lib.sh
@@ -51,3 +51,13 @@ ci_charmcraft_copy()
     sudo lxc file pull ${charmcraft_lxc}${charm} ${copy_destination}
   done
 }
+
+ci_charmcraft_promote()
+{
+  # Promote an existing charm revision to a channel
+  local charmcraft_lxc=$1
+  local charm=$2
+  local revision=$3
+  local channel=$4
+  sudo lxc shell $charmcraft_lxc --env CHARMCRAFT_AUTH="$CHARMCRAFT_AUTH" -- bash -c "charmcraft release $charm --revision $revision --channel $channel"
+}

--- a/jobs/build-microk8s-charm.yaml
+++ b/jobs/build-microk8s-charm.yaml
@@ -68,6 +68,9 @@
           - file:
               credential-id: JUJUACCOUNTS_SERVERSTACK
               variable: JUJUACCOUNTS
+          - text:
+              credential-id: charmcraft_creds
+              variable: CHARMCRAFT_AUTH
     parameters:
       - string:
           name: REPOSITORY
@@ -75,7 +78,7 @@
           description: |
             Source repository for MicroK8s charm tests.
       - string:
-          name: BRANCH
+          name: TAG
           default: "master"
           description: |
             Branch from which to run the MicroK8s charm tests.
@@ -86,14 +89,14 @@
             MicroK8s charm to release.
       - string:
           name: FROM_CHANNEL
-          default: "latest/edge"
+          default: "edge"
           description: |
-            Integration tests will be run against this channel. Must be in `track/risk` or `track/risk/branch` format.
+            Run integration tests against this channel.
       - string:
           name: TO_CHANNEL
-          default: "latest/stable"
+          default: "stable"
           description: |
-            After tests pass, charm will be pushed to this channel. Must be in `track/risk` or `track/risk/branch` format.
+            After tests pass, charm will be pushed to this channel.
       - string:
           name: CLUSTER_SIZE
           default: "3"
@@ -104,6 +107,11 @@
           default: "1.21 1.22 1.23"
           description: |
             MicroK8s snap channels to test (space or comma separated).
+      - string:
+          name: SERIES
+          default: "focal jammy"
+          description:
+            Test MicroK8s snap under these series.
       - bool:
           name: SKIP_TESTS
           default: "false"

--- a/jobs/microk8s/charms/release.sh
+++ b/jobs/microk8s/charms/release.sh
@@ -7,72 +7,57 @@
 ## Configuration
 ## - REPOSITORY: Repository to pull the MicroK8s charm code from
 ## - TAG: Tag to checkout
-## - CHARM_NAME: Charm name to test (microk8s)
-## - FROM_CHANNEL: Pull charm from this channel (latest/edge)
-## - TO_CHANNEL: After running tests, release revision to this channel (latest/stable)
-## - SKIP_TESTS: Do not run tests
-## - SKIP_RELEASE: Do not release
+## - CHARM_NAME: Name of MicroK8s charm (default: microk8s)
+## - FROM_CHANNEL: Run integration tests against this channel. (default: edge)
+## - TO_CHANNEL: After tests pass, charm will be pushed to this channel. (default: stable)
+## - CLUSTER_SIZE: Cluster size for the integration tests.
+## - SNAP_CHANNELS: MicroK8s snap channels to test (space separated list).
+## - SERIES: Run tests for these OS series (space separated list) (default: focal jammy).
+## - SKIP_TESTS: Skip tests for promoting release (NOT RECOMMENDED).
+## - SKIP_RELEASE: Skip promoting build to TO_CHANNEL after tests succeed.
 ## - JOB_NAME: from jenkins
 ## - BUILD_NUMBER: from jenkins
 
 ## Secrets
+## - CHARMCRAFT_AUTH: charmcraft credentials. output of `charmcraft login --export auth; cat auth`
 ## - JUJUCONTROLLERS: controllers.yaml configuration file for Juju
 ## - JUJUACCOUNTS: accounts.yaml configuration file for Juju
 
+_DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$_DIR" ]]; then _DIR="$PWD"; fi
+. "$_DIR/../../build-charms/charmcraft-lib.sh"
+
+## default optional variables
+JOB_NAME="${JOB_NAME:-unnamed-job}"
+BUILD_NUMBER="${BUILD_NUMBER:-0}"
+export JUJU_MODEL=${JOB_NAME}-${BUILD_NUMBER}
+
 # Cleanup old containers
-container_prefix="${JOB_NAME}"
-old_containers=$(sudo lxc list -c n -f csv "${container_prefix}" | xargs)
-if [[ ! -z $old_containers ]]; then
-  echo Removing old containers, $old_containers
-  sudo lxc delete --force $old_containers
-fi
+ci_lxc_delete "${JOB_NAME}"
 
 # Configure cleanup routine
-container="${container_prefix}-${BUILD_NUMBER}"
+export charmcraft_lxc="${JOB_NAME}-${BUILD_NUMBER}"
 function cleanup() {
   set +e
-  sudo lxc shell $container -- bash -c 'charmcraft logout'
-  sudo lxc delete $container --force
+  ci_lxc_delete $charmcraft_lxc
   juju destroy-model $JUJU_MODEL -y --timeout 1m --force
   rm -rf $JUJU_DATA
   set -e
 }
 trap cleanup EXIT
 
-# Launch local LXD container to publish to charmcraft
-sudo lxc launch ubuntu:20.04 $container
-timeout 5m bash -c "
-  until sudo lxc shell $container -- bash -c 'snap install charmcraft --classic'; do
-    sleep 3
-  done
-"
+# Launch container
+ci_charmcraft_launch $charmcraft_lxc
 
-# TODO: update when charmcraft supports non-interactive logins
-# sudo lxc file push $CHARMCRAFT_CREDENTIALS $container/charmcraft.credentials
-# sudo lxc shell $container -- bash -c 'mkdir -p ~/snap/charmcraft/common/config/charmcraft.credentials'
-# sudo lxc shell $container -- bash -c 'cp charmcraft.credentials ~/snap/charmcraft/common/config/charmcraft.credentials'
-sudo lxc shell $container -- bash -c 'charmcraft login'
-sudo lxc shell $container -- bash -c 'charmcraft whoami'
-
-# Retrieve revision from CharmHub API. For reference:
+# Retrieve revision from CharmHub API. For reference (http://api.snapcraft.io/docs/charms.html#charm_info). Note that `head -1` is needed because the info endpoint returns an entry for each base.
 #
-# curl --silent https://api.charmhub.io/v1/charm/microk8s-testing/releases -b ./snap/charmcraft/common/config/charmcraft.credentials  | jq '.["channel-map"][] | {channel: .channel, revision: .revision}'
-# {
-#   "channel": "latest/edge",
-#   "revision": 9
-# }
-# {
-#   "channel": "latest/stable",
-#   "revision": 3
-# }
-revision=$(sudo lxc shell $container -- \
-  bash -c "curl https://api.charmhub.io/v1/charm/$CHARM_NAME/releases -b ~/snap/charmcraft/common/config/charmcraft.credentials" \
-    | jq -r ".[\"channel-map\"][] | select(.channel == \"$FROM_CHANNEL\") | .revision")
+# curl 'https://api.charmhub.io/v2/charms/info/microk8s?fields=channel-map' | jq -r '.["channel-map"][] | select(.channel.name == "edge") | select(.channel.base.architecture == "amd64") | .revision.revision' | head -1
+# 20
+revision=$(curl --silent 'https://api.charmhub.io/v2/charms/info/microk8s?fields=channel-map' | jq -r '.["channel-map"][] | select(.channel.name == "'"$FROM_CHANNEL"'") | select(.channel.base.architecture == "amd64") | .revision.revision' | head -1)
 
 # Run tests
 if [[ "$SKIP_TESTS" != 'true' ]]; then
   export JUJU_DATA=$PWD/data
-  export JUJU_MODEL=${JOB_NAME}-${BUILD_NUMBER}
   mkdir -p $JUJU_DATA
   cp $JUJUACCOUNTS $JUJU_DATA/accounts.yaml
   cp $JUJUCONTROLLERS $JUJU_DATA/controllers.yaml
@@ -83,7 +68,7 @@ if [[ "$SKIP_TESTS" != 'true' ]]; then
   juju add-model $JUJU_MODEL
   juju model-config http-proxy=$PROXY https-proxy=$PROXY ftp-proxy=$PROXY no-proxy=$NO_PROXY
 
-  git clone $REPOSITORY -b $BRANCH microk8s-charm
+  git clone $REPOSITORY -b $TAG microk8s-charm
   cd microk8s-charm
 
   python3 -m venv venv
@@ -101,11 +86,12 @@ if [[ "$SKIP_TESTS" != 'true' ]]; then
   export MK8S_NO_PROXY=$NO_PROXY
   export MK8S_CONSTRAINTS='mem=2G cores=2 root-disk=20G'
   export MK8S_SNAP_CHANNELS=$SNAP_CHANNELS
+  export MK8S_SERIES=$SERIES
 
   tox -e integration -- --model $JUJU_MODEL -n 3
 fi
 
 # Release
 if [[ "$SKIP_RELEASE" != 'true' ]]; then
-  sudo lxc shell $container -- bash -c "charmcraft release $CHARM_NAME --revision $revision --channel $TO_CHANNEL"
+  ci_charmcraft_promote $charmcraft_lxc $CHARM_NAME $revision $TO_CHANNEL
 fi


### PR DESCRIPTION
## Summary

Update the release-microk8s-charm job.

## Changes

- Run tests for focal and jammy (needs https://github.com/canonical/charm-microk8s/pull/35)
- Use charmcraft credentials properly
- Use public charmhub API