### PR TITLE
new ps5 workers are online, lets maintain em

### DIFF
--- a/jobs/infra-ps5.yaml
+++ b/jobs/infra-ps5.yaml
@@ -1,0 +1,57 @@
+# Jenkins maintainer jobs for the ps5 workers
+
+- project:
+    name: infra-ps5
+    arch: ['amd64-8', 'amd64-9', 'amd64-11', 'amd64-12']
+    jobs:
+      - 'infra-maintain-ps5-{arch}'
+
+- job-template:
+    name: 'infra-maintain-ps5-{arch}'
+    description: |
+      Keeps jenkins worker {arch} configured properly.
+    node: runner-ps5-{arch}
+    project-type: freestyle
+    scm:
+      - k8s-jenkins-jenkaas
+    wrappers:
+      - default-job-wrapper
+      - ci-creds
+    triggers:
+        - timed: "H */6 * * *"
+    properties:
+      - block-on-build-release
+      - build-discarder:
+          num-to-keep: 3
+    builders:
+      - set-env:
+          JOB_SPEC_DIR: "jobs/infra"
+      - shell: |
+          rm -rf /var/lib/jenkins/slaves/*/workspace/validate*
+
+          # infra job needs exclusive dpkg access to keep pkgs updated; kill
+          # and clean up if any dpkg procs/locks are found.
+          sudo pkill -9 -e -f ^/usr/bin/dpkg && sleep 5 || true
+          sudo fuser -v -k /var/cache/debconf/config.dat && sleep 5 || true
+          sudo dpkg --configure -a --force-confdef --force-confnew
+
+          sudo apt update
+          sudo DEBIAN_FRONTEND=noninteractive apt -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew -qy dist-upgrade
+          sudo apt install -qy python3-venv
+
+          # show worker characteristics (not fatal)
+          lscpu || true
+          free -h || true
+          df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm' || true
+      - run-venv:
+          COMMAND: |
+              #!/bin/bash
+              set -eux
+              set -o allexport
+              [[ -f $WORKSPACE/.env ]] && source $WORKSPACE/.env
+              set +o allexport
+
+              bash jobs/infra/fixtures/cleanup-env.sh
+
+              venv/bin/pip install ansible
+              venv/bin/ansible-playbook jobs/infra/playbook-jenkins.yml --limit localhost --tags 'jenkins' -i jobs/infra/hosts


### PR DESCRIPTION
In preparation of the migration to PS5, IS added 4 new workers to our jenkaas env.  Add new infra jobs for these so we can put them to use.  We'll keep these separate from the old `infra-*` jobs so we can easily kill those once the migration is complete.

https://jenkins.canonical.com/k8s/view/Infra/