### PR TITLE
poison CHARM_BASE_DIR path from responding to git rev-parse

### DIFF
--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -33,6 +33,7 @@ def test_build_env_missing_env(charms):
 def test_environment(tmpdir):
     """Creates a fixture defining test environment variables."""
     saved_env, test_env = {}, dict(
+        CHARM_BASE_DIR=str(tmpdir),
         CHARM_BUILD_DIR=f'{tmpdir / "build"}',
         CHARM_LAYERS_DIR=f'{tmpdir / "layers"}',
         CHARM_INTERFACES_DIR=f'{tmpdir / "interfaces"}',


### PR DESCRIPTION
[here's](https://github.com/juju/charm-tools/blob/master/charmtools/build/builder.py#L277-L291) where charmtools builds the layers list
[here's](https://github.com/juju/charm-tools/blob/master/charmtools/build/builder.py#L105-L108) where it's using a local directory
[here's](https://github.com/juju/charm-tools/blob/6ff9c20032f140771064fef6f655b655a33efb8c/charmtools/fetchers.py#L110-L127) where it pulls the rev
and because the layers and interfaces are pulled into the workspace's folder, and there's no `.git` folder there -- it searches up til it hits a `git` folder -- you end up with hit on the jenkins workspace path which provides its `git rev-parse HEAD`


This PR poisons the `git rev-parse` command to fail by putting a `.git` file in `$WORKSPACE/.cache/charmbuild/$BUILD_TAG`