### PR TITLE
Improve empty version detection in mk8s pre-releases

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -154,6 +154,9 @@ class Microk8sSnap:
                     click.echo(line_parts)
                     version = line_parts[1]
                     revision = line_parts[2]
+                    # In case of a channel that we do not have released anything yet,
+                    # eg in a pre-stable release, we have: the line_parts to be:
+                    # ['beta', '↑', '↑']. We detect this case below.
                     if len(version) <= 1 or '.' not in version:
                         # Nothing released on this track/channel
                         break

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -154,7 +154,7 @@ class Microk8sSnap:
                     click.echo(line_parts)
                     version = line_parts[1]
                     revision = line_parts[2]
-                    if version == "-":
+                    if len(version) <= 1 or '.' not in version:
                         # Nothing released on this track/channel
                         break
                     is_prerelease, major_minor_version = self._extract_version(version)

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -157,7 +157,7 @@ class Microk8sSnap:
                     # In case of a channel that we do not have released anything yet,
                     # eg in a pre-stable release, we have: the line_parts to be:
                     # ['beta', '↑', '↑']. We detect this case below.
-                    if len(version) <= 1 or '.' not in version:
+                    if len(version) <= 1 or "." not in version:
                         # Nothing released on this track/channel
                         break
                     is_prerelease, major_minor_version = self._extract_version(version)


### PR DESCRIPTION
Detecting a empty version started failing with:
```
09:27:35  Searching for 1.26/beta* in revisions list
09:27:35  Calling ['snapcraft', 'status', 'microk8s', '--arch', 'amd64']
09:27:37  ['beta', '↑', '↑']
09:27:37  ↑
09:27:37  Traceback (most recent call last):
09:27:37    File "jobs/microk8s/release-pre-release.py", line 63, in <module>
09:27:37      snap = Microk8sSnap(track, channel)
09:27:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/jobs/microk8s/snapstore.py", line 32, in __init__
09:27:37      release_info = self._try_status(track, channel, arch)
09:27:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/jobs/microk8s/snapstore.py", line 160, in _try_status
09:27:37      is_prerelease, major_minor_version = self._extract_version(version)
09:27:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/jobs/microk8s/snapstore.py", line 190, in _extract_version
09:27:37      major_minor_version = "{}.{}".format(version_parts[0], version_parts[1])
09:27:37  IndexError: list index out of range
```
I believe the version in an empty channel used to be a "-" now it is an up arrow.
