### PR TITLE
`test_snap_version` handles `latest/edge` charm option

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -239,7 +239,7 @@ async def test_status_messages(model):
             assert message in unit.workload_status_message
 
 
-async def test_snap_versions(model):
+async def test_snap_versions(model, tools):
     """Validate that the installed snap versions are consistent with channel
     config on the charms.
     """
@@ -263,6 +263,17 @@ async def test_snap_versions(model):
             click.echo(message)
             continue
         track = channel.split("/")[0]
+        if track == "latest":
+            # Use snap info to determine the versions of the latest/{risk}
+            stdout, *_ = await tools.run("snap", "info", *snaps)
+            info = {
+                i["name"]: i["channels"][channel].split(".", 2)[:2]
+                for i in yaml.safe_load_all(stdout)
+            }
+            expected, *_ = info.values()
+            track = ".".join(expected)
+            err = f"not all {channel} snaps are on an the same track={track}"
+            assert all(i == expected for i in info.values()), err
         for unit in app.units:
             action = await juju_run(unit, "snap list", check=False)
             assert action.status == "completed"


### PR DESCRIPTION
if the charm's channel is 'latest/{risk}', test that the running snaps on a unit matches the channel version in snapstore for that 'latest/{risk}' channel