### PR TITLE
Adjust promote method to only promote one charm revision.

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -352,12 +352,7 @@ class _CharmHub(CharmcraftCmd):
             charm_status = [
                 row
                 for row in self.status(charm_entity)
-                if all(
-                    (
-                        row["Revision"],
-                        f"{row['Track']}/{row['Channel']}" == from_channel,
-                    )
-                )
+                if row["Revision"] and f"{row['Track']}/{row['Channel']}" == from_channel
             ]
 
         calls = set()

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -352,7 +352,8 @@ class _CharmHub(CharmcraftCmd):
             charm_status = [
                 row
                 for row in self.status(charm_entity)
-                if row["Revision"] and f"{row['Track']}/{row['Channel']}" == from_channel
+                if row["Revision"]
+                and f"{row['Track']}/{row['Channel']}" == from_channel
             ]
 
         calls = set()

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -245,6 +245,7 @@ class CharmcraftCmd(_WrappedCmd):
 
 class _CharmHub(CharmcraftCmd):
     STATUS_RESOURCE = re.compile(r"(\S+) \(r(\d+)\)")
+    BASE_RE = re.compile(r"(\S+) (\S+) \((\S+)\)")
 
     @staticmethod
     def _table_to_list(header, body):
@@ -269,18 +270,24 @@ class _CharmHub(CharmcraftCmd):
 
     def status(self, charm_entity):
         """Read CLI Table output from charmcraft status and parse."""
-        charm_status = self.charmcraft.status(charm_entity)
+        charm_status = self.charmcraft.status(charm_entity, _out=None)
         header, *body = charm_status.stdout.decode().splitlines()
         channel_status = self._table_to_list(header, body)
 
         for idx, row in enumerate(channel_status):
-            resources = row.get("Resources", "")
-            if resources == "-":
-                row["Resources"] = []
-            elif resources == "↑":
-                row["Resources"] = channel_status[idx - 1]["Resources"]
-            else:
-                row["Resources"] = dict(self.STATUS_RESOURCE.findall(resources))
+            base_split = self.BASE_RE.findall(row.get("Base"))
+            assert base_split, "Failed to split base into name, channel, and arch"
+            row["Base"] = dict(zip(["name", "channel", "architecture"], base_split[0]))
+            for prop in ["Resources", "Revision", "Version"]:
+                value = row.get(prop, "")
+                if value == "↑":
+                    row[prop] = channel_status[idx - 1][prop]
+                elif value == "-":
+                    row[prop] = {} if prop == "Resources" else None
+                elif prop == "Resources":
+                    row[prop] = dict(self.STATUS_RESOURCE.findall(value))
+                else:
+                    row[prop] = value
         return channel_status
 
     def revisions(self, charm_entity):
@@ -337,30 +344,39 @@ class _CharmHub(CharmcraftCmd):
         self._echo(
             f"Promoting :: {charm_entity:^35} :: from:{from_channel} to: {to_channels}"
         )
-        if from_channel == "unpublished":
+        if "unpublished" == from_channel:
             charm_status = self._unpublished_revisions(charm_entity)
         else:
             charm_status = [
                 row
                 for row in self.status(charm_entity)
-                if f"{row['Track']}/{row['Channel']}" == from_channel
+                if all(
+                    (
+                        row["Revision"],
+                        f"{row['Track']}/{row['Channel']}" == from_channel,
+                    )
+                )
             ]
 
         calls = set()
         for row in charm_status:
-            revision, resources = row["Revision"], row["Resources"]
+            revision, resources = int(row["Revision"]), row["Resources"]
             resource_args = (
                 f"--resource={name}:{rev}" for name, rev in resources.items() if rev
             )
             calls.add(
                 (
+                    revision,
                     charm_entity,
                     f"--revision={revision}",
                     *(f"--channel={chan}" for chan in to_channels),
                     *resource_args,
                 )
             )
-        for args in calls:
+
+        # Act on the charm with the highest revision number
+        # This should always be the most recently built charm
+        for _, *args in sorted(calls)[-1:]:
             self.charmcraft.release(*args)
 
     def upload(self, dst_path):
@@ -523,14 +539,37 @@ class BuildEnv:
         self.db_json.write_text(json.dumps(dict(self.db)))
         self.store.put_item(Item=dict(self.db))
 
-    def promote_all(self, from_channel="unpublished", to_channels=("edge",)):
+    def promote_all(self, from_channel="beta", to_channels=("edge",)):
         """Promote set of charm artifacts in charmhub."""
+        track = self.db["build_args"].get("track") or "latest"
+        if from_channel.lower() in RISKS:
+            from_channel = f"{track}/{from_channel.lower()}"
+        assert (
+            from_channel != "unpublished"
+        ), "It's unwise to promote unpublished charms."
+        ch_channels = [
+            f"{track}/{chan.lower()}" if (chan.lower() in RISKS) else chan
+            for chan in to_channels
+        ]
+        failed_entities = []
         for charm_map in self.artifacts:
             for charm_name, charm_opts in charm_map.items():
                 if not any(match in self.filter_by_tag for match in charm_opts["tags"]):
                     continue
-                to_channels = self.apply_channel_bounds(charm_name, to_channels)
-                _CharmHub(self).promote(charm_name, from_channel, to_channels)
+                ch_channels = self.apply_channel_bounds(charm_name, ch_channels)
+                try:
+                    _CharmHub(self).promote(charm_name, from_channel, ch_channels)
+                except Exception:
+                    self.echo(traceback.format_exc())
+                    failed_entities.append(charm_name)
+
+        if any(failed_entities):
+            count = len(failed_entities)
+            plural = "s" if count > 1 else ""
+            raise SystemExit(
+                f"Encountered {count} Promote All Failure{plural}:\n\t"
+                + ", ".join(failed_entities)
+            )
 
     def download(self, layer_name):
         """Pull layer source from the charm store."""
@@ -1137,13 +1176,16 @@ def build_bundles(
     multiple=True,
 )
 @click.option(
+    "--track", required=True, help="track to promote charm to", default="latest"
+)
+@click.option(
     "--from-channel",
     default="unpublished",
     required=True,
     help="Charm channel to publish from",
 )
 @click.option("--to-channel", required=True, help="Charm channel to publish to")
-def promote(charm_list, filter_by_tag, from_channel, to_channel):
+def promote(charm_list, filter_by_tag, track, from_channel, to_channel):
     """
     Promote channel for a set of charms filtered by tag.
     """
@@ -1153,6 +1195,7 @@ def promote(charm_list, filter_by_tag, from_channel, to_channel):
         "filter_by_tag": list(filter_by_tag),
         "to_channel": to_channel,
         "from_channel": from_channel,
+        "track": track,
     }
     build_env.clean()
     return build_env.promote_all(

--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -276,8 +276,10 @@ class _CharmHub(CharmcraftCmd):
 
         for idx, row in enumerate(channel_status):
             base_split = self.BASE_RE.findall(row.get("Base"))
-            assert base_split, "Failed to split base into name, channel, and arch"
-            row["Base"] = dict(zip(["name", "channel", "architecture"], base_split[0]))
+            if base_split:
+                row["Base"] = dict(
+                    zip(["name", "channel", "architecture"], base_split[0])
+                )
             for prop in ["Resources", "Revision", "Version"]:
                 value = row.get(prop, "")
                 if value == "↑":
@@ -377,6 +379,7 @@ class _CharmHub(CharmcraftCmd):
         # Act on the charm with the highest revision number
         # This should always be the most recently built charm
         for _, *args in sorted(calls)[-1:]:
+            # self._echo(" ".join(["charmcraft", "release", *args]))
             self.charmcraft.release(*args)
 
     def upload(self, dst_path):

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -551,6 +551,7 @@ def test_promote_command(mock_build_env, charms):
         "filter_by_tag": ["tag1", "tag2"],
         "from_channel": "latest/edge",
         "to_channel": "latest/beta",
+        "track": "latest",
     }
     mock_build_env.promote_all.assert_called_once_with(
         from_channel="latest/edge",


### PR DESCRIPTION
With the introduction of charmhub bases, multiple charm revisions could end up matching some specific `from_channel` like say for instance `latest/candidate`

There could be more than 1 `latest/candidate` release from days gone by on a base (LTS + ARCH) which is now no longer supported by the charm.

For the time being until we make better use of charm tracks, bases, and charmhub in general it's reasonable to assume that the most recent charm version in a `from_channel` is the one that was intended to be promoted. 