### PR TITLE
build containerd resources with charm builds

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -4,6 +4,8 @@
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
   flannel: '{out_path}/flannel-amd64.tar.gz'
   flannel-arm64: '{out_path}/flannel-arm64.tar.gz'
+'containerd':
+  containerd: '{out_path}/containerd-multiarch.tgz'
 'calico':
   calico: '{out_path}/calico-amd64.tar.gz'
   calico-arm64: '{out_path}/calico-arm64.tar.gz'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -46,6 +46,7 @@
     downstream: charmed-kubernetes/charm-containerd.git
     store: 'https://charmhub.io/containerd'
     summary: Containerd container runtime subordinate
+    build-resources: 'cd {out_path}; bash {src_path}/build-resources.sh'
     tags:
       - k8s
       - containerd


### PR DESCRIPTION
Upon merging this PR, containerd will need to attach the 1.6.10 resource to the charm published to charmhub
*  https://github.com/charmed-kubernetes/charm-containerd/pull/84