### PR TITLE
use git rev-parse to gather the short commit id rather the git describe

### DIFF
--- a/jobs/build-charms/charmcraft-lib.sh
+++ b/jobs/build-charms/charmcraft-lib.sh
@@ -31,7 +31,7 @@ ci_charmcraft_pack()
   local subdir=${4:-.}
   sudo lxc shell $charmcraft_lxc -- bash -c "rm -rf /root/*"
   sudo lxc shell $charmcraft_lxc -- bash -c "git clone ${repository} -b ${branch} charm"
-  sudo lxc shell $charmcraft_lxc -- bash -c "cd charm/$subdir; cat version || git describe --dirty --always | tee version"
+  sudo lxc shell $charmcraft_lxc -- bash -c "cd charm/$subdir; cat version || git rev-parse --short HEAD | tee version"
   sudo lxc shell $charmcraft_lxc --env CHARMCRAFT_MANAGED_MODE=1 -- bash -c "cd charm; charmcraft pack -v -p $subdir"
 }
 


### PR DESCRIPTION
Similar to https://github.com/charmed-kubernetes/jenkins/commit/02d8bfbb57177f455e6a2b67d921ed904764d3b1, use `git rev-parse --short HEAD` to find the branch's short commit-sha