### PR TITLE
update template language; add a jjb checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
 ---
+Mark below if this PR requires a job refresh (`jjb`) after merge:
+
+- [ ] Needs `jjb` after merge
 
 Please make sure to open PR's against the correct code:
 
-- For integration tests please make those changes in `jobs/integration`
-- For MicroK8s, those changes are in `jobs/build-microk8s`
-- For charm builds, `jobs/build-charms`
-- For bundle builds, `jobs/build-bundles`
+- For integration tests, please make changes in `jobs/integration`
+- For validation envs, `jobs/validate`
+- For MicroK8s,`jobs/microk8s`
+- For charm/bundle builds, `jobs/build-charms`


### PR DESCRIPTION
Update our jenkins PR template with accurate locations and add a checkbox if submitters know that a PR will need a `jjb` run.