### PR TITLE
Update test requirements cffi to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,9 @@ certifi==2020.12.5
     # via
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.5
     # via
+    #   bcrypt
     #   cryptography
     #   pynacl
 charset-normalizer==2.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,9 +43,8 @@ certifi==2020.12.5
     # via
     #   kubernetes
     #   requests
-cffi==1.14.5
+cffi==1.15.1
     # via
-    #   bcrypt
     #   cryptography
     #   pynacl
 charset-normalizer==2.0.12

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
      pip == 22.0.4
      pip-tools
 commands =
-     pip install cffi flake8
+     pip install cffi==1.14.5 flake8
      pip-sync {toxinidir}/requirements.txt
      {posargs:inv test}
 setenv   =


### PR DESCRIPTION
Tox installs the latest cffi, but then it is removed and an
older version is installed. This is causing problems looking
for an older version of ffi.h

PyNaCl requires the newest version of cffi >= 1.4.1

