### PR TITLE
ensure oci-images are sunk with 1.25

### DIFF
--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,10 +16,10 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.24'
+          default: '1.25'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
-            exists (otherwise 'master'), then process the image list for this `version`.
+            exists (otherwise 'main'), then process the image list for this `version`.
       - string:
           name: k8s_tag
           default: ''


### PR DESCRIPTION
We were missing a `1.25-upstream` line in our `container-images.txt` file (in the bundle repo), which led to an incomplete container listing for the 1.25 release.  This is because we didn't sync upstream oci images for 1.25.  Let's do that.