### PR TITLE
Remove Multus resources

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -31,7 +31,5 @@
   calico-cni-arm64: '{out_path}/calico-cni-arm64.tar.gz'
   calicoctl-image: '{out_path}/calicoctl-image.tar.gz'
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
-'multus':
-  net-attach-def-manager-image: 'net-attach-def-manager'
 'sriov-cni':
   sriov-cni-image: 'sriov-cni'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -378,7 +378,6 @@
     upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
 - multus:
     bugs: 'https://bugs.launchpad.net/charm-multus'
-    build-resources: 'cd {src_path}/net-attach-def-manager; ./build'
     docs: 'https://charmhub.io/multus/docs'
     downstream: charmed-kubernetes/charm-multus
     store: 'https://charmhub.io/multus'


### PR DESCRIPTION
## Changes
The recent [conversion](https://github.com/charmed-kubernetes/charm-multus/pull/20) of the Multus charm to the Sidecar pattern removed the need for an external image to manage the NADs lifecycle.

This PR removes the image from our CI jobs.

Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge
