### PR TITLE
Bug fix: identify pre-stable microk8s releases

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -185,7 +185,7 @@ class Microk8sSnap:
         version_parts = version.replace("-", ".").split(".")
         click.echo(version)
         is_prerelease = False
-        if not version_parts[2].isdigit():
+        if not version_parts[3].isdigit():
             is_prerelease = True
         major_minor_version = "{}.{}".format(version_parts[0], version_parts[1])
         return (is_prerelease, major_minor_version)

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -185,7 +185,7 @@ class Microk8sSnap:
         version_parts = version.replace("-", ".").split(".")
         click.echo(version)
         is_prerelease = False
-        if not version_parts[3].isdigit():
+        if len(version_parts) > 3 and not version_parts[3].isdigit():
             is_prerelease = True
         major_minor_version = "{}.{}".format(version_parts[0], version_parts[1])
         return (is_prerelease, major_minor_version)


### PR DESCRIPTION
This PR fixes an off by one error in identifying if a released snap is part of a pre-stable release. The version string we need to parse looks like this: `v1.23.3` or `v1.26.0-rc.0`, to identify if this is a pre-stable we replace the `-` with `.` and then we need to look at position [3] to look for something that is not a digit, eg alpha, beta, rc.