### PR TITLE
parse sh.RunningCommand.stdout rather than str-like object

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -89,7 +89,7 @@ def generate_manifest(reactive_charm, archs):
         }
 
     def _generate_tools():
-        ret = json.loads(sh.charm.version(format="json"))
+        ret = json.loads(sh.charm.version(format="json").stdout)
         return {
             "charmtool-version": ret["charm-tools"]["version"],
             "charmtool-started-at": datetime.utcnow().isoformat() + "Z",

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -102,7 +102,7 @@ def charm_cmd():
         )
 
     with patch("sh.charm", create=True) as charm:
-        charm.version.return_value = '{"charm-tools": {"version": "1.2.3"}}'
+        charm.version.return_value.stdout = '{"charm-tools": {"version": "1.2.3"}}'
         cmd = charm.bake.return_value
         cmd.build.side_effect = partial(command_response, "build")
         yield cmd


### PR DESCRIPTION
https://amoffat.github.io/sh/sections/command_class.html#running-command demonstrates you cannot `json.loads(sh.command())`

