### PR TITLE
prevent having git tags included in the git commit sha.

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -713,7 +713,7 @@ class BuildEntity:
         if not Path(self.src_path).exists():
             raise BuildException(f"Could not locate {self.src_path}")
         if short:
-            git_commit = git("describe", dirty=True, always=True, _cwd=self.src_path)
+            git_commit = git("rev-parse", "--short", "HEAD", _cwd=self.src_path)
         else:
             git_commit = git("rev-parse", "HEAD", _cwd=self.src_path)
         return git_commit.stdout.decode().strip()


### PR DESCRIPTION
If a commit is tagged, then `git describe --dirty --always` shows the tag rather than the sha.

The intent here was to just get the shortened sha.  

```bash
❯ git log --summary HEAD^..HEAD --pretty=oneline
0c12c3f2e24b7a9b953de5837158f945abc048ca (HEAD -> stable, tag: 1.24+ck1, origin/stable) 1.24+ck1 Cherries (#852)
 create mode 100644 fragments/k8s/cdk/icon.svg
 create mode 100644 overlays/vault-storage-overlay.yaml
~/git/charmed-kubernetes/bundle stable*
❯ 
~/git/charmed-kubernetes/bundle stable*
❯ git rev-parse HEAD
0c12c3f2e24b7a9b953de5837158f945abc048ca
~/git/charmed-kubernetes/bundle stable*
❯ git rev-parse --short HEAD
0c12c3f
~/git/charmed-kubernetes/bundle stable*
❯ git describe --dirty --always
1.24+ck1
```