### PR TITLE
Handle the semantic versioning of pre-stable releases

### DIFF
--- a/jobs/microk8s/utils.py
+++ b/jobs/microk8s/utils.py
@@ -62,9 +62,12 @@ def compare_releases(a, b):
     if b.startswith("v"):
         b = b[1:]
 
-    # eks releases may have dashes eg 1.23-5
-    a = a.replace("-", ".")
-    b = b.replace("-", ".")
+    # eks releases may have dashes eg 1.23-5 so we need to "normalize" this
+    # but the pre-stable released eg 1.24.0-alpha.0 are fine.
+    if not any(id in a for id in ["alpha", "beta", "rc"]):
+        a = a.replace("-", ".")
+    if not any(id in a for id in ["alpha", "beta", "rc"]):
+        b = b.replace("-", ".")
 
     if a == b:
         return 0


### PR DESCRIPTION
When parsing the versions we replace the "-" with "." so we get a valid version eg for eksd we change 1.23-4 to 1.23.4. However, this is not right for the pre-stable releases where 1.24.0-rc.0 changes to 1.24.0.rc.0 resulting in the following error:
```
 Searching on GH releases for a tag starting with: v1.26.0-alpha
23:07:37  Traceback (most recent call last):
23:07:37    File "jobs/microk8s/release-pre-release.py", line 75, in <module>
23:07:37      pre_release = get_latest_pre_release(track, channel[1])
23:07:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-9/workspace/release-microk8s-arch-arm64/jobs/microk8s/utils.py", line 114, in get_latest_pre_release
23:07:37      if compare_releases(max_release, release_candidate) < 0:
23:07:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-9/workspace/release-microk8s-arch-arm64/jobs/microk8s/utils.py", line 72, in compare_releases
23:07:37      return semver.compare(a, b)
23:07:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-9/workspace/release-microk8s-arch-arm64/.tox/py38/lib/python3.8/site-packages/semver.py", line 159, in wrapper
23:07:37      return func(*args, **kwargs)
23:07:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-9/workspace/release-microk8s-arch-arm64/.tox/py38/lib/python3.8/site-packages/semver.py", line 856, in compare
23:07:37      v1 = VersionInfo.parse(ver1)
23:07:37    File "/var/lib/jenkins/slaves/jenkins-slave-focal-9/workspace/release-microk8s-arch-arm64/.tox/py38/lib/python3.8/site-packages/semver.py", line 726, in parse
23:07:37      raise ValueError("%s is not valid SemVer string" % version)
23:07:37  ValueError: 1.26.0.alpha.3 is not valid SemVer string
```
This PR addresses this by not changing the version string if it contains alpha, beta or rc.