### PR TITLE
do not fail if juju teardown fails

### DIFF
--- a/jobs/microk8s/charms/release.sh
+++ b/jobs/microk8s/charms/release.sh
@@ -38,8 +38,8 @@ ci_lxc_delete "${JOB_NAME}"
 # Configure cleanup routine
 export charmcraft_lxc="${JOB_NAME}-${BUILD_NUMBER}"
 function cleanup() {
-  set +e
   ci_lxc_delete $charmcraft_lxc
+  set +e
   juju destroy-model $JUJU_MODEL -y --timeout 1m --force
   rm -rf $JUJU_DATA
   set -e


### PR DESCRIPTION
### Summary

Small followup fix for #888. I missed that ci_lxd_delete does `set -e` upon return, therefore failures to teardown the Juju model cause job failures.