### PR TITLE
use the layer/charm options for minimum channel support in the release jobs

### DIFF
--- a/cilib/version.py
+++ b/cilib/version.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from typing import Optional, Union
 import semver
 from cilib import log
 
@@ -33,3 +35,84 @@ def greater(version_a, version_b):
 def lesser(version_a, version_b):
     """Check that version_a < version_b"""
     return compare(version_a, version_b) <= 0
+
+
+RISKS = ["stable", "candidate", "beta", "edge"]
+
+
+@dataclass
+class Release:
+    """Representation of Charm or Snap Release version."""
+
+    major: int
+    minor: int
+    risk: Optional[str]
+
+    def __str__(self):
+        risk = ""
+        if self.risk:
+            risk = f"/{self.risk}" if self.risk.lower() in RISKS else ""
+        return f"{self.major}.{self.minor}{risk}"
+
+    def _as_cmp(self):
+        return (
+            self.major,
+            self.minor,
+            RISKS[::-1].index(self.risk.lower()) + 1 if self.risk else 0,
+        )
+
+    @classmethod
+    def mk(cls, rel: str) -> "Release":
+        has_risk = rel.split("/")
+        if len(has_risk) == 2:
+            track, risk = has_risk
+        else:
+            track, risk = has_risk[0], None
+        return cls(*map(int, track.split(".")), risk)
+
+    def __eq__(self, other: "Release") -> bool:
+        return self._as_cmp() == other._as_cmp()
+
+    def __gt__(self, other: "Release") -> bool:
+        return self._as_cmp() > other._as_cmp()
+
+    def __lt__(self, other: "Release") -> bool:
+        return self._as_cmp() < other._as_cmp()
+
+
+@dataclass
+class ChannelRange:
+    """Determine if channel is within a channel range.
+
+    Usage:
+        assert "latest/edge" in ChannelRange("1.18", "1.25/stable") # latest/<anything> is ignored
+        assert "1.24/edge" in ChannelRange("1.18", "1.25/stable")   # within bounds inclusively
+        assert "1.24/edge" in ChannelRange("1.18", None)            # No upper bound
+        assert "1.24/edge" in ChannelRange(None, "1.25/stable")     # No lower bound
+        assert "1.24/edge" in ChannelRange(None, None)              # No bounds
+    """
+
+    _min: Optional[str]
+    _max: Optional[str]
+
+    @property
+    def min(self) -> Optional[Release]:
+        """Release object representing the minimum."""
+        return self._min and Release.mk(self._min)
+
+    @property
+    def max(self) -> Optional[Release]:
+        """Release object representing the maximum."""
+        return self._max and Release.mk(self._max)
+
+    def __contains__(self, other: Union[str, Release]) -> bool:
+        """Implements comparitor."""
+        if isinstance(other, str) and other.startswith("latest"):
+            return True
+        if not isinstance(other, Release):
+            other = Release.mk(str(other))
+        if self.min and other < self.min:
+            return False
+        if self.max and other > self.max:
+            return False
+        return True

--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -187,7 +187,7 @@ def _rename_branch(
                 log.info(f"Skipping  :: {layer_name:^40} :: {to_name} already exists")
                 continue
 
-            log.info(f"Renaming :: {layer_name:^40} :: from: {from_name} to:{to_name}")
+            log.info(f"Renaming  :: {layer_name:^40} :: from: {from_name} to:{to_name}")
 
             try:
                 repo.rename_branch(from_name, to_name)

--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -38,7 +38,15 @@ from cilib.service.snap import SnapService
 from cilib.service.deb import DebService, DebCNIService, DebCriToolsService
 from cilib.service.ppa import PPAService
 from cilib.service.charm import CharmService
+from cilib.version import ChannelRange
 from drypy import dryrun
+
+
+def channel_range(entity):
+    range_def = entity.get("channel-range", {})
+    definitions = range_def.get("min"), range_def.get("max")
+    assert all(isinstance(_, (str, type(None))) for _ in definitions)
+    return ChannelRange(*definitions)
 
 
 @click.group()
@@ -81,7 +89,9 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
         for layer_name, params in layer_map.items():
             downstream = params["downstream"]
             if not params.get("needs_stable", True):
-                log.info(f"Skipping {layer_name} :: does not require stable branch")
+                log.info(
+                    f"Skipping  :: {layer_name:^40} :: does not require stable branch"
+                )
                 continue
 
             tags = params.get("tags", None)
@@ -89,18 +99,24 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
                 if not any(match in filter_by_tag for match in tags):
                     continue
 
+            if not stable_release in channel_range(params):
+                log.info(
+                    f"Skipping  :: {layer_name:^40} :: out of supported channel-range"
+                )
+                continue
+
             repo = Repository.with_session(*downstream.split("/"), read_only=dry_run)
             default_branch = params.get("branch") or repo.default_branch
 
-            log.info(
-                f"Releasing :: {layer_name:^35} :: from: {default_branch} to:{new_branch} "
-            )
-
             if new_branch in repo.branches:
                 log.info(
-                    f"Skipping  :: {layer_name:^35} :: {new_branch} already exists"
+                    f"Skipping  :: {layer_name:^40} :: {new_branch} already exists"
                 )
                 continue
+
+            log.info(
+                f"Releasing :: {layer_name:^40} :: from: {default_branch} to:{new_branch}"
+            )
 
             try:
                 repo.copy_branch(default_branch, new_branch)
@@ -156,21 +172,22 @@ def _rename_branch(
                     continue
 
             if not params.get("supports_rename", True):
-                log.info(f"Skipping {layer_name} :: does not support branch renaming")
+                log.info(
+                    f"Skipping  :: {layer_name:^40} :: does not support branch renaming"
+                )
                 continue
 
             repo = Repository.with_session(*downstream.split("/"), read_only=dry_run)
-            log.info(
-                f"Renaming Branch:: {layer_name:^35} :: from: {from_name} to:{to_name}"
-            )
 
             if from_name not in repo.branches:
-                log.info(f"Skipping  :: {layer_name:^35} :: {from_name} doesn't exist")
+                log.info(f"Skipping  :: {layer_name:^40} :: {from_name} doesn't exist")
                 continue
 
             if to_name in repo.branches:
-                log.info(f"Skipping  :: {layer_name:^35} :: {to_name} already exists")
+                log.info(f"Skipping  :: {layer_name:^40} :: {to_name} already exists")
                 continue
+
+            log.info(f"Renaming :: {layer_name:^40} :: from: {from_name} to:{to_name}")
 
             try:
                 repo.rename_branch(from_name, to_name)
@@ -207,7 +224,13 @@ def _tag_stable_forks(
                     continue
 
             if not params.get("needs_tagging", True):
-                log.info(f"Skipping {layer_name} :: does not require tagging")
+                log.info(f"Skipping  :: {layer_name:^40} :: does not require tagging")
+                continue
+
+            if not k8s_version in channel_range(params):
+                log.info(
+                    f"Skipping  :: {layer_name:^40} :: out of supported channel-range"
+                )
                 continue
 
             downstream = params["downstream"]
@@ -217,12 +240,11 @@ def _tag_stable_forks(
                 tag = f"ck-{k8s_version}-{bundle_rev}"
             repo = Repository.with_session(*downstream.split("/"), read_only=dry_run)
 
-            log.info(f"Tagging {layer_name} ({tag}) :: {downstream}")
-
             if tag in repo.tags:
-                log.info(f"Skipping  :: {layer_name:^35} :: {tag} already exists")
+                log.info(f"Skipping  :: {layer_name:^40} :: {tag} already exists")
                 continue
 
+            log.info(f"Tagging   :: {layer_name:^40} :: {downstream} ({tag})")
             try:
                 repo.tag_branch(stable_branch, tag)
             except HTTPError:

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -39,54 +39,6 @@ def test_matched_numerical_channel(charms, risk, expected):
     assert charms.matched_numerical_channel(risk, track_map) == expected
 
 
-@pytest.mark.parametrize(
-    "a, b",
-    [
-        ("2.15/edge", "2.14/EDGE"),
-        ("0.15/stable", "0.15/candidate"),
-        ("0.15/candidate", "0.15/beta"),
-        ("0.15/beta", "0.15/edge"),
-        ("0.15/edge", "0.15"),
-    ],
-)
-def test_release_comparitors(charms, a, b):
-    a, b = map(charms.Release.mk, (a, b))
-    assert a > b
-    assert b < a
-    assert a != b
-
-
-@pytest.mark.parametrize(
-    "channel",
-    [
-        "2.15/edge",
-        "0.15/stable",
-        "0.15/candidate",
-        "0.15/beta",
-    ],
-)
-def test_channel_comparitor(charms, channel):
-    # latest/<anything> is excluded from channel range comparison
-    assert "latest/banana" in charms.ChannelRange("0.15/edge", "0.15/edge")
-
-    # all channels are excluded from channel range comparison without min or max
-    assert channel in charms.ChannelRange(None, None)
-
-    # all channel params are greater than 0.14 and 0.14/stable
-    assert channel in charms.ChannelRange("0.14", None)
-    assert channel in charms.ChannelRange("0.14/stable", None)
-
-    # all channel params are less than 2.15/edge and 2.16
-    assert channel in charms.ChannelRange(None, "2.15/edge")
-    assert channel in charms.ChannelRange(None, "2.16")
-
-    # all channel params fall outside the range starting at 2.15/candidate
-    assert channel not in charms.ChannelRange("2.15/candidate", None)
-
-    # all channel params fall outside the range ending at 0.15/edge
-    assert channel not in charms.ChannelRange(None, "0.15/edge")
-
-
 def test_build_env_missing_env(charms):
     """Ensure missing environment variables raise Exception."""
     with pytest.raises(charms.BuildException) as ie:

--- a/tests/unit/cilib/test_version.py
+++ b/tests/unit/cilib/test_version.py
@@ -1,0 +1,50 @@
+import pytest
+import cilib.version as version
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        ("2.15/edge", "2.14/EDGE"),
+        ("0.15/stable", "0.15/candidate"),
+        ("0.15/candidate", "0.15/beta"),
+        ("0.15/beta", "0.15/edge"),
+        ("0.15/edge", "0.15"),
+    ],
+)
+def test_release_comparitors(a, b):
+    a, b = map(version.Release.mk, (a, b))
+    assert a > b
+    assert b < a
+    assert a != b
+
+
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "2.15/edge",
+        "0.15/stable",
+        "0.15/candidate",
+        "0.15/beta",
+    ],
+)
+def test_channel_comparitor(channel):
+    # latest/<anything> is excluded from channel range comparison
+    assert "latest/banana" in version.ChannelRange("0.15/edge", "0.15/edge")
+
+    # all channels are excluded from channel range comparison without min or max
+    assert channel in version.ChannelRange(None, None)
+
+    # all channel params are greater than 0.14 and 0.14/stable
+    assert channel in version.ChannelRange("0.14", None)
+    assert channel in version.ChannelRange("0.14/stable", None)
+
+    # all channel params are less than 2.15/edge and 2.16
+    assert channel in version.ChannelRange(None, "2.15/edge")
+    assert channel in version.ChannelRange(None, "2.16")
+
+    # all channel params fall outside the range starting at 2.15/candidate
+    assert channel not in version.ChannelRange("2.15/candidate", None)
+
+    # all channel params fall outside the range ending at 0.15/edge
+    assert channel not in version.ChannelRange(None, "0.15/edge")

--- a/tests/unit/sync_upstream/test_sync.py
+++ b/tests/unit/sync_upstream/test_sync.py
@@ -42,7 +42,7 @@ def test_sync_no_default_branch(mock_base, sync):
 def test_sync_cut_stable_release(mock_copy_branch, sync):
     """Tests that cut stable release job creates a new branch from the default branch."""
     runner = CliRunner()
-    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("1.2.3", None)]):
+    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("100.23", None)]):
         result = runner.invoke(
             sync.cut_stable_release,
             [
@@ -54,7 +54,7 @@ def test_sync_cut_stable_release(mock_copy_branch, sync):
             ],
         )
     assert result.exception is None
-    mock_copy_branch.assert_called_once_with("main", "release_1.2.3")
+    mock_copy_branch.assert_called_once_with("main", "release_100.23")
 
 
 @mock.patch("sync.Repository.default_branch", mock.PropertyMock(return_value="main"))
@@ -63,35 +63,35 @@ def test_sync_cut_stable_release(mock_copy_branch, sync):
 def test_tag_stable_bundle(mock_tag_branch, sync):
     """Tests that tag stable bundle job creates a tags selected branch with release."""
     runner = CliRunner()
-    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("1.2.3", None)]):
+    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("100.23", None)]):
         result = runner.invoke(
             sync.tag_stable,
             [
                 "--layer-list=jobs/includes/charm-layer-list.inc",
                 "--charm-list=jobs/includes/charm-support-matrix.inc",
-                "--k8s-version=1.2.3",
+                "--k8s-version=100.23",
                 "--bundle-revision=1234",
                 "--dry-run",
                 "--filter-by-tag=calico",
             ],
         )
     assert result.exception is None
-    mock_tag_branch.assert_called_once_with("release_1.2.3", "ck-1.2.3-1234")
+    mock_tag_branch.assert_called_once_with("release_100.23", "ck-100.23-1234")
 
 
 @mock.patch("sync.Repository.default_branch", mock.PropertyMock(return_value="main"))
-@mock.patch("sync.Repository.tags", mock.PropertyMock(return_value=["ck-1.2.3-1234"]))
+@mock.patch("sync.Repository.tags", mock.PropertyMock(return_value=["ck-100.23-1234"]))
 @mock.patch("sync.Repository.tag_branch")
 def test_tag_stable_bugfix(mock_tag_branch, sync):
     """Tests that tag stable bundle job creates a tags selected branch with release."""
     runner = CliRunner()
-    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("1.2.3", None)]):
+    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("100.23", None)]):
         result = runner.invoke(
             sync.tag_stable,
             [
                 "--layer-list=jobs/includes/charm-layer-list.inc",
                 "--charm-list=jobs/includes/charm-support-matrix.inc",
-                "--k8s-version=1.2.3",
+                "--k8s-version=100.23",
                 "--bundle-revision=ck2",
                 "--dry-run",
                 "--bugfix",
@@ -99,29 +99,29 @@ def test_tag_stable_bugfix(mock_tag_branch, sync):
             ],
         )
     assert result.exception is None
-    mock_tag_branch.assert_called_once_with("release_1.2.3", "1.2.3+ck2")
+    mock_tag_branch.assert_called_once_with("release_100.23", "100.23+ck2")
 
 
 @mock.patch(
     "sync.Repository.branches",
-    mock.PropertyMock(return_value=["main", "release_1.2.3"]),
+    mock.PropertyMock(return_value=["main", "release_100.23"]),
 )
 @mock.patch("sync.Repository.rename_branch")
 def test_rename_branch(mock_rename_branch, sync):
     """Tests that tag stable bundle job creates a tags selected branch with release."""
     runner = CliRunner()
-    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("1.2.3", None)]):
+    with mock.patch.object(sync, "SNAP_K8S_TRACK_LIST", [("100.23", None)]):
         result = runner.invoke(
             sync.rename_branch,
             [
                 "--layer-list=jobs/includes/charm-layer-list.inc",
                 "--charm-list=jobs/includes/charm-support-matrix.inc",
                 "--ancillary-list=jobs/includes/ancillary-list.inc",
-                "--from-name=release_1.2.3",
-                "--to-name=release-1.2.3",
+                "--from-name=release_100.23",
+                "--to-name=release-100.23",
                 "--dry-run",
                 "--filter-by-tag=calico",
             ],
         )
     assert result.exception is None
-    mock_rename_branch.assert_called_once_with("release_1.2.3", "release-1.2.3")
+    mock_rename_branch.assert_called_once_with("release_100.23", "release-100.23")


### PR DESCRIPTION
Moves the `ChannelRange` object and `Release` objects to `cilib.version` in order to spread its usage between build_charms and the other release jobs.  

any layer or charm can specify an option like this:

```yaml
    channel-range:
      min: '1.25'
      max: '1.30'
```

which bounds its channel range.  Both min and max are optional. 

Previously, these were only used by charm build job, but it's necessary to also be able to use these in other jobs (such as sync)