### PR TITLE
upgrade protobuf from 3.15.6 -> 3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -204,7 +204,7 @@ ppft==1.7.6.5
     # via pathos
 prettytable==3.4.1
     # via -r requirements.in
-protobuf==3.15.6
+protobuf==3.20.1
     # via macaroonbakery
 py==1.10.0
     # via


### PR DESCRIPTION
I found that upgrading this package removed so many warnings from the validation runs.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge