### PR TITLE
make examples and flow more consistent with updates for the 1.25 release

### DIFF
--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -157,7 +157,7 @@ any changes as a result of SolQA testing.
 
 ### CNCF Conformance
 
-**Job**: https://jenkins.canonical.com/k8s/job/conformance/
+**Job**: https://jenkins.canonical.com/k8s/job/conformance-cncf-ck/
 
 ### Document release notes
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -11,7 +11,7 @@ locally.
 
 Each step should contain the following:
 
-- Job name as seen in jenkins
+- Job name as seen in jenkins (where applicable)
 - Description
 - Any additional notes/caveats
 - Example jenkins screenshots if necessary on the options that should be used.
@@ -27,108 +27,99 @@ Solutions QA a solid base to test from.
 
 #### Conflict resolution
 
-At the time of the feature freeze, the stable branches are git reset to match
+At the time of the feature freeze, the release branches are git reset to match
 the default branches at that point, per the documentation below. During the
 feature freeze and Solutions QA period, fixes which need to be applied to
 address CI or QA failures, and only those specific fixes, are cherry-picked in
-to the stable branches.
+to the respective release branches.
 
 ## Prepare CI
 
 ### $next release
 
-Once upstream has an RC for the next stable release, our CI should stop
-building pre-prelease snaps. This ensures the 1.xx/edge channel will end up
-with 1.xx.0 instead of 1.xx.1-alpha.0.
+If not done already, add the upcoming release to the CI enumerations
+as well as our custom snap jobs. For example, see the additions made
+for the 1.25 release:
 
-https://github.com/charmed-kubernetes/jenkins/pull/764
+- https://github.com/charmed-kubernetes/jenkins/pull/974
+- https://github.com/charmed-kubernetes/jenkins/commit/2416d9e98f9f9c6b26b5b94215c43650a9b241e4
+
+> **Note**: Nightly charm and bundle builds will target both
+`latest/edge` and `{$next}/edge` channels.
+
+Once upstream has an RC for the upcoming release, our CI should stop
+building pre-prelease snaps. This ensures the 1.xx track will end up
+with 1.xx.0 instead of 1.xx.1-alpha.0. For example:
+
+- https://github.com/charmed-kubernetes/jenkins/pull/991
 
 Additionally, if not done already, CI should be including the 1.xx/edge in the
-version matrix for relevant tests. For example, see the 1.23 update where we
-add n and drop n-4 from our test matrix:
+version matrix for relevant tests. For example, see the update where we
+adjusted tests for our 1.25 release:
 
-https://github.com/charmed-kubernetes/jenkins/pull/761
+- https://github.com/charmed-kubernetes/jenkins/pull/997
 
 ### $next++ release
 
 It may feel early, but part of releasing the next stable version requires
 preparing for the release that will follow. This requires opening tracks and
-building relevant snaps and charms that will be used in the new 'edge' channel.
+building relevant snaps and charms that will be used in the new `edge` channel.
 
-For example, we requested 1.24 tracks while preparing for the 1.23 release:
+For example, we requested 1.26 snap tracks while preparing for the 1.25 release:
 
-https://forum.snapcraft.io/t/kubernetes-1-24-snap-tracks/27828
+- https://forum.snapcraft.io/t/kubernetes-1-26-snap-tracks/31491
 
-We also added support for CI to build/upload to those requested tracks (k8s
-snaps as well as cdk-addons):
+Charm track requests are made by contacting
+[~snapstore](https://chat.canonical.com/canonical/channels/snapstore)
+and asking for new tracks to be opened for every neccessary
+[charm](https://charmhub.io/charm) and [bundle](https://charmhub.io/bundle)
+owned by `Canonical Kubernetes` on [charmhub.io](https://charmhub.io). For example:
 
-- https://github.com/charmed-kubernetes/jenkins/pull/765/files
-- https://github.com/charmed-kubernetes/jenkins/commit/b0ce1fb0053908043ce25f10cca40be6531c3156
-
-Charm tracks can be created by contacting [~snapstore](https://chat.canonical.com/canonical/channels/snapstore) and asking for new tracks to be opened for every neccessary [charm](https://charmhub.io/charm) and [bundle](https://charmhub.io/bundle) owned by `Canonical Kubernetes` on [charmhub.io](https://charmhub.io)
+- https://chat.canonical.com/canonical/pl/mbyp1gkfrtryube18pti7dsray
 
 ## Preparing the release
 
-### Tag existing stable branches with the current stable bundle
-#### :warning: **Deprecated Step**
+### ~~Tag existing stable branches with the current stable bundle~~
 
-Starting with release 1.24, each repo has a unique branch for each 
-Charm release. This step was previously necessary to tag the 
-previous stable release before resyncing each branch from `main` -> `stable`.
-Tagging of the `release_x.xx` branch will now take place at the end of the release.
+**Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
 
-> For all charm repos that make up CK, tag the existing stable branches with
-> the most recently released stable `cs:charmed-kubernetes` bundle revision.
+For all charm repos that make up CK, tag the existing stable branches with
+the most recently released stable `charmed-kubernetes` bundle revision.
+
+> **Note**: This step is deprecated.
 >
-> **Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
+> Starting with release 1.24, each repo has a unique branch for each
+> CK release. This step was previously necessary to tag the
+> previous stable release before resyncing each branch from `main` -> `stable`.
+> Tagging of the `release_x.xx` branch will now take place at the end of the release.
 
-### Submit PR to bump K8S Track Map
-
-Add the next release to the track map enumerations. To use the newly created tracks, 
-include the next release to the track list/map.
-
-```python
-    ...
-    ("1.25", ["1.25/beta", "1.25/edge"]),
-]
-```
-
-Example PR:
- - https://github.com/charmed-kubernetes/jenkins/pull/974
-
-This will allow and charm-builds targetting `edge` or `beta` channels to flow to the
-`1.25` tracks while any charm-builds targetting `candidate` or `stable` will flow to
-`1.24` tracks.
-
-:warning: Nightly charm and bundle builds will target `latest/edge` and this `{track}/edge`
-
-### Reset release_x.xx from `default` git branches
-
-We need to create release branches from
-`main`. This will be our snapshot from which we test, fix, and subsequently
-promote to the new release.
+### Create release branches for all repos
 
 **Job**: https://jenkins.canonical.com/k8s/job/cut-stable-release/
 
-### Submit PR's to bundle and charms to pin snap channel on the release branches
+We need to create `release_x.xx` branches from `main` for all
+Charmed Kubernetes repositories. This will be our snapshot
+from which we test, fix, and subsequently promote to the new release.
+
+### Pin snap channel on bundles/charms in the release branches
 
 We need to make sure that the bundle fragments and kubernetes-worker/control-plane/e2e
 are set to `<k8sver>/stable`. This should be done on each of the relevant git
-`stable` branches. For example, for 1.23 GA:
+`release_x.xx` branches. For example, for the 1.25 GA:
 
-- https://github.com/charmed-kubernetes/bundle/pull/815
-- https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/15
-- https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/192
-- https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/104
+- https://github.com/charmed-kubernetes/bundle/pull/858
+- https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/24
+- https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/243
+- https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/129
 
-> Note: The charms themselves also need to be done as some do not use our
-  bundles for deployment.
+> **Note**: Changes to the above charms are required as some of our customers
+do not use our bundles for deployment.
 
 ### Bump snap channel to next minor release
 
 Once the rebase has occurred we need to bump the same charms and bundle
 fragments in the `main` git branches to the next k8s minor version,
-e.g. `1.24/edge`. You don't have to do this right away; in fact, you
+e.g. `1.26/edge`. You don't have to do this right away; in fact, you
 should wait until you actually have snaps in the `$next/edge` tracks
 before making this change.
 
@@ -136,12 +127,13 @@ before making this change.
 
 **Job**: https://jenkins.canonical.com/k8s/job/build-charms/
 
-Pull down all layers and checkout their release branches. From there build
-each charm against those local branches. After the charms are built they need to be
-promoted to the **beta** channel in the charmstore.
+This job clones the `release_x.xx` branch for each of our repos. It then builds
+each charm using those local repos. After the charms are built, they will
+be promoted to the `beta` channel in Charmhub based on the build options
+shown below.
 
-> **Note**: Beta channel is required as any bugfix releases happening at the
-  same time will use the candidate channels for staging those releases.
+> **Note**: The `beta` channel is required as any bugfix release happening at
+the same time will use the `candidate` channel for staging.
 
 #### Charm build options
 
@@ -149,32 +141,32 @@ promoted to the **beta** channel in the charmstore.
 
 ### Promote new K8s snaps
 
-K8s snap promotion to `beta` is handled by the `sync-snaps` job and will happen
-automatically after following the `Prepare CI` section noted above. If for some
-reason you need to manually build K8s snaps from a specific branch, use the
-following job with a `branch` parameter like `1.23.0`:
-
 **Job**: https://jenkins.canonical.com/k8s/job/build-snap-from-branch/
+
+K8s snap promotion is handled by the `sync-snaps` job and will happen
+automatically after following the `Prepare CI` section above. If for some
+reason you need to manually build K8s snaps from a specific branch, use the
+above job with a `branch` parameter like `1.25.0`:
 
 The `branch` parameter gets translated to `v$branch` by
 [snap.py](https://github.com/charmed-kubernetes/jenkins/blob/0b334c52b2c4f816b03ff866c44301724b8b471c/cilib/service/snap.py#L172)
 which must correspond to a valid tag in our
 [internal k8s mirror](https://git.launchpad.net/k8s-internal-mirror/refs/).
 
-> **Info**: Please note that currently **CDK-ADDONS** snap needs to be
-    manually released to the appropriate channels:
-    **Job**: https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-amd64-1.23/
+> **Note**: Currently, the **CDK-ADDONS** snap needs to be manually built for
+> the appropriate channels:
+> - https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-1.25/
 
 ### Notify Solutions QA
 
 At the end of the first week and assuming all major blockers are resolved, the
 release is passed over to Solutions QA (SolQA) for a final sign-off. This is done
 by tagging the current Jenkins commit with the release version and informing SolQA
-of that taga. SolQA will then have the remaining week to test and file bugs as they
-happened so engineering can work towards getting them resolved prior to going GA.
+of that tag. SolQA will then have the remaining week to test and file bugs as they
+happen so engineering can work towards getting them resolved prior to GA.
 
 Please note the [Conflict Resolution Section](#conflict-resolution) for making
-any changes as a result of their testing.
+any changes as a result of SolQA testing.
 
 ### CNCF Conformance
 
@@ -190,22 +182,33 @@ any changes as a result of their testing.
 
 ### Promote charms from **beta** to **stable**
 
+**Job**: https://jenkins.canonical.com/k8s/job/promote-charms/
+
 This job takes a tag, from_channel, and to_channel. The tag defaults to `k8s` so
 it will only promote the necessary charms that make up charmed-kubernetes (the
 others are kubeflow related).
-
-**Job**: https://jenkins.canonical.com/k8s/job/promote-charms/
 
 #### Promote charm Options
 
 ![promote charm options](promote-charms.png)
 
-**Job**: https://jenkins.canonical.com/k8s/job/promote-bundles/
+### Build bundles to **stable**
 
+Bundles cannot be promoted because they reference specific charm channels at
+build time. Therefore, it's required to build bundles which reference the
+stable charm channels.
+
+> **Note**: The `bundle` filter shown below ensures only bundles are built
+when this job runs.
+
+#### Build bundle Options
+
+![build bundle options](build-bundle-options.png)
 
 ### Submit PR to bump K8S Track Map
 
-Add candidate and stable branches to the track map
+If not done already, ensure all channels are listed for this release
+in the track map of our CI `./cilib/enums.py`:
 
 ```diff
 -     "1.25": ["1.25/beta", "1.25/edge"],
@@ -213,38 +216,30 @@ Add candidate and stable branches to the track map
 }
 ```
 
-This will allow and charm-builds targetting all channels to flow to the
-`1.25` tracks.
-
-### Build bundles to **stable**
-
-Bundles cannot be promoted because when built they reference specific charm channels
-Therefore, it's required to build bundles which reference the stable charm channels. 
-
-#### Build bundle Options
-
-![build bundle options](build-bundle-options.png)
-
 ### Tag release branches with the current stable bundle
 
+**Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
+
 For all charm repos that make up CK, tag the existing release branches with
-the most recently released stable `charmed-kubernetes` bundle revision.
-
-Use the `x.xx/stable` version number from [charmhub.io/charmed-kubernetes](https://charmhub.io/charmed-kubernetes), not the `latest/stable` version number
-
-> **Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
+the most recently released stable `charmed-kubernetes` bundle revision. Use
+the `x.xx/stable` version number from
+[charmhub.io/charmed-kubernetes](https://charmhub.io/charmed-kubernetes),
+not the `latest/stable` version number.
 
 #### Sync Stable Tag Bundle Rev Options
 
 ![sync stable tag bundle rev options](sync-stable-tag-bundle-rev-options.png)
 
-### Promote snaps from <stable track>/stable to latest/<risks>
+### Promote snaps from `<x.xx>/stable` to `latest/<risks>`
 
-This promotion is handled by the `sync-snaps` job. Once charms and bundles
-have been promoted, set the `K8S_STABLE` enum to the release semver. For
-example, for 1.22 GA:
+**Job**: https://jenkins.canonical.com/k8s/job/sync-snaps/
 
-https://github.com/charmed-kubernetes/jenkins/pull/728
+This job will automatically promote snaps to `latest`. The only
+prereqs are that charms and bundles have been promoted, and that
+the `K8S_STABLE` enum is set to this release `x.xx`. For example,
+for the 1.24 GA:
+
+- https://github.com/charmed-kubernetes/jenkins/pull/902/files
 
 ### Send announcement
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -53,11 +53,12 @@ with 1.xx.0 instead of 1.xx.1-alpha.0. For example:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/991
 
-Additionally, if not done already, CI should be including the 1.xx/edge in the
-version matrix for relevant tests. For example, see the update where we
-adjusted tests for our 1.25 release:
+Additionally, if not done already, CI should include 1.xx in the version matrix
+and config for relevant jobs. For example, see these updates where we adjusted
+tests for our 1.25 release:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/997
+- https://github.com/charmed-kubernetes/jenkins/pull/1005
 
 ### $next++ release
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -45,7 +45,7 @@ for the 1.25 release:
 - https://github.com/charmed-kubernetes/jenkins/commit/2416d9e98f9f9c6b26b5b94215c43650a9b241e4
 
 > **Note**: Nightly charm and bundle builds will target both
-`latest/edge` and `{$next}/edge` channels.
+`latest/edge` and `$next/edge` channels.
 
 Once upstream has an RC for the upcoming release, our CI should stop
 building pre-prelease snaps. This ensures the 1.xx track will end up
@@ -80,33 +80,19 @@ owned by `Canonical Kubernetes` on [charmhub.io](https://charmhub.io). For examp
 
 ## Preparing the release
 
-### ~~Tag existing stable branches with the current stable bundle~~
-
-**Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
-
-For all charm repos that make up CK, tag the existing stable branches with
-the most recently released stable `charmed-kubernetes` bundle revision.
-
-> **Note**: This step is deprecated.
->
-> Starting with release 1.24, each repo has a unique branch for each
-> CK release. This step was previously necessary to tag the
-> previous stable release before resyncing each branch from `main` -> `stable`.
-> Tagging of the `release_x.xx` branch will now take place at the end of the release.
-
 ### Create release branches for all repos
 
 **Job**: https://jenkins.canonical.com/k8s/job/cut-stable-release/
 
-We need to create `release_x.xx` branches from `main` for all
+We need to create `release_1.xx` branches from `main` for all
 Charmed Kubernetes repositories. This will be our snapshot
 from which we test, fix, and subsequently promote to the new release.
 
 ### Pin snap channel on bundles/charms in the release branches
 
 We need to make sure that the bundle fragments and kubernetes-worker/control-plane/e2e
-are set to `<k8sver>/stable`. This should be done on each of the relevant git
-`release_x.xx` branches. For example, for the 1.25 GA:
+have `1.xx/stable` set as the default snap channel. This should be done on each of
+the relevant git `release_1.xx` branches. For example, for the 1.25 GA:
 
 - https://github.com/charmed-kubernetes/bundle/pull/858
 - https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/24
@@ -121,14 +107,14 @@ do not use our bundles for deployment.
 Once the rebase has occurred we need to bump the same charms and bundle
 fragments in the `main` git branches to the next k8s minor version,
 e.g. `1.26/edge`. You don't have to do this right away; in fact, you
-should wait until you actually have snaps in the `$next/edge` tracks
+should wait until you actually have snaps in the `$next++/edge` channels
 before making this change.
 
 ### Build new CK Charms from release git branches
 
 **Job**: https://jenkins.canonical.com/k8s/job/build-charms/
 
-This job clones the `release_x.xx` branch for each of our repos. It then builds
+This job clones the `release_1.xx` branch for each of our repos. It then builds
 each charm using those local repos. After the charms are built, they will
 be promoted to the `beta` channel in Charmhub based on the build options
 shown below.
@@ -147,7 +133,7 @@ the same time will use the `candidate` channel for staging.
 K8s snap promotion is handled by the `sync-snaps` job and will happen
 automatically after following the `Prepare CI` section above. If for some
 reason you need to manually build K8s snaps from a specific branch, use the
-above job with a `branch` parameter like `1.25.0`:
+above job with a `branch` parameter like `1.25.0`.
 
 The `branch` parameter gets translated to `v$branch` by
 [snap.py](https://github.com/charmed-kubernetes/jenkins/blob/0b334c52b2c4f816b03ff866c44301724b8b471c/cilib/service/snap.py#L172)
@@ -206,24 +192,13 @@ when this job runs.
 
 ![build bundle options](build-bundle-options.png)
 
-### Submit PR to bump K8S Track Map
-
-If not done already, ensure all channels are listed for this release
-in the track map of our CI `./cilib/enums.py`:
-
-```diff
--     "1.25": ["1.25/beta", "1.25/edge"],
-+     "1.25": ["1.25/stable", "1.25/candidate", "1.25/beta", "1.25/edge"],
-}
-```
-
 ### Tag release branches with the current stable bundle
 
 **Job**: https://jenkins.canonical.com/k8s/job/sync-stable-tag-bundle-rev/
 
 For all charm repos that make up CK, tag the existing release branches with
 the most recently released stable `charmed-kubernetes` bundle revision. Use
-the `x.xx/stable` version number from
+the `1.xx/stable` version number from
 [charmhub.io/charmed-kubernetes](https://charmhub.io/charmed-kubernetes),
 not the `latest/stable` version number.
 
@@ -231,13 +206,13 @@ not the `latest/stable` version number.
 
 ![sync stable tag bundle rev options](sync-stable-tag-bundle-rev-options.png)
 
-### Promote snaps from `<x.xx>/stable` to `latest/<risks>`
+### Promote snaps from `1.xx/stable` to `latest/<risks>`
 
 **Job**: https://jenkins.canonical.com/k8s/job/sync-snaps/
 
 This job will automatically promote snaps to `latest`. The only
 prereqs are that charms and bundles have been promoted, and that
-the `K8S_STABLE` enum is set to this release `x.xx`. For example,
+the `K8S_STABLE` enum is set to this release `1.xx`. For example,
 for the 1.24 GA:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/902/files


### PR DESCRIPTION
I re-organized some sections based on the order of things we need to do in a new stable release.  It's a pretty big diff, though most of that is due to the content moving around.

Suggest to read/review this as a new document rather than one with 100 diffs.