### PR TITLE
Add gatekeeper tests

### DIFF
--- a/jobs/integration/templates/gatekeeper-policy-spec.yaml
+++ b/jobs/integration/templates/gatekeeper-policy-spec.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: ns-must-have-gk
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    labels: ["gatekeeper"]

--- a/jobs/integration/templates/gatekeeper-policy.yaml
+++ b/jobs/integration/templates/gatekeeper-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            labels:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlabels
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_]}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("you must provide labels: %v", [missing])
+        }

--- a/jobs/integration/templates/integrator-charm-data/vsphere/storage-class.yaml
+++ b/jobs/integration/templates/integrator-charm-data/vsphere/storage-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mystorage
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  diskformat: zeroedthick

--- a/jobs/integration/templates/validate-gatekeeper-policy.yaml
+++ b/jobs/integration/templates/validate-gatekeeper-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: test-ns
+    labels:
+        gatekeeper: "true"

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -10,7 +10,6 @@ from .logger import log
 from .utils import (
     JujuRunError,
     kubectl,
-    scp_to,
     wait_for_application_status,
     kubectl_apply,
     kubectl_delete,
@@ -291,7 +290,7 @@ class OPATestBase:
 
         try:
             await block_until_with_coroutine(check_app_missing, timeout=120)
-        except asyncio.TimeoutError as e:
+        except asyncio.TimeoutError:
             raise AssertionError(f"Application {app_name} was not removed")
 
 
@@ -299,7 +298,6 @@ class OPATestBase:
 class TestOPAWebhook(OPATestBase):
     async def test_opa_webhook_ready(self, opa_controller_manager):
         await self.wait_for_units(opa_controller_manager)
-        unit = opa_controller_manager.units[0]
 
         log("Waiting for gatekeeper charm to be ready")
         await wait_for_application_status(

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -317,7 +317,6 @@ class TestOPA:
                 "gatekeeper-controller-manager",
             )
 
-
     async def test_opa_audit(self, storage_pool):
         log("Deploying the gatekeeper charm")
         audit = await self.k8s_model.deploy(

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -181,11 +181,11 @@ class TestOPA:
         await action.wait()
         assert len(json.loads(action.results["violations"])) > 0
 
-    async def wait_for_units(self, app, error_status=["blocked", "error"]):
+    async def wait_for_units(self, app, error_status=("blocked", "error")):
         while (
             status := app.units[0].workload_status if app.units else None
         ) != "active":
-            assert status not in ("blocked", "error")
+            assert status not in error_status
             await asyncio.sleep(5)
 
     async def test_opa_webhook(self, storage_pool):

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -130,8 +130,6 @@ class TestOPA:
 
     @pytest.fixture(scope="module")
     async def storage_pool(self, model, k8s_model, tools):
-        # This assumes that we are running on vsphere, should it be
-        # extended to run on other clouds as well?
         control_plane_app = model.applications["kubernetes-control-plane"]
         control_plane_unit = control_plane_app.units[0]
         remote_path = "/tmp/storage-class.yaml"
@@ -200,6 +198,7 @@ class TestOPA:
             assert status not in error_status
             await asyncio.sleep(5)
 
+    @pytest.mark.clouds(["vsphere"])
     async def test_opa_webhook(self, storage_pool):
         log("Deploying the gatekeeper charm")
         webhook = await self.k8s_model.deploy(
@@ -323,6 +322,7 @@ class TestOPA:
                 "gatekeeper-controller-manager",
             )
 
+    @pytest.mark.clouds(["vsphere"])
     async def test_opa_audit(self, storage_pool):
         log("Deploying the gatekeeper charm")
         audit = await self.k8s_model.deploy(

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -144,6 +144,8 @@ class OPATestBase:
         storage_pool_name = "teststorage"
         log("Creating storage pool")
         try:
+            # TODO: When use `k8s_model.create_storage_pool` once we start using
+            # python-libjuju  >= 3.0.0
             await tools.run(
                 "juju",
                 "create-storage-pool",
@@ -156,6 +158,8 @@ class OPATestBase:
             yield storage_pool_name
         finally:
             log("Removing storage pool")
+            # TODO: When use `k8s_model.remove_storage_pool` once we start using
+            # python-libjuju  >= 3.0.0
             await tools.run(
                 "juju",
                 "remove-storage-pool",
@@ -204,6 +208,9 @@ class OPATestBase:
             yield audit
         finally:
             log("Deleting the audit charm")
+            # TODO: Currently `k8s_model.remove_application` does not support removing
+            # storage, this feature will be added in a later python-libjuju version,
+            # once that is done we should replace this with one such call.
             await tools.run(
                 "juju",
                 "remove-application",
@@ -309,6 +316,9 @@ class TestOPAWebhook(OPATestBase):
             await self.validate_create_ns()
         finally:
             log("Deleting the audit charm")
+            # TODO: Currently `k8s_model.remove_application` does not support removing
+            # storage, this feature will be added in a later python-libjuju version,
+            # once that is done we should replace this with one such call.
             await self.tools.run(
                 "juju",
                 "remove-application",

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -1,0 +1,390 @@
+import asyncio
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from .logger import log
+from .utils import JujuRunError, kubectl, scp_to, wait_for_application_status
+
+templates = Path(__file__).parent / "templates"
+
+
+class TestOPA:
+    @pytest.fixture(autouse=True)
+    def setup(self, model, k8s_model, tools):
+        self.model = model
+        self.k8s_model = k8s_model
+        self.tools = tools
+        control_plane_app = self.model.applications["kubernetes-control-plane"]
+        self.control_plane_unit = control_plane_app.units[0]
+
+    async def validate_create_ns_with_label(self):
+        remote_path = "/tmp/validate-gatekeeper-policy.yaml"
+        await scp_to(
+            templates / "validate-gatekeeper-policy.yaml",
+            self.control_plane_unit,
+            remote_path,
+            self.tools.controller_name,
+            self.tools.connection,
+        )
+
+        # Create the namespace
+        cmd = f"apply -f {remote_path}"
+        log("Creating namespace")
+        await kubectl(self.model, cmd)
+
+        # Wait for namespace to go active
+        cmd = "get ns test-ns -o jsonpath='{{.status.phase}}'"
+        log("Waiting for namespace to become active")
+        while result := await kubectl(self.model, cmd):
+            if result.output == "Active":
+                break
+            await asyncio.sleep(1)
+
+        # Delete the namespace
+        cmd = "delete ns test-ns"
+        await kubectl(self.model, cmd)
+
+    async def validate_create_ns(self, name=None):
+        if not name:
+            name = f"test-ns-{random.randint(1, 99999)}"
+
+        cmd = f"create ns {name}"
+        log("Creating namespace")
+        await kubectl(self.model, cmd)
+
+        # Wait for namespace to go active
+        cmd = f"get ns {name} -o jsonpath='{{.status.phase}}'"
+        log("Waiting for namespace to become active")
+        while result := await kubectl(self.model, cmd):
+            if result.output == "Active":
+                break
+            await asyncio.sleep(1)
+
+        # Delete the namespace
+        cmd = f"delete ns {name}"
+        await kubectl(self.model, cmd)
+
+    async def validate_create_ns_fail(self, name=None):
+        if not name:
+            name = f"test-ns-{random.randint(1, 99999)}"
+
+        cmd = f"create ns {name}"
+        # Creating the namespace should raise
+        log("Creating namespace without any labels")
+        try:
+            await kubectl(self.model, cmd)
+        except JujuRunError as e:
+            assert e.output.startswith(
+                "Error from server (Forbidden): admission webhook "
+                '"validation.gatekeeper.sh" denied the request:'
+            )
+        else:
+            pytest.fail("Creating the namespace should fail, but it didn't")
+
+    async def deploy_example_policy(self):
+        remote_policy_path = "/tmp/policy.yaml"
+        remote_policy_spec_path = "/tmp/policy-spec.yaml"
+        await scp_to(
+            templates / "gatekeeper-policy.yaml",
+            self.control_plane_unit,
+            remote_policy_path,
+            self.tools.controller_name,
+            self.tools.connection,
+        )
+        await scp_to(
+            templates / "gatekeeper-policy-spec.yaml",
+            self.control_plane_unit,
+            remote_policy_spec_path,
+            self.tools.controller_name,
+            self.tools.connection,
+        )
+        await kubectl(self.model, f"apply -f {remote_policy_path}")
+        await kubectl(self.model, f"apply -f {remote_policy_spec_path}")
+
+    async def destroy_example_policy(self):
+        remote_path = "/tmp/policy.yaml"
+        await scp_to(
+            templates / "gatekeeper-policy.yaml",
+            self.control_plane_unit,
+            remote_path,
+            self.tools.controller_name,
+            self.tools.connection,
+        )
+        await kubectl(self.model, f"delete -f {remote_path}")
+
+    @pytest.fixture
+    async def create_storage_pool(self, model, tools):
+        # This assumes that we are running on vsphere, should it be
+        # extended to run on other clouds as well?
+        control_plane_app = model.applications["kubernetes-control-plane"]
+        control_plane_unit = control_plane_app.units[0]
+        remote_path = "/tmp/storage-class.yaml"
+        storage_pool_name = "teststorage"
+        await scp_to(
+            templates / "integrator-charm-data" / "vsphere" / "storage-class.yaml",
+            control_plane_unit,
+            remote_path,
+            tools.controller_name,
+            tools.connection,
+        )
+        log("Creating storage class")
+        try:
+            await kubectl(model, f"create -f {remote_path}")
+            await tools.run(
+                "juju",
+                "create-storage-pool",
+                storage_pool_name,
+                "kubernetes",
+                "-m",
+                tools.k8s_connection,
+                "storage-class=mystorage",
+            )
+            yield storage_pool_name
+        finally:
+            log("Removing storage class")
+            await kubectl(model, f"delete -f {remote_path}")
+            await tools.run(
+                "juju",
+                "remove-storage-pool",
+                "-m",
+                tools.k8s_connection,
+                storage_pool_name,
+            )
+
+    async def test_opa_webhook(self):
+        log("Deploying the gatekeeper charm")
+        webhook = await self.k8s_model.deploy(
+            "gatekeeper-controller-manager",
+            channel=self.tools.charm_channel,
+            trust=True,
+        )
+
+        while (
+            status := webhook.units[0].workload_status if webhook.units else None
+        ) != "active":
+            assert status not in ("blocked", "error")
+            await asyncio.sleep(5)
+        unit = webhook.units[0]
+
+        try:
+            log("Waiting for gatekeeper charm to be ready")
+            await wait_for_application_status(
+                self.k8s_model, "gatekeeper-controller-manager", status="active"
+            )
+
+            await self.validate_create_ns()
+            log("Creating policy and constraint crds")
+            await self.deploy_example_policy()
+            log("Test that the policy is enforced")
+            await self.validate_create_ns_fail()
+            await self.validate_create_ns_with_label()
+            log("Delete the policy")
+
+            log("Deploying the audit charm")
+            audit = await self.k8s_model.deploy(
+                "gatekeeper-audit",
+                channel=self.tools.charm_channel,
+                trust=True,
+            )
+            while (
+                status := audit.units[0].workload_status if audit.units else None
+            ) != "active":
+                assert status not in ("blocked", "error")
+                await asyncio.sleep(5)
+
+            log("Test that the policy is enforced")
+            await self.validate_create_ns_fail()
+            await self.validate_create_ns_with_label()
+            await self.destroy_example_policy()
+            log("Validate that the policy is no longer enforced")
+            await self.validate_create_ns()
+
+            log("Configuring charm to lower audit interval")
+            await self.tools.run(
+                "juju",
+                "config",
+                "-m",
+                self.tools.k8s_connection,
+                "gatekeeper-audit",
+                "audit-interval=1",
+            )
+            await wait_for_application_status(
+                self.k8s_model, "gatekeeper-audit", status="active"
+            )
+
+            log("Running list-violations action")
+            total_violations = 0
+            while total_violations == 0:
+                action = await unit.run_action("list-violations")
+                await action.wait()
+                assert action.status == "completed"
+                assert "constraint-violations" in action.results
+                constraint_violations = json.loads(
+                    action.results["constraint-violations"]
+                )
+                total_violations = constraint_violations[0].get("total-violations")
+                await asyncio.sleep(5)
+
+            log("Running get-violation action")
+            action = await unit.run_action(
+                "get-violation",
+                **{
+                    "constraint-template": "K8sRequiredLabels",
+                    "constraint": "ns-must-have-gk",
+                },
+            )
+            await action.wait()
+            assert len(json.loads(action.results["violations"])) > 0
+
+            await audit.destroy()
+            interval = await self.tools.run(
+                "juju", "model-config", "update-status-hook-interval"
+            )
+            interval = interval[0].strip()
+            try:
+                log("Decrease update status hook interval")
+                await self.tools.run(
+                    "juju", "model-config", "update-status-hook-interval=5s"
+                )
+                log("Waiting for status to change to blocked")
+                while (
+                    status := webhook.units[0].workload_status
+                    if webhook.units
+                    else None
+                ) != "blocked":
+                    assert status != "error"
+                    await asyncio.sleep(5)
+                log("Reconcile resources")
+                await unit.run_action("reconcile-resources")
+                while (
+                    status := webhook.units[0].workload_status
+                    if webhook.units
+                    else None
+                ) != "active":
+                    assert status != "error"
+                    await asyncio.sleep(5)
+            finally:
+                await self.tools.run(
+                    "juju", "model-config", f"update-status-hook-interval={interval}"
+                )
+
+            # Check that the webhook works
+            await self.validate_create_ns()
+            log("Creating policy and constraint crds")
+            await self.deploy_example_policy()
+            log("Test that the policy is enforced")
+            await self.validate_create_ns_fail()
+            await self.validate_create_ns_with_label()
+            await self.destroy_example_policy()
+        finally:
+            log("Deleting the gatekeeper charm")
+            await self.tools.run(
+                "juju",
+                "remove-application",
+                "-m",
+                self.tools.k8s_connection,
+                "--force",
+                "gatekeeper-controller-manager",
+            )
+
+    async def test_opa_audit(self, create_storage_pool):
+        log("Deploying the gatekeeper charm")
+        audit = await self.k8s_model.deploy(
+            "gatekeeper-audit",
+            channel=self.tools.charm_channel,
+            trust=True,
+            storage={"audit-volume": {"pool": create_storage_pool}},
+        )
+        while (
+            status := audit.units[0].workload_status if audit.units else None
+        ) != "active":
+            assert status not in ("blocked", "error")
+            await asyncio.sleep(5)
+
+        unit = audit.units[0]
+
+        log("Waiting for gatekeeper charm to be ready")
+        await wait_for_application_status(
+            self.k8s_model, "gatekeeper-audit", status="active"
+        )
+        await self.validate_create_ns()
+        log("Creating policy and constraint crds")
+        await self.deploy_example_policy()
+        log("Configuring charm to lower audit interval")
+        await self.tools.run(
+            "juju",
+            "config",
+            "-m",
+            self.tools.k8s_connection,
+            "gatekeeper-audit",
+            "audit-interval=1",
+        )
+        await wait_for_application_status(
+            self.k8s_model, "gatekeeper-audit", status="active"
+        )
+
+        log("Running list-violations action")
+        total_violations = 0
+        while total_violations == 0:
+            action = await unit.run_action("list-violations")
+            await action.wait()
+            assert action.status == "completed"
+            assert "constraint-violations" in action.results
+            constraint_violations = json.loads(action.results["constraint-violations"])
+            total_violations = constraint_violations[0].get("total-violations")
+            await asyncio.sleep(5)
+
+        log("Running get-violation action")
+        action = await unit.run_action(
+            "get-violation",
+            **{
+                "constraint-template": "K8sRequiredLabels",
+                "constraint": "ns-must-have-gk",
+            },
+        )
+        await action.wait()
+        assert len(json.loads(action.results["violations"])) > 0
+
+        log("Deploying the gatekeeper charm")
+        webhook = await self.k8s_model.deploy(
+            "gatekeeper-controller-manager",
+            channel=self.tools.charm_channel,
+            trust=True,
+        )
+        while (
+            status := webhook.units[0].workload_status if webhook.units else None
+        ) != "active":
+            assert status not in ("blocked", "error")
+            await asyncio.sleep(5)
+        log("Deleting the gatekeeper charm")
+        await webhook.destroy()
+
+        interval = await self.tools.run(
+            "juju", "model-config", "update-status-hook-interval"
+        )
+        interval = interval[0].strip()
+        try:
+            log("Decrease update status hook interval")
+            await self.tools.run(
+                "juju", "model-config", "update-status-hook-interval=5s"
+            )
+            log("Waiting for status to change to blocked")
+            while (
+                status := audit.units[0].workload_status if audit.units else None
+            ) != "blocked":
+                assert status != "error"
+                await asyncio.sleep(5)
+            log("Reconcile resources")
+            await unit.run_action("reconcile-resources")
+            while (
+                status := audit.units[0].workload_status if audit.units else None
+            ) != "active":
+                assert status != "error"
+                await asyncio.sleep(5)
+        finally:
+            await self.tools.run(
+                "juju", "model-config", f"update-status-hook-interval={interval}"
+            )

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -1,8 +1,6 @@
 import asyncio
-from bdb import Breakpoint
 import json
 import random
-from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -295,11 +293,11 @@ class TestOPA:
                     await asyncio.sleep(5)
             finally:
                 await self.tools.run(
-                "juju",
-                "model-config",
-                "-m",
-                self.tools.k8s_connection,
-                f"update-status-hook-interval={interval}",
+                    "juju",
+                    "model-config",
+                    "-m",
+                    self.tools.k8s_connection,
+                    f"update-status-hook-interval={interval}",
                 )
 
             # Check that the webhook works
@@ -327,7 +325,7 @@ class TestOPA:
             channel=self.tools.charm_channel,
             trust=True,
             storage={"audit-volume": {"pool": storage_pool}},
-            config={"audit-interval": 1}
+            config={"audit-interval": 1},
         )
         while (
             status := audit.units[0].workload_status if audit.units else None
@@ -401,11 +399,11 @@ class TestOPA:
                     await asyncio.sleep(5)
             finally:
                 await self.tools.run(
-                "juju",
-                "model-config",
-                "-m",
-                self.tools.k8s_connection,
-                f"update-status-hook-interval={interval}",
+                    "juju",
+                    "model-config",
+                    "-m",
+                    self.tools.k8s_connection,
+                    f"update-status-hook-interval={interval}",
                 )
         finally:
             await self.tools.run(

--- a/jobs/integration/test_opa.py
+++ b/jobs/integration/test_opa.py
@@ -3,15 +3,23 @@ import json
 import random
 from pathlib import Path
 
+from juju.utils import block_until_with_coroutine
 import pytest
 
 from .logger import log
-from .utils import JujuRunError, kubectl, scp_to, wait_for_application_status
+from .utils import (
+    JujuRunError,
+    kubectl,
+    scp_to,
+    wait_for_application_status,
+    kubectl_apply,
+    kubectl_delete,
+)
 
 templates = Path(__file__).parent / "templates"
 
 
-class TestOPA:
+class OPATestBase:
     @pytest.fixture(autouse=True)
     def setup(self, model, k8s_model, tools):
         self.model = model
@@ -21,19 +29,14 @@ class TestOPA:
         self.control_plane_unit = control_plane_app.units[0]
 
     async def validate_create_ns_with_label(self):
-        remote_path = "/tmp/validate-gatekeeper-policy.yaml"
-        await scp_to(
+        # Create the namespace
+        log("Creating namespace")
+        await kubectl_apply(
             templates / "validate-gatekeeper-policy.yaml",
             self.control_plane_unit,
-            remote_path,
-            self.tools.controller_name,
-            self.tools.connection,
+            self.tools,
+            self.model,
         )
-
-        # Create the namespace
-        cmd = f"apply -f {remote_path}"
-        log("Creating namespace")
-        await kubectl(self.model, cmd)
 
         # Wait for namespace to go active
         cmd = "get ns test-ns -o jsonpath='{.status.phase}'"
@@ -45,7 +48,12 @@ class TestOPA:
 
         # Delete the namespace
         cmd = "delete ns test-ns"
-        await kubectl(self.model, cmd)
+        await kubectl_delete(
+            templates / "validate-gatekeeper-policy.yaml",
+            self.control_plane_unit,
+            self.tools,
+            self.model,
+        )
 
     async def validate_create_ns(self, name=None):
         if not name:
@@ -82,7 +90,7 @@ class TestOPA:
                 "Error from server (InternalError): Internal error occurred"
             ):
                 # Try again as it might be transient/initialization related
-                await asyncio.sleep(7)
+                await asyncio.sleep(10)
                 try:
                     await kubectl(self.model, cmd)
                 except JujuRunError as e:
@@ -97,53 +105,53 @@ class TestOPA:
         )
 
     async def deploy_example_policy(self):
-        remote_policy_path = "/tmp/policy.yaml"
-        remote_policy_spec_path = "/tmp/policy-spec.yaml"
-        await scp_to(
+        await kubectl_apply(
             templates / "gatekeeper-policy.yaml",
             self.control_plane_unit,
-            remote_policy_path,
-            self.tools.controller_name,
-            self.tools.connection,
+            self.tools,
+            self.model,
         )
-        await scp_to(
+        await kubectl_apply(
             templates / "gatekeeper-policy-spec.yaml",
             self.control_plane_unit,
-            remote_policy_spec_path,
-            self.tools.controller_name,
-            self.tools.connection,
+            self.tools,
+            self.model,
         )
-        await kubectl(self.model, f"apply -f {remote_policy_path}")
-        await kubectl(self.model, f"apply -f {remote_policy_spec_path}")
 
     async def destroy_example_policy(self):
-        remote_path = "/tmp/policy.yaml"
-        await scp_to(
+        log("Delete example policy")
+        await kubectl_delete(
             templates / "gatekeeper-policy.yaml",
             self.control_plane_unit,
-            remote_path,
-            self.tools.controller_name,
-            self.tools.connection,
+            self.tools,
+            self.model,
         )
-        log("Delete example policy")
-        await kubectl(self.model, f"delete -f {remote_path}")
 
-    @pytest.fixture(scope="module")
-    async def storage_pool(self, model, k8s_model, tools):
+    @pytest.fixture(scope="class")
+    async def storage_class(self, model, k8s_model, tools):
         control_plane_app = model.applications["kubernetes-control-plane"]
         control_plane_unit = control_plane_app.units[0]
-        remote_path = "/tmp/storage-class.yaml"
-        storage_pool_name = "teststorage"
-        await scp_to(
-            templates / "integrator-charm-data" / "vsphere" / "storage-class.yaml",
-            control_plane_unit,
-            remote_path,
-            tools.controller_name,
-            tools.connection,
-        )
-        log("Creating storage class")
         try:
-            await kubectl(model, f"create -f {remote_path}")
+            await kubectl_apply(
+                templates / "integrator-charm-data" / "vsphere" / "storage-class.yaml",
+                control_plane_unit,
+                tools,
+                model,
+            )
+            yield
+        finally:
+            await kubectl_delete(
+                templates / "integrator-charm-data" / "vsphere" / "storage-class.yaml",
+                control_plane_unit,
+                tools,
+                model,
+            )
+
+    @pytest.fixture(scope="class")
+    async def storage_pool(self, model, k8s_model, tools, storage_class):
+        storage_pool_name = "teststorage"
+        log("Creating storage pool")
+        try:
             await tools.run(
                 "juju",
                 "create-storage-pool",
@@ -155,17 +163,90 @@ class TestOPA:
             )
             yield storage_pool_name
         finally:
-            log("Removing storage class")
-            try:
-                await kubectl(model, f"delete -f {remote_path}")
-            finally:
-                await tools.run(
-                    "juju",
-                    "remove-storage-pool",
-                    "-m",
-                    tools.k8s_connection,
-                    storage_pool_name,
-                )
+            log("Removing storage pool")
+            await tools.run(
+                "juju",
+                "remove-storage-pool",
+                "-m",
+                tools.k8s_connection,
+                storage_pool_name,
+            )
+
+    @pytest.fixture(scope="class")
+    async def update_status_interval(self, tools, k8s_model):
+        interval = await tools.run(
+            "juju",
+            "model-config",
+            "-m",
+            tools.k8s_connection,
+            "update-status-hook-interval",
+        )
+        interval = interval[0].strip()
+        try:
+            log("Decrease update status hook interval")
+            await tools.run(
+                "juju",
+                "model-config",
+                "-m",
+                tools.k8s_connection,
+                "update-status-hook-interval=5s",
+            )
+            yield
+        finally:
+            await tools.run(
+                "juju",
+                "model-config",
+                "-m",
+                tools.k8s_connection,
+                f"update-status-hook-interval={interval}",
+            )
+
+    @pytest.fixture(scope="class")
+    async def opa_controller_manager(self, model, k8s_model, tools):
+        try:
+            log("Deploying the webhook charm")
+            webhook = await k8s_model.deploy(
+                "gatekeeper-controller-manager",
+                channel=tools.charm_channel,
+                trust=True,
+            )
+            yield webhook
+        finally:
+            log("Deleting the gatekeeper charm")
+            await tools.run(
+                "juju",
+                "remove-application",
+                "-m",
+                tools.k8s_connection,
+                "--force",
+                "gatekeeper-controller-manager",
+            )
+            await self.wait_for_app_removed("gatekeeper-controller-manager", k8s_model)
+
+    @pytest.fixture(scope="class")
+    async def opa_audit(self, model, k8s_model, tools, storage_pool):
+        try:
+            log("Deploying the audit charm")
+            audit = await k8s_model.deploy(
+                "gatekeeper-audit",
+                channel=tools.charm_channel,
+                trust=True,
+                storage={"audit-volume": {"pool": storage_pool}},
+                config={"audit-interval": 1},
+            )
+            yield audit
+        finally:
+            log("Deleting the audit charm")
+            await tools.run(
+                "juju",
+                "remove-application",
+                "-m",
+                tools.k8s_connection,
+                "--force",
+                "--destroy-storage",
+                "gatekeeper-audit",
+            )
+            await self.wait_for_app_removed("gatekeeper-audit", k8s_model)
 
     async def _validate_audit_actions(self, unit):
         log("Running list-violations action")
@@ -191,140 +272,67 @@ class TestOPA:
         await action.wait()
         assert len(json.loads(action.results["violations"])) > 0
 
-    async def wait_for_units(self, app, error_status=("blocked", "error")):
+    async def wait_for_units(
+        self, app, error_status=("blocked", "error"), expected_status="active"
+    ):
         while (
             status := app.units[0].workload_status if app.units else None
-        ) != "active":
+        ) != expected_status:
             assert status not in error_status
             await asyncio.sleep(5)
 
-    @pytest.mark.clouds(["vsphere"])
-    async def test_opa_webhook(self, storage_pool):
-        log("Deploying the gatekeeper charm")
-        webhook = await self.k8s_model.deploy(
-            "gatekeeper-controller-manager",
-            channel=self.tools.charm_channel,
-            trust=True,
-        )
+    async def wait_for_app_removed(self, app_name, k8s_model=None):
+        if not k8s_model:
+            k8s_model = self.k8s_model
+
+        async def check_app_missing():
+            apps = await k8s_model.get_status()
+            return app_name not in apps.applications
 
         try:
-            await self.wait_for_units(webhook)
-            unit = webhook.units[0]
+            await block_until_with_coroutine(check_app_missing, timeout=120)
+        except asyncio.TimeoutError as e:
+            raise AssertionError(f"Application {app_name} was not removed")
 
-            log("Waiting for gatekeeper charm to be ready")
-            await wait_for_application_status(
-                self.k8s_model, "gatekeeper-controller-manager", status="active"
-            )
 
-            try:
-                await self.validate_create_ns()
-            except JujuRunError as e:
-                if e.output.startswith(
-                    "Error from server (InternalError): Internal error occurred"
-                ):
-                    # Try again as it might be transient/initialization related
-                    await asyncio.sleep(5)
-                    await self.validate_create_ns()
-                else:
-                    raise
-            log("Creating policy and constraint crds")
-            await self.deploy_example_policy()
-            log("Test that the policy is enforced")
-            await self.validate_create_ns_fail()
-            await self.validate_create_ns_with_label()
-            await self.destroy_example_policy()
+@pytest.mark.clouds(["vsphere"])
+class TestOPAWebhook(OPATestBase):
+    async def test_opa_webhook_ready(self, opa_controller_manager):
+        await self.wait_for_units(opa_controller_manager)
+        unit = opa_controller_manager.units[0]
 
-            log("Deploying the audit charm")
-            audit = await self.k8s_model.deploy(
-                "gatekeeper-audit",
-                channel=self.tools.charm_channel,
-                trust=True,
-                storage={"audit-volume": {"pool": storage_pool}},
-                config={"audit-interval": 1},
-            )
-            await self.wait_for_units(audit)
+        log("Waiting for gatekeeper charm to be ready")
+        await wait_for_application_status(
+            self.k8s_model, "gatekeeper-controller-manager", status="active"
+        )
 
-            try:
-                await self.deploy_example_policy()
-                log("Test that the policy is enforced")
-                await self.validate_create_ns_fail()
-                await self.validate_create_ns_with_label()
-                await self._validate_audit_actions(audit.units[0])
-                await self.destroy_example_policy()
-                log("Validate that the policy is no longer enforced")
-                await self.validate_create_ns()
-            finally:
-                log("Deleting the audit charm")
-                await self.tools.run(
-                    "juju",
-                    "remove-application",
-                    "-m",
-                    self.tools.k8s_connection,
-                    "--force",
-                    "--destroy-storage",
-                    "gatekeeper-audit",
-                )
-                while audit.units:
-                    await asyncio.sleep(5)
-
-            interval = await self.tools.run(
-                "juju",
-                "model-config",
-                "-m",
-                self.tools.k8s_connection,
-                "update-status-hook-interval",
-            )
-            interval = interval[0].strip()
-            try:
-                log("Decrease update status hook interval")
-                await self.tools.run(
-                    "juju",
-                    "model-config",
-                    "-m",
-                    self.tools.k8s_connection,
-                    "update-status-hook-interval=5s",
-                )
-                log("Waiting for status to change to blocked")
-                await self.wait_for_units(webhook, error_status=("error",))
-                log("Reconcile resources")
-                await unit.run_action("reconcile-resources")
-                while (
-                    status := webhook.units[0].workload_status
-                    if webhook.units
-                    else None
-                ) != "active":
-                    assert status != "error"
-                    await asyncio.sleep(5)
-            finally:
-                await self.tools.run(
-                    "juju",
-                    "model-config",
-                    "-m",
-                    self.tools.k8s_connection,
-                    f"update-status-hook-interval={interval}",
-                )
-
-            # Check that the webhook works
+    async def test_create_ns_no_policy(self, opa_controller_manager):
+        try:
             await self.validate_create_ns()
-            log("Creating policy and constraint crds")
-            await self.deploy_example_policy()
-            log("Test that the policy is enforced")
+        except JujuRunError as e:
+            if e.output.startswith(
+                "Error from server (InternalError): Internal error occurred"
+            ):
+                # Try again as it might be transient/initialization related
+                await asyncio.sleep(5)
+                await self.validate_create_ns()
+            else:
+                raise
+
+    async def test_policy_enforcement(self, opa_controller_manager):
+        log("Creating policy and constraint crds")
+        await self.deploy_example_policy()
+        log("Test that the policy is enforced")
+        try:
             await self.validate_create_ns_fail()
             await self.validate_create_ns_with_label()
-            await self.destroy_example_policy()
         finally:
-            log("Deleting the gatekeeper charm")
-            await self.tools.run(
-                "juju",
-                "remove-application",
-                "-m",
-                self.tools.k8s_connection,
-                "gatekeeper-controller-manager",
-            )
+            await self.destroy_example_policy()
 
-    @pytest.mark.clouds(["vsphere"])
-    async def test_opa_audit(self, storage_pool):
-        log("Deploying the gatekeeper charm")
+    async def test_audit_deploy(
+        self, opa_controller_manager, update_status_interval, storage_pool
+    ):
+        log("Deploying the audit charm")
         audit = await self.k8s_model.deploy(
             "gatekeeper-audit",
             channel=self.tools.charm_channel,
@@ -332,69 +340,21 @@ class TestOPA:
             storage={"audit-volume": {"pool": storage_pool}},
             config={"audit-interval": 1},
         )
-        await self.wait_for_units(audit)
 
-        unit = audit.units[0]
-
-        log("Waiting for gatekeeper charm to be ready")
-        await wait_for_application_status(
-            self.k8s_model, "gatekeeper-audit", status="active"
-        )
+        log("Waiting for audit charm to be ready")
         try:
-            await self.validate_create_ns()
-            log("Creating policy and constraint crds")
+            await self.wait_for_units(audit)
+
             await self.deploy_example_policy()
-
-            await self._validate_audit_actions(unit)
-
-            log("Deploying the gatekeeper charm")
-            webhook = await self.k8s_model.deploy(
-                "gatekeeper-controller-manager",
-                channel=self.tools.charm_channel,
-                trust=True,
-            )
-            await self.wait_for_units(webhook)
-            await wait_for_application_status(
-                self.k8s_model, "gatekeeper-controller-manager", status="active"
-            )
-
             log("Test that the policy is enforced")
             await self.validate_create_ns_fail()
             await self.validate_create_ns_with_label()
-            log("Deleting the gatekeeper charm")
-            await webhook.destroy()
-
-            interval = await self.tools.run(
-                "juju",
-                "model-config",
-                "-m",
-                self.tools.k8s_connection,
-                "update-status-hook-interval",
-            )
-            interval = interval[0].strip()
-            try:
-                log("Decrease update status hook interval")
-                await self.tools.run(
-                    "juju",
-                    "model-config",
-                    "-m",
-                    self.tools.k8s_connection,
-                    "update-status-hook-interval=5s",
-                )
-                log("Waiting for status to change to blocked")
-                await self.wait_for_units(audit, error_status=("error"))
-                log("Reconcile resources")
-                await unit.run_action("reconcile-resources")
-                await self.wait_for_units(audit, error_status=("error"))
-            finally:
-                await self.tools.run(
-                    "juju",
-                    "model-config",
-                    "-m",
-                    self.tools.k8s_connection,
-                    f"update-status-hook-interval={interval}",
-                )
+            await self._validate_audit_actions(audit.units[0])
+            await self.destroy_example_policy()
+            log("Validate that the policy is no longer enforced")
+            await self.validate_create_ns()
         finally:
+            log("Deleting the audit charm")
             await self.tools.run(
                 "juju",
                 "remove-application",
@@ -404,5 +364,78 @@ class TestOPA:
                 "--destroy-storage",
                 "gatekeeper-audit",
             )
-            while audit.units:
-                await asyncio.sleep(5)
+            await self.wait_for_app_removed("gatekeeper-audit")
+
+    async def test_manager_reconcile(
+        self, opa_controller_manager, update_status_interval
+    ):
+        await self.wait_for_units(
+            opa_controller_manager, error_status=("error",), expected_status="blocked"
+        )
+        log("Reconcile resources")
+        await opa_controller_manager.units[0].run_action("reconcile-resources")
+        await self.wait_for_units(opa_controller_manager, error_status=("error",))
+
+        # Check that the opa_controller_manager works
+        await self.validate_create_ns()
+        log("Creating policy and constraint crds")
+        await self.deploy_example_policy()
+        log("Test that the policy is enforced")
+        await self.validate_create_ns_fail()
+        await self.validate_create_ns_with_label()
+        await self.destroy_example_policy()
+
+
+@pytest.mark.clouds(["vsphere"])
+class TestOPAAudit(OPATestBase):
+    async def test_opa_audit_ready(self, opa_audit):
+        await self.wait_for_units(opa_audit)
+
+        log("Waiting for audit charm to be ready")
+        await wait_for_application_status(
+            self.k8s_model, "gatekeeper-audit", status="active"
+        )
+
+    async def test_create_ns_no_policy(self, opa_audit):
+        await self.validate_create_ns()
+
+    async def test_policy_auditing(self, opa_audit, update_status_interval):
+        log("Creating policy and constraint crds")
+        await self.deploy_example_policy()
+        await self._validate_audit_actions(opa_audit.units[0])
+
+    @pytest.mark.dependency()
+    async def test_manager_deploy(self, opa_audit, update_status_interval):
+        log("Deploying the gatekeeper charm")
+        webhook = await self.k8s_model.deploy(
+            "gatekeeper-controller-manager",
+            channel=self.tools.charm_channel,
+            trust=True,
+        )
+        try:
+            await self.wait_for_units(webhook)
+            await wait_for_application_status(
+                self.k8s_model, "gatekeeper-controller-manager", status="active"
+            )
+
+            log("Test that the policy is enforced")
+            await self.validate_create_ns_fail()
+            await self.validate_create_ns_with_label()
+        finally:
+            log("Deleting the gatekeeper charm")
+            await webhook.destroy()
+            await self.wait_for_app_removed("gatekeeper-controller-manager")
+
+    @pytest.mark.dependency(depends=["test_manager_deploy"])
+    async def test_audit_reconcile(self, opa_audit, update_status_interval):
+        log("Waiting for status to change to blocked")
+        await self.wait_for_units(
+            opa_audit, error_status=("error",), expected_status="blocked"
+        )
+        log("Reconcile resources")
+        await opa_audit.units[0].run_action("reconcile-resources")
+        await self.wait_for_units(opa_audit, error_status=("error",))
+
+        log("Creating policy and constraint crds")
+        await self.deploy_example_policy()
+        await self._validate_audit_actions(opa_audit.units[0])

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -467,6 +467,15 @@ async def wait_for_status(workload_status, units):
         ) from e
 
 
+async def wait_for_application_status(model, app_name, status="active"):
+    while True:
+        apps = await model.get_status()
+        app = apps.applications[app_name]
+        if app.status.status == status:
+            return
+        await asyncio.sleep(5)
+
+
 async def prep_series_upgrade(machine, new_series, tools):
     log.info(f"preparing series upgrade for machine {machine.id}")
     await tools.run(

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -3,7 +3,6 @@ import functools
 import ipaddress
 import json
 import os
-import random
 import subprocess
 import time
 import traceback
@@ -477,7 +476,7 @@ async def wait_for_application_status(model, app_name, status="active"):
 
     try:
         await block_until_with_coroutine(check_app_status, timeout=120)
-    except asyncio.TimeoutError as e:
+    except asyncio.TimeoutError:
         apps = await model.get_status()
         app = apps.applications[app_name]
         raise AssertionError(f"Application has unexpected status: {app.status.status}")


### PR DESCRIPTION
Adds tests for the gatekeeper charms.

The `gatekeeper-audit` charm requires storage, this means that I had to define a `storageClass` and a juju `storage-pool`. I used the `vsphere` provisioner assuming that the jobs will run on vsphere, is this correct?

The tests are not only testing the correctness of each charm on its own, but also the integration of one charm with the other (ie. deploy first one charm and then the other, remove one charm, deploy -> apply policy -> deploy the other, etc)
