### PR TITLE
Nrpe/ignore space check

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2319,7 +2319,10 @@ async def nagios(model, tools):
             "nrpe",
             series=series,
             config=dict(
-                swap="", swap_activity="", ro_filesystem_excludes=",".join(excludes)
+                ro_filesystem_excludes=",".join(excludes),
+                space_check="check: disabled",  # don't run the space_check
+                swap="",
+                swap_activity="", 
             ),
             num_units=0,
             channel="stable",

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2322,7 +2322,7 @@ async def nagios(model, tools):
                 ro_filesystem_excludes=",".join(excludes),
                 space_check="check: disabled",  # don't run the space_check
                 swap="",
-                swap_activity="", 
+                swap_activity="",
             ),
             num_units=0,
             channel="stable",


### PR DESCRIPTION
ignore `space_check` during nagios tests

This test once turned up a positive critical check -- but just one that's pointless, a volume mount on one of the juju operator pods was "fullish" so it was a critical check

```
13:24:38 [validate-charm-bugfix-jammy-1.25-stable] >           raise asyncio.TimeoutError(timeout_msg.format(results))
13:24:38 [validate-charm-bugfix-jammy-1.25-stable] E           asyncio.exceptions.TimeoutError: Failed to stabalize nagios after after deployment
13:24:38 [validate-charm-bugfix-jammy-1.25-stable] E           alerts: 
13:24:38 [validate-charm-bugfix-jammy-1.25-stable] E           critical/juju-kubernetes-worker-1-check_space_var_lib_kubelet_pods_313f5416-1ead-4de4-b839-ee65c1bd5f46_volume-subpaths_modeloperator_juju-operator_0
13:24:38 [validate-charm-bugfix-jammy-1.25-stable] E           ---
```

and because it's pointless -- let's just ignore it.