### PR TITLE
Adds gatekeeper controller manager to support matrix

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -399,6 +399,17 @@
       - coredns
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-coredns.git'
+- gatekeeper-controller-manager:
+    bugs: 'https://launchpad.net/opa-gatekeeper-operator'
+    docs: 'https://charmhub.io/gatekeeper-controller-manager/docs'
+    downstream: charmed-kubernetes/opa-gatekeeper-operators
+    store: 'https://charmhub.io/gatekeeper-controller-manager'
+    subdir: opa-manager-operator
+    summary: Controller charm for Gatekeeper
+    tags:
+      - k8s-operator
+      - gatekeeper-controller-manager
+    upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 
 # EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard
 # - k8s-dashboard:


### PR DESCRIPTION
Adds support for building/releasing the gatekeeper-controller-manager charm. 

Since this charm is similar to metallb in that the source repo houses multiple charms, the metallb yaml was used as a template. The yaml includes the subdir field to facilitate building the charm from the correct subdirectory. 
