### PR TITLE
ensure Release.mk can handle floats

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -70,7 +70,7 @@ class Release:
 
     @classmethod
     def mk(cls, rel: str) -> "Release":
-        has_risk = rel.split("/")
+        has_risk = str(rel).split("/")
         if len(has_risk) == 2:
             track, risk = has_risk
         else:


### PR DESCRIPTION
Noticed a `build-charms` failure:
```
02:59:51 [vsphere-cloud-provider] Traceback (most recent call last):
02:59:51   File "jobs/build-charms/charms.py", line 986, in build
02:59:51     entity.promote(to_channels=build_env.to_channels)
02:59:51   File "jobs/build-charms/charms.py", line 810, in promote
02:59:51     ch_channels = self.build.apply_channel_bounds(self.entity, ch_channels)
02:59:51   File "jobs/build-charms/charms.py", line 460, in apply_channel_bounds
02:59:51     return [channel for channel in to_channels if channel in channel_range]
02:59:51   File "jobs/build-charms/charms.py", line 460, in <listcomp>
02:59:51     return [channel for channel in to_channels if channel in channel_range]
02:59:51   File "jobs/build-charms/charms.py", line 139, in __contains__
02:59:51     if self.min and other < self.min:
02:59:51   File "jobs/build-charms/charms.py", line 126, in min
02:59:51     return self._min and Release.mk(self._min)
02:59:51   File "jobs/build-charms/charms.py", line 73, in mk
02:59:51     has_risk = rel.split("/")
02:59:51 AttributeError: 'float' object has no attribute 'split'
```

The `charm*.inc` files might include a string attr, or they might include something that looks like a float.  When finding the $risk, let's make sure that attr always looks like a `split()`-able string.