### PR TITLE
failed juju deployments should report failures to show up in generated reports

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -194,11 +194,6 @@ function ci::run
         juju::deploy
         juju::wait
 
-        kv::set "deploy_result" "True"
-        kv::set "deploy_endtime" "$(timestamp)"
-        touch "meta/deployresult-True"
-        python bin/s3 cp "meta/deployresult-True" "meta/deployresult-True"
-
         juju::deploy::after
 
         test::execute result

--- a/juju.bash
+++ b/juju.bash
@@ -86,14 +86,19 @@ function juju::wait
     timeout 45m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w
 
     ret=$?
+
+    is_pass="True"
     if (( ret > 0 )); then
-        kv::set "deploy_result" "False"
-        kv::set "deploy_endtime" "$(timestamp)"
-        touch "meta/deployresult-False"
-        python bin/s3 cp "meta/deployresult-False" "meta/deployresult-False"
+        is_pass="False"
+    fi
 
+    kv::set "deploy_result" "$(is_pass)"
+    kv::set "deploy_endtime" "$(timestamp)"
+    touch "meta/deployresult-$(is_pass)"
+    python bin/s3 cp "meta/deployresult-$(is_pass)" "meta/deployresult-$(is_pass)"
+
+    if (( ret > 0 )); then
         test::report "False"
-
         exit "$ret"
     fi
 }

--- a/juju.bash
+++ b/juju.bash
@@ -92,10 +92,10 @@ function juju::wait
         is_pass="False"
     fi
 
-    kv::set "deploy_result" "$(is_pass)"
+    kv::set "deploy_result" "${is_pass}"
     kv::set "deploy_endtime" "$(timestamp)"
-    touch "meta/deployresult-$(is_pass)"
-    python bin/s3 cp "meta/deployresult-$(is_pass)" "meta/deployresult-$(is_pass)"
+    touch "meta/deployresult-${is_pass}"
+    python bin/s3 cp "meta/deployresult-${is_pass}" "meta/deployresult-${is_pass}"
 
     if (( ret > 0 )); then
         test::report "False"

--- a/juju.bash
+++ b/juju.bash
@@ -87,6 +87,13 @@ function juju::wait
 
     ret=$?
     if (( ret > 0 )); then
+        kv::set "deploy_result" "False"
+        kv::set "deploy_endtime" "$(timestamp)"
+        touch "meta/deployresult-False"
+        python bin/s3 cp "meta/deployresult-False" "meta/deployresult-False"
+
+        test::report "False"
+
         exit "$ret"
     fi
 }


### PR DESCRIPTION
Before exiting and moving on the cleanup stage, a failed deployment ought to post that it's failed its deployment so that the run will show up as a failure in the [generated reports](https://github.com/charmed-kubernetes/jenkins/blob/main/bin/report#L167-L173)


The report job was filtering out results that don't include a `result` metadata

