### PR TITLE
re-tag charms that ride on a kubernetes provider cloud, rather than a…

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -60,13 +60,13 @@
     upstream: "https://github.com/charmed-kubernetes/kube-state-metrics-operator.git"
     downstream: 'charmed-kubernetes/kube-state-metrics-operator.git'
     namespace: 'containers'
-    tags: ['kube-state-metrics']
+    tags: ['k8s-operator', 'kube-state-metrics']
     store: 'ch'
 - kubernetes-autoscaler:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-autoscaler.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-autoscaler.git'
     namespace: 'containers'
-    tags: ['k8s', 'kubernetes-autoscaler']
+    tags: ['k8s-operator', 'kubernetes-autoscaler']
     store: 'ch'
 - kubernetes-e2e:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-e2e.git"
@@ -85,7 +85,7 @@
     upstream: "https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator.git"
     downstream: 'charmed-kubernetes/kubernetes-metrics-server-operator.git'
     namespace: 'containers'
-    tags: ['kubernetes-metrics-server']
+    tags: ['k8s-operator', 'kubernetes-metrics-server']
 - kubernetes-worker:
     upstream: "https://github.com/charmed-kubernetes/charm-kubernetes-worker.git"
     downstream: 'charmed-kubernetes/charm-kubernetes-worker.git'


### PR DESCRIPTION
I'm not sure the name `k8s-operator` best describes these charms, but they aren't machine charms and aren't dependent on a specific version of kubernetes necessarily to operate.  Unlike the `k8s` tagged charms which are charms associated with the operation of charmed-kubernetes