### PR TITLE
Resolve issue running integration tests due to Sequence not being subscriptable

### DIFF
--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -6,10 +6,9 @@ import os
 import subprocess
 import time
 import traceback
-from collections.abc import Sequence
 from contextlib import contextmanager
 from subprocess import check_output, check_call
-from typing import Mapping, Any, Union
+from typing import Mapping, Any, Union, Sequence
 
 from juju.unit import Unit
 from juju.controller import Controller


### PR DESCRIPTION
resolves error:

```
[validate-ck-snapd-upgrade-focal-1.25-stable] ImportError while loading conftest '/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-9/workspace/validate-ck-snapd-upgrade/jobs/integration/conftest.py'.
[validate-ck-snapd-upgrade-focal-1.25-stable] jobs/integration/conftest.py:17: in <module>
[validate-ck-snapd-upgrade-focal-1.25-stable]     from .utils import (
[validate-ck-snapd-upgrade-focal-1.25-stable] jobs/integration/utils.py:461: in <module>
[validate-ck-snapd-upgrade-focal-1.25-stable]     async def wait_for_status(workload_status: str, units: Union[Unit, Sequence[Unit]]):
[validate-ck-snapd-upgrade-focal-1.25-stable] E   TypeError: 'ABCMeta' object is not subscriptable
```