### PR TITLE
specify that the vsphere-cloud-provider shouldn't be pushed to any charmhub track less than 1.25

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -291,6 +291,8 @@
       - vsphere-cloud-provider
       - integrator
     upstream: 'https://github.com/charmed-kubernetes/vsphere-cloud-provider.git'
+    channel-range:
+      min: 1.25
 - metallb-controller:
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb-controller/docs'

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -38,6 +38,54 @@ def test_matched_numerical_channel(charms, risk, expected):
     assert charms.matched_numerical_channel(risk, track_map) == expected
 
 
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        ("2.15/edge", "2.14/EDGE"),
+        ("0.15/stable", "0.15/candidate"),
+        ("0.15/candidate", "0.15/beta"),
+        ("0.15/beta", "0.15/edge"),
+        ("0.15/edge", "0.15"),
+    ],
+)
+def test_release_comparitors(charms, a, b):
+    a, b = map(charms.Release.mk, (a, b))
+    assert a > b
+    assert b < a
+    assert a != b
+
+
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "2.15/edge",
+        "0.15/stable",
+        "0.15/candidate",
+        "0.15/beta",
+    ],
+)
+def test_channel_comparitor(charms, channel):
+    # latest/<anything> is excluded from channel range comparison
+    assert "latest/banana" in charms.ChannelRange("0.15/edge", "0.15/edge")
+
+    # all channels are excluded from channel range comparison without min or max
+    assert channel in charms.ChannelRange(None, None)
+
+    # all channel params are greater than 0.14 and 0.14/stable
+    assert channel in charms.ChannelRange("0.14", None)
+    assert channel in charms.ChannelRange("0.14/stable", None)
+
+    # all channel params are less than 2.15/edge and 2.16
+    assert channel in charms.ChannelRange(None, "2.15/edge")
+    assert channel in charms.ChannelRange(None, "2.16")
+
+    # all channel params fall outside the range starting at 2.15/candidate
+    assert channel not in charms.ChannelRange("2.15/candidate", None)
+
+    # all channel params fall outside the range ending at 0.15/edge
+    assert channel not in charms.ChannelRange(None, "0.15/edge")
+
+
 def test_build_env_missing_env(charms):
     """Ensure missing environment variables raise Exception."""
     with pytest.raises(charms.BuildException) as ie:


### PR DESCRIPTION
Implement range boundaries for charmhub tracks and risks to prevent charms from landing in tracks which shouldn't be opened

Required a new class called `ChannelRange`

```python
assert "latest/edge" in ChannelRange("1.18", "1.25/stable") # latest/<anything> is ignored
assert "1.24/edge" in ChannelRange("1.18", "1.25/stable")   # within bounds inclusively
assert "1.24/edge" in ChannelRange("1.18", None)            # No upper bound
assert "1.24/edge" in ChannelRange(None, "1.25/stable")     # No lower bound
assert "1.24/edge" in ChannelRange(None, None)              # No bounds
```