### PR TITLE
pip-tools broken with pip 22.1

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -278,6 +278,10 @@
           set +o allexport
 
           python3.8 -m venv venv
+
+          # le sigh. pin for https://github.com/jazzband/pip-tools/issues/1617
+          python3 -m pip install pip==22.0.4
+
           venv/bin/python -m pip install pip-tools wheel
           venv/bin/pip-sync requirements.txt
 


### PR DESCRIPTION
New pip/pip-tools breakage: https://github.com/jazzband/pip-tools/issues/1617

Pin to 22.0.4. Looks good:

https://jenkins.canonical.com/k8s/view/Infra/job/infra-maintain-ps5-amd64-12/2/console
