### PR TITLE
resolve issue referencing string rather than unit object

### DIFF
--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -10,6 +10,7 @@ from typing import Mapping, Any
 
 from contextlib import contextmanager
 from juju.controller import Controller
+from juju.machine import Machine
 from juju.errors import JujuError
 from juju.utils import block_until_with_coroutine
 from subprocess import check_output, check_call
@@ -449,8 +450,10 @@ spec:
     )
 
 
-def _units(machine):
-    return [unit for unit in machine.model.units if unit.machine.id == machine.id]
+def _units(machine: Machine):
+    return [
+        unit for unit in machine.model.units.values() if unit.machine.id == machine.id
+    ]
 
 
 async def wait_for_status(workload_status, units):


### PR DESCRIPTION
Issue found in the ck-series-upgrade test:

`machine.model.units` is a `Mapping[str, Unit]`

```
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] machine = <Machine entity_id="4">
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable]     def _units(machine):
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] >       return [unit for unit in machine.model.units if unit.machine.id == machine.id]
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] jobs/integration/utils.py:453: 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] .0 = <dict_keyiterator object at 0x7f8d538a6130>
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] >   return [unit for unit in machine.model.units if unit.machine.id == machine.id]
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] E   AttributeError: 'str' object has no attribute 'machine'
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] 
17:17:41 [validate-ck-series-upgrade-focal-1.25-stable] jobs/integration/utils.py:453: AttributeError
```