### PR TITLE
pin pack charm-tools until all reactive charms can build with charmcraft

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -118,7 +118,7 @@
         - jenkins
       ignore_errors: yes
     - name: upgrade charm
-      command: "snap refresh charm --channel latest/edge"
+      command: "snap refresh charm --channel 2.x/stable"
       ignore_errors: yes
       tags:
         - jenkins


### PR DESCRIPTION
Pins charm-tools to 2.x branch until the builds can be migrated to using charmcraft. 

- [ ] Needs `jjb` after merge
