### PR TITLE
run sync-oci-images with 1.26

### DIFF
--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.25'
+          default: '1.26'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.


### PR DESCRIPTION
---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge

