### PR TITLE
Pin Juju to 2.9

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -149,7 +149,7 @@
         - "charm --classic --edge"
         - "charmcraft --classic --edge"
         - "go --classic --stable"
-        - "juju --classic --candidate"
+        - "juju --classic --channel=2.9/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
         - "kubectl --classic"

--- a/jobs/validate-offline/playbook.yml
+++ b/jobs/validate-offline/playbook.yml
@@ -27,7 +27,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel latest/candidate"
+        - "juju --classic --channel=2.9/stable"
         - "juju-wait --classic"
         - "lxd"
       tags:

--- a/jobs/validate/playbooks/single-system.yml
+++ b/jobs/validate/playbooks/single-system.yml
@@ -34,7 +34,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --candidate"
+        - "juju --classic --channel=2.9/stable"
         - "juju-wait --classic"
         - "juju-crashdump --classic --edge"
         - "lxd"


### PR DESCRIPTION
Temporarily getting around the error:
```
08:31:29  + timeout 4m juju destroy-controller -y --destroy-all-models --destroy-storage release-microk8s-beta-arm64
08:31:29  Sorry, home directories outside of /home are not currently supported. 
08:31:29  See https://forum.snapcraft.io/t/11209 for details.
```