### PR TITLE
Bug/integration/type error on unit join

### DIFF
--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -6,15 +6,16 @@ import os
 import subprocess
 import time
 import traceback
-from typing import Mapping, Any
-
+from collections.abc import Sequence
 from contextlib import contextmanager
+from subprocess import check_output, check_call
+from typing import Mapping, Any, Union
+
 from juju.unit import Unit
 from juju.controller import Controller
 from juju.machine import Machine
 from juju.errors import JujuError
 from juju.utils import block_until_with_coroutine
-from subprocess import check_output, check_call
 from cilib import log
 import click
 
@@ -457,10 +458,15 @@ def _units(machine: Machine):
     ]
 
 
-async def wait_for_status(workload_status, units):
+async def wait_for_status(workload_status: str, units: Union[Unit, Sequence[Unit]]):
+    """
+    Wait for unit or units to reach a specific workload_state or fail in 120s.
+    """
     if not isinstance(units, (list, tuple)):
         units = [units]
-    log.info(f'waiting for {workload_status} status on {", ".join(u.name for u in units)}')
+    log.info(
+        f'waiting for {workload_status} status on {", ".join(u.name for u in units)}'
+    )
     model = units[0].model
     try:
         await model.block_until(

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -460,7 +460,7 @@ def _units(machine: Machine):
 async def wait_for_status(workload_status, units):
     if not isinstance(units, (list, tuple)):
         units = [units]
-    log.info(f'waiting for {workload_status} status on {", ".join(units)}')
+    log.info(f'waiting for {workload_status} status on {", ".join(u.name for u in units)}')
     model = units[0].model
     try:
         await model.block_until(


### PR DESCRIPTION
series upgrade tests failure:

```
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] workload_status = 'blocked', units = [<Unit entity_id="etcd/1">]
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] 
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable]     async def wait_for_status(workload_status, units):
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable]         if not isinstance(units, (list, tuple)):
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable]             units = [units]
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] >       log.info(f'waiting for {workload_status} status on {", ".join(units)}')
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] E       TypeError: sequence item 0: expected str instance, Unit found
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] 
17:02:51 [validate-ck-series-upgrade-focal-1.25-stable] jobs/integration/utils.py:463: TypeError
```