### PR TITLE
snapcraft doesnt like --with in 7.0; use candidate snap for now

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -136,7 +136,7 @@
         - jenkins
         - adhoc
     - name: upgrade snapcraft
-      command: "snap refresh snapcraft --channel latest/edge"
+      command: "snap refresh snapcraft --channel latest/candidate"
       ignore_errors: yes
       tags:
         - jenkins


### PR DESCRIPTION
Looks like snapcraft 7 is changing login behavior, including what blob is exported for use when auth'ing via envar.  There are some conflicting statements:

https://bugs.launchpad.net/snapcraft/+bug/1971972

Until we know more about the blob and whether or not `--with` will be reinstated, hold the workers on the candidate channel (v6).