### PR TITLE
set 1.25 as the default stable

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -44,6 +44,7 @@ K8S_CRI_TOOLS_SEMVER = "1.19"
 
 # Kubernetes build source to go version map
 K8S_GO_MAP = {
+    "1.26": "go/1.19/stable",
     "1.25": "go/1.19/stable",
     "1.24": "go/1.18/stable",
     "1.23": "go/1.17/stable",
@@ -70,6 +71,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.23", ["1.23/stable", "1.23/candidate", "1.23/beta", "1.23/edge"]),
     ("1.24", ["1.24/stable", "1.24/candidate", "1.24/beta", "1.24/edge"]),
     ("1.25", ["1.25/stable", "1.25/candidate", "1.25/beta", "1.25/edge"]),
+    ("1.26", ["1.26/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -8,7 +8,7 @@ JOBS_PATH = Path("jobs")
 # Current supported STABLE K8s MAJOR.MINOR release. This determines what the
 # latest/stable channel is set to. It should be updated whenever a new CK
 # major.minor is GA.
-K8S_STABLE_VERSION = "1.24"
+K8S_STABLE_VERSION = "1.25"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
@@ -20,7 +20,7 @@ K8S_STABLE_VERSION = "1.24"
 K8S_NEXT_VERSION = "1.26"
 
 # Lowest K8S SEMVER to process, this is usually stable - 3
-K8S_STARTING_SEMVER = "1.21.0"
+K8S_STARTING_SEMVER = "1.22.0"
 
 # Supported arches
 K8S_SUPPORT_ARCHES = ["amd64", "ppc64el", "s390x", "arm64"]

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -92,7 +92,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.22', '1.23', '1.24', '1.25']
+    version: ['1.23', '1.24', '1.25', '1.26']
     jobs:
       - 'build-release-cdk-addons-{version}'
 

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -28,13 +28,12 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.24/stable
+            - 1.25/stable
       - axis:
           type: user-defined
           name: series
           values:
             - focal
-            - bionic
             - jammy
     builders:
       - set-env:
@@ -67,14 +66,14 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.25/stable
             - 1.24/stable
-            - 1.23/stable
       - axis:
           type: user-defined
           name: series
           values:
             - focal
-            - bionic
+            - jammy
       - axis:
           type: user-defined
           name: arch

--- a/jobs/release/bugfix-spec
+++ b/jobs/release/bugfix-spec
@@ -15,7 +15,7 @@ set -x
 ###############################################################################
 # ENV
 ###############################################################################
-SNAP_VERSION=${1:-1.24/stable}
+SNAP_VERSION=${1:-1.25/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=candidate

--- a/jobs/release/bugfix-upgrade-spec
+++ b/jobs/release/bugfix-upgrade-spec
@@ -37,10 +37,10 @@ function test::execute
 ###############################################################################
 # ENV
 ###############################################################################
-SNAP_VERSION_UPGRADE_TO=1.24/candidate
+SNAP_VERSION_UPGRADE_TO=1.25/candidate
 export SNAP_VERSION_UPGRADE_TO
 
-SNAP_VERSION=${1:-1.24/stable}
+SNAP_VERSION=${1:-1.25/stable}
 SERIES=${2:-focal}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=stable

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -31,13 +31,11 @@
             - 1.25/edge
             - 1.24/edge
             - 1.23/edge
-            - 1.22/edge
       - axis:
           type: user-defined
           name: series
           values:
             - focal
-            - bionic
             - jammy
       - axis:
           type: user-defined
@@ -88,9 +86,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.25/stable
             - 1.24/stable
             - 1.23/stable
-            - 1.22/stable
       - axis:
           type: user-defined
           name: series
@@ -150,7 +148,6 @@
             - 1.25/edge
             - 1.24/edge
             - 1.23/edge
-            - 1.22/edge
       - axis:
           type: user-defined
           name: series
@@ -208,8 +205,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.24/stable
             - 1.23/stable
-            - 1.22/stable
       - axis:
           type: user-defined
           name: series
@@ -256,7 +253,7 @@
     parameters:
       - string:
            name: SNAP_VERSION
-           default: 1.24/stable
+           default: 1.25/stable
       - string:
            name: SERIES
            default: focal
@@ -287,7 +284,7 @@
     parameters:
       - string:
            name: SNAP_VERSION
-           default: 1.24/stable
+           default: 1.25/stable
       - string:
            name: SERIES
            default: focal


### PR DESCRIPTION
- set current stable version to 1.25
- drop <= 1.22 from our matrix where appropriate (most tests only need to run against n-2)
- bionic is covered by `validate-ck-stable`; drop it for other jobs to reduce run time
- snap tracks [are open](https://forum.snapcraft.io/t/kubernetes-1-26-snap-tracks/31491) for 1.26; start building them

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge
  - `[build-snaps|release|validate].yaml`