### PR TITLE
use ch for artifacts we add for testing

### DIFF
--- a/jobs/integration/charm/test_kata.py
+++ b/jobs/integration/charm/test_kata.py
@@ -11,9 +11,7 @@ async def test_kata(model, tools):
     :param model: Object
     :return: None
     """
-    kata_app = await model.deploy(
-        "kata", num_units=0, channel="edge"  # Subordinate.
-    )
+    kata_app = await model.deploy("kata", num_units=0, channel="edge")  # Subordinate.
 
     await kata_app.add_relation(
         "kata:containerd", "kubernetes-control-plane:container-runtime"

--- a/jobs/integration/charm/test_kata.py
+++ b/jobs/integration/charm/test_kata.py
@@ -11,7 +11,7 @@ async def test_kata(model, tools):
     :param model: Object
     :return: None
     """
-    kata_app = await model.deploy("kata", num_units=0, channel="edge")  # Subordinate.
+    kata_app = await model.deploy("kata", num_units=0, channel=tools.charm_channel)  # Subordinate.
 
     await kata_app.add_relation(
         "kata:containerd", "kubernetes-control-plane:container-runtime"

--- a/jobs/integration/charm/test_kata.py
+++ b/jobs/integration/charm/test_kata.py
@@ -11,7 +11,9 @@ async def test_kata(model, tools):
     :param model: Object
     :return: None
     """
-    kata_app = await model.deploy("kata", num_units=0, channel=tools.charm_channel)  # Subordinate.
+    kata_app = await model.deploy(
+        "kata", num_units=0, channel=tools.charm_channel
+    )  # Subordinate.
 
     await kata_app.add_relation(
         "kata:containerd", "kubernetes-control-plane:container-runtime"

--- a/jobs/integration/charm/test_kata.py
+++ b/jobs/integration/charm/test_kata.py
@@ -12,7 +12,7 @@ async def test_kata(model, tools):
     :return: None
     """
     kata_app = await model.deploy(
-        "cs:~containers/kata", num_units=0, channel="edge"  # Subordinate.
+        "kata", num_units=0, channel="edge"  # Subordinate.
     )
 
     await kata_app.add_relation(

--- a/jobs/integration/test_aws_iam.py
+++ b/jobs/integration/test_aws_iam.py
@@ -130,7 +130,7 @@ async def test_validate_aws_iam(model, tools):
 
     # 1) deploy
     log("deploying aws-iam")
-    await model.deploy("cs:~containers/aws-iam", channel="edge", num_units=0)
+    await model.deploy("aws-iam", channel="edge", num_units=0)
     await model.add_relation("aws-iam", "kubernetes-control-plane")
     await model.add_relation("aws-iam", "easyrsa")
     log("waiting for cluster to settle...")

--- a/jobs/integration/test_aws_iam.py
+++ b/jobs/integration/test_aws_iam.py
@@ -130,7 +130,7 @@ async def test_validate_aws_iam(model, tools):
 
     # 1) deploy
     log("deploying aws-iam")
-    await model.deploy("aws-iam", channel="edge", num_units=0)
+    await model.deploy("aws-iam", channel=tools.charm_channel, num_units=0)
     await model.add_relation("aws-iam", "kubernetes-control-plane")
     await model.add_relation("aws-iam", "easyrsa")
     log("waiting for cluster to settle...")

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2516,7 +2516,7 @@ async def test_containerd_to_docker(model, tools):
     # Block until docker's removed, ignore `blocked` worker.
 
     containerd_app = await model.deploy(
-        "containerd", num_units=0, channel="edge"  # Subordinate.
+        "containerd", num_units=0, channel=tools.charm_channel  # Subordinate.
     )
 
     await containerd_app.add_relation("containerd", "kubernetes-control-plane")

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2499,7 +2499,7 @@ async def test_containerd_to_docker(model, tools):
     # Block until containerd's removed, ignore `blocked` worker.
 
     docker_app = await model.deploy(
-        "docker", num_units=0, channel="edge"  # Subordinate.
+        "docker", num_units=0, channel=tools.charm_channel  # Subordinate.
     )
 
     await docker_app.add_relation("docker", "kubernetes-control-plane")

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1927,7 +1927,7 @@ async def test_dns_provider(model, k8s_model, tools):
 
         log("Deploying CoreDNS charm")
         coredns = await k8s_model.deploy(
-            "cs:~containers/coredns",
+            "coredns",
             channel=tools.charm_channel,
         )
 
@@ -2499,7 +2499,7 @@ async def test_containerd_to_docker(model, tools):
     # Block until containerd's removed, ignore `blocked` worker.
 
     docker_app = await model.deploy(
-        "cs:~containers/docker", num_units=0, channel="edge"  # Subordinate.
+        "docker", num_units=0, channel="edge"  # Subordinate.
     )
 
     await docker_app.add_relation("docker", "kubernetes-control-plane")
@@ -2516,7 +2516,7 @@ async def test_containerd_to_docker(model, tools):
     # Block until docker's removed, ignore `blocked` worker.
 
     containerd_app = await model.deploy(
-        "cs:~containers/containerd", num_units=0, channel="edge"  # Subordinate.
+        "containerd", num_units=0, channel="edge"  # Subordinate.
     )
 
     await containerd_app.add_relation("containerd", "kubernetes-control-plane")

--- a/jobs/validate-hacluster/Jenkinsfile
+++ b/jobs/validate-hacluster/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 deployCDK(controller: params.controller,
                           cloud: params.cloud,
                           model: juju_model,
-                          bundle: "cs:~containers/${params.bundle}",
+                          bundle: "${params.bundle}",
                           version_overlay: params.overlay,
                           bundle_channel: params.bundle_channel)
             }


### PR DESCRIPTION
Without this, we'll test things like:

```
08:49:43 [validate-ck-amd64-bionic-1.24-beta] Deploying cs:~containers/coredns-21
08:49:43 [validate-ck-amd64-bionic-1.24-beta]   Waiting for CoreDNS charm to be ready
```

Boo.  We want to use the ch version of charms that we add during testing.