### PR TITLE
gcp purge resources

### DIFF
--- a/jobs/infra/fixtures/cleanup-env.sh
+++ b/jobs/infra/fixtures/cleanup-env.sh
@@ -109,8 +109,8 @@ function purge::aws
     # aws --region us-east-2 ec2 describe-security-groups --filters Name=owner-id,Values=018302341396 --query "SecurityGroups[*].{Name:GroupId}" --output json | jq -r '.[].Name' | parallel aws --region us-east-1 ec2 delete-security-group --group-id "{}"
 }
 
-purge:aws
-purge:gce
+purge::aws
+purge::gce
 
 sudo lxc list --format json | jq -r ".[] | .name" | parallel sudo lxc delete --force {}
 for cntr in $(sudo lxc profile list --format json | jq -r ".[] | .name"); do

--- a/jobs/infra/fixtures/cleanup-gce.sh
+++ b/jobs/infra/fixtures/cleanup-gce.sh
@@ -7,65 +7,64 @@ fi
 echo "sourced ${BASH_SOURCE:-$0}"
 
 
-function purge:gce:instances
+function purge::gce::instances
 {
     local user="$1"
-    local project="--project=$2"
     local fields="--format=table[no-heading](name,zone)"
     local filter="--filter=metadata.items.filter(key:owner).flatten()~$user"
     echo "Fetching GCE instances..."
-    local instances=$(gcloud compute instances list $project $fields $filter)
+    local instances=$(gcloud compute instances list $fields $filter)
     echo -n "Purging GCE instances..."
     if [ -z "$instances" ]; then
         echo "None"
     else
         echo -e "\n$instances\n----"
         while read -r host zone; do
-            echo gcloud compute instances delete $host --zone $zone $project --quiet
+            echo gcloud compute instances delete $host --zone $zone --quiet
         done <<< "$instances"
     fi
 }
 
-function purge:gce:service_accounts
+function purge::gce::service_accounts
 {
-    local project="--project=${1}"
     local fields="--format=table[no-heading](email)"
     local filter="--filter=email:juju-gcp-"
     echo "Fetching GCE Service Accounts..."
-    local service_accounts=$(gcloud iam service-accounts list $project $fields $filter)
+    local service_accounts=$(gcloud iam service-accounts list $fields $filter)
     echo -n "Purging GCE Service Accounts..."
     if [ -z "$service_accounts" ]; then
         echo "None"
     else
         echo -e "\n$service_accounts\n----"
         while read -r email; do
-            purge:gce:service_account_keys "$email" "$1"
-            gcloud iam service-accounts delete $email $project --quiet
+            purge::gce::service_account_keys "$email" "$1"
+            gcloud iam service-accounts delete $email --quiet
         done <<< "$service_accounts"
     fi
 }
 
-function purge:gce:service_account_keys
+function purge::gce::service_account_keys
 {
     local iam="--iam-account=${1}"
-    local project="--project=${2}"
     local fields="--format=table[no-heading](name)"
     local filter="--filter=keyType:USER_MANAGED"
-    local keys=$(gcloud iam service-accounts keys list $project $iam $fields $filter)
+    local keys=$(gcloud iam service-accounts keys list $iam $fields $filter)
     echo -n "Purging GCE Service Account Keys for $1 ..."
     if [ -z "$keys" ]; then
         echo "None"
     else
         echo
         while read -r key; do
-            gcloud iam service-accounts keys delete $project $iam $key --quiet
+            gcloud iam service-accounts keys delete $iam $key --quiet
         done <<< "$keys"
     fi    
 }
 
-function purge:gce
+function purge::gce
 {
-    local project="ubuntu-benchmarking"
-    purge:gce:service_accounts $project
-    purge:gce:instances k8sci $project
+    local user="k8sci"
+    local project=$(gcloud projects list "--format=table[no-heading](projectId)")
+    gcloud config set project "$project"
+    purge::gce::service_accounts
+    purge::gce::instances "$user"
 }

--- a/jobs/infra/fixtures/cleanup-gce.sh
+++ b/jobs/infra/fixtures/cleanup-gce.sh
@@ -63,6 +63,7 @@ function purge::gce::service_account_keys
 function purge::gce
 {
     local user="k8sci"
+    gcloud auth activate-service-account --key-file /var/lib/jenkins/.local/share/juju/gce.json
     local project=$(gcloud projects list "--format=table[no-heading](projectId)")
     gcloud config set project "$project"
     purge::gce::service_accounts

--- a/jobs/infra/fixtures/cleanup-gce.sh
+++ b/jobs/infra/fixtures/cleanup-gce.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -eu
 
 if [[ $0 == $BASH_SOURCE ]]; then
   echo "$0 should be sourced";

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -149,6 +149,7 @@
         - "charm --classic --channel 2.x/stable"
         - "charmcraft --classic --edge"
         - "go --classic --stable"
+        - "google-cloud-cli --classic --channel=latest/stable"
         - "juju --classic --channel=2.9/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
@@ -263,6 +264,11 @@
         group: jenkins
         mode: 0644
         force: yes
+      tags:
+        - jenkins
+    - name: setup gce creds
+      command: "gcloud auth activate-service-account --key-file data/gce.json"
+      ignore_errors: yes
       tags:
         - jenkins
     - name: create surl dir

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -142,6 +142,12 @@
       tags:
         - jenkins
         - adhoc
+    - name: upgrade google-cloud-cli
+      command: "snap refresh google-cloud-cli --channel latest/stable"
+      ignore_errors: yes
+      tags:
+        - jenkins
+        - adhoc
     - name: install snap deps
       command: "snap install {{item}}"
       ignore_errors: yes
@@ -149,7 +155,7 @@
         - "charm --classic --channel 2.x/stable"
         - "charmcraft --classic --edge"
         - "go --classic --stable"
-        - "google-cloud-cli --classic --channel=latest/stable"
+        - "google-cloud-cli --classic --channel latest/stable"
         - "juju --classic --channel=2.9/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
@@ -266,11 +272,6 @@
         force: yes
       tags:
         - jenkins
-    - name: setup gce creds
-      command: "gcloud auth activate-service-account --key-file data/gce.json"
-      ignore_errors: yes
-      tags:
-        - jenkins
     - name: create surl dir
       file:
         path: /var/lib/jenkins/snap/surl/common
@@ -316,6 +317,11 @@
         owner: jenkins
         group: jenkins
         mode: 0644
+      tags:
+        - jenkins
+    - name: setup gce creds
+      command: "gcloud auth activate-service-account --key-file /var/lib/jenkins/.local/share/juju/gce.json"
+      ignore_errors: yes
       tags:
         - jenkins
     - name: copy gpg public key

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -319,11 +319,6 @@
         mode: 0644
       tags:
         - jenkins
-    - name: setup gce creds
-      command: "gcloud auth activate-service-account --key-file /var/lib/jenkins/.local/share/juju/gce.json"
-      ignore_errors: yes
-      tags:
-        - jenkins
     - name: copy gpg public key
       copy:
         src: "{{ lookup('env', 'K8STEAMCI_GPG_PUB') }}"


### PR DESCRIPTION
Uses the juju cloud credentials for gce to run gce purging

```
14:39:38 + purge::gce
14:39:38 + local user=k8sci
14:39:38 + gcloud auth activate-service-account --key-file /var/lib/jenkins/.local/share/juju/gce.json
14:39:39 Activated service account credentials for: [kubernetes@ubuntu-benchmarking.iam.gserviceaccount.com]
14:39:39 ++ gcloud projects list '--format=table[no-heading](projectId)'
14:39:41 + local project=ubuntu-benchmarking
14:39:41 + gcloud config set project ubuntu-benchmarking
14:39:43 Updated property [core/project].
14:39:43 + purge::gce::service_accounts
14:39:43 + local 'fields=--format=table[no-heading](email)'
14:39:43 + local filter=--filter=email:juju-gcp-
14:39:43 + echo 'Fetching GCE Service Accounts...'
14:39:43 Fetching GCE Service Accounts...
14:39:43 ++ gcloud iam service-accounts list '--format=table[no-heading](email)' --filter=email:juju-gcp-
14:39:44 + local service_accounts=
14:39:44 + echo -n 'Purging GCE Service Accounts...'
14:39:44 Purging GCE Service Accounts...+ '[' -z '' ']'
14:39:44 + echo None
14:39:44 None
14:39:44 + purge::gce::instances k8sci
14:39:44 + local user=k8sci
14:39:44 + local 'fields=--format=table[no-heading](name,zone)'
14:39:44 + local 'filter=--filter=metadata.items.filter(key:owner).flatten()~k8sci'
14:39:44 + echo 'Fetching GCE instances...'
14:39:44 Fetching GCE instances...
14:39:44 ++ gcloud compute instances list '--format=table[no-heading](name,zone)' '--filter=metadata.items.filter(key:owner).flatten()~k8sci'
14:39:45 WARNING: The following filter keys were not present in any resource : metadata.items
14:39:46 + local instances=
14:39:46 + echo -n 'Purging GCE instances...'
14:39:46 Purging GCE instances...+ '[' -z '' ']'
14:39:46 + echo None
14:39:46 None
```