### PR TITLE
Remove the `ConfigObj` dependency

### DIFF
--- a/jobs/integration/test_aws_iam.py
+++ b/jobs/integration/test_aws_iam.py
@@ -7,7 +7,7 @@ from .logger import log
 from .utils import juju_run
 from subprocess import check_output
 from shlex import split
-from configobj import ConfigObj
+from configparser import ConfigParser
 from cilib.run import capture
 import os
 
@@ -51,11 +51,12 @@ def arn():
 
 
 def get_test_keys():
-    creds = ConfigObj(str(Path("~/.aws/credentials").expanduser()))
-    if "default" not in creds.keys():
+    creds = ConfigParser()
+    creds.read(Path("~/.aws/credentials").expanduser())
+    if "default" not in creds.sections():
         raise Exception("Could not find default aws credentials")
-    key_id = creds.get("default")["aws_access_key_id"]
-    key = creds.get("default")["aws_secret_access_key"]
+    key_id = creds["default"]["aws_access_key_id"]
+    key = creds["default"]["aws_secret_access_key"]
     return {"id": key_id, "key": key}
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,6 @@ black
 boto3
 bs4
 contextvars
-configobj
 drypy
 loguru
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,8 +56,6 @@ click==8.1.2
     #   mkdocs
 colorama==0.3.9
     # via awscli
-configobj==5.0.6
-    # via -r requirements.in
 contextvars==2.4
     # via -r requirements.in
 cryptography==3.4.7
@@ -320,7 +318,6 @@ sh==1.14.3
 six==1.15.0
     # via
     #   bcrypt
-    #   configobj
     #   fasteners
     #   google-auth
     #   jenkins-job-builder


### PR DESCRIPTION
Thanks to @Courtney-E-Miller


It was pointed out that this dependency is no longer maintained.  Swapping to parsing the `ConfigParser` built-in rather than an external dependency