### PR TITLE
multus validation: adjust deployment of ceph-osd and ceph-mon for jammy

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -318,12 +318,14 @@ async def proxy_app(model):
 
 @pytest.fixture(autouse=True)
 def skip_by_app(request, model):
-    """Skip tests if missing certain applications"""
-    if request.node.get_closest_marker("skip_apps"):
-        apps = request.node.get_closest_marker("skip_apps").args[0]
-        is_available = any(app in model.applications for app in apps)
-        if not is_available:
-            pytest.skip("skipped, no matching applications found: {}".format(apps))
+    """Skip tests if application predicate is True."""
+    skip_marker = request.node.get_closest_marker("skip_if_apps")
+    if not skip_marker:
+        return
+    predicate = skip_marker.args[0]
+    apps = model.applications
+    if predicate(apps):
+        pytest.skip(f"skipped, because of deployed apps: {apps}")
 
 
 def _charm_name(app):

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -4,6 +4,7 @@
 import os
 import pytest
 import asyncio
+import inspect
 import uuid
 from pathlib import Path
 import yaml
@@ -317,7 +318,7 @@ async def proxy_app(model):
 
 
 @pytest.fixture(autouse=True)
-def skip_by_app(request, model):
+def skip_if_apps(request, model):
     """Skip tests if application predicate is True."""
     skip_marker = request.node.get_closest_marker("skip_if_apps")
     if not skip_marker:
@@ -325,7 +326,8 @@ def skip_by_app(request, model):
     predicate = skip_marker.args[0]
     apps = model.applications
     if predicate(apps):
-        pytest.skip(f"skipped, because of deployed apps: {apps}")
+        method = inspect.getsource(predicate).strip()
+        pytest.skip(f"skipped, because '{method}' was True")
 
 
 def _charm_name(app):

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -327,7 +327,7 @@ def skip_if_apps(request, model):
     apps = model.applications
     if predicate(apps):
         method = inspect.getsource(predicate).strip()
-        pytest.skip(f"skipped, because '{method}' was True")
+        pytest.skip(f"'{method}' was True")
 
 
 def _charm_name(app):

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -448,7 +448,12 @@ async def test_kubelet_anonymous_auth_disabled(model, tools):
     await asyncio.gather(*(validate_unit(unit) for unit in units))
 
 
-@pytest.mark.skip_apps(["canal", "calico", "tigera-secure-ee"])
+@pytest.mark.skip_if_apps(
+    # skip this test if none of these CNIs is deployed
+    lambda model_apps: not any(
+        a in model_apps for a in ["canal", "calico", "tigera-secure-ee"]
+    )
+)
 async def test_network_policies(model, tools):
     """Apply network policy and use two busyboxes to validate it."""
     here = os.path.dirname(os.path.abspath(__file__))
@@ -2426,6 +2431,10 @@ async def test_nfs(model, tools):
     await tools.juju_wait()
 
 
+@pytest.mark.skip_if_apps(
+    # skip this test if ceph-mon and ceph-osd are already installed
+    lambda model_apps: all(app in model_apps for app in ["ceph-mon", "ceph-osd"])
+)
 async def test_ceph(model, tools):
     # setup
     series = os.environ["SERIES"]

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -450,9 +450,7 @@ async def test_kubelet_anonymous_auth_disabled(model, tools):
 
 @pytest.mark.skip_if_apps(
     # skip this test if none of these CNIs is deployed
-    lambda model_apps: not any(
-        a in model_apps for a in ["canal", "calico", "tigera-secure-ee"]
-    )
+    lambda apps: not any(a in apps for a in ["canal", "calico", "tigera-secure-ee"])
 )
 async def test_network_policies(model, tools):
     """Apply network policy and use two busyboxes to validate it."""
@@ -2433,7 +2431,7 @@ async def test_nfs(model, tools):
 
 @pytest.mark.skip_if_apps(
     # skip this test if ceph-mon and ceph-osd are already installed
-    lambda model_apps: all(app in model_apps for app in ["ceph-mon", "ceph-osd"])
+    lambda apps: all(a in apps for a in ["ceph-mon", "ceph-osd"])
 )
 async def test_ceph(model, tools):
     # setup

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -35,7 +35,7 @@ EOF
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon --channel="$CEPH_CHANNEL"
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd --channel="$CEPH_CHANNEL" \
          --constraints="root-disk=32G" \
-         --storage osd-devices=32G,2 \
+         --storage osd-devices=8G,1 \
          --storage osd-journals=8G,1
     juju relate -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-osd ceph-mon
     juju relate -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-mon:client kubernetes-control-plane

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -31,13 +31,12 @@ EOF
          --overlay overlay.yaml \
          --force \
          --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
-    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon
-    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd \
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon --channel="$CEPH_CHANNEL"
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd --channel="$CEPH_CHANNEL" \
          --storage osd-devices=32G,2 \
          --storage osd-journals=8G,1
-    juju add-relation -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-osd ceph-mon
-    juju add-relation -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-mon:admin kubernetes-control-plane
-    juju add-relation -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-mon:client kubernetes-control-plane
+    juju relate -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-osd ceph-mon
+    juju relate -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-mon:client kubernetes-control-plane
 }
 
 function juju::deploy::after
@@ -81,6 +80,7 @@ function ci::cleanup::before
 ###############################################################################
 SNAP_VERSION=${1:-1.26/edge}
 SERIES=${2:-jammy}
+CEPH_CHANNEL=${5:-quincy/stable}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-edge}
 JUJU_CLOUD=vsphere/Boston

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -33,6 +33,7 @@ EOF
          --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon --channel="$CEPH_CHANNEL"
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd --channel="$CEPH_CHANNEL" \
+         --constraints="root-disk=32G" \
          --storage osd-devices=32G,2 \
          --storage osd-journals=8G,1
     juju relate -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-osd ceph-mon

--- a/jobs/validate/multus-spec
+++ b/jobs/validate/multus-spec
@@ -27,6 +27,7 @@ applications:
       channel: $SNAP_VERSION
 EOF
 
+    juju model-config -m "$JUJU_CONTROLLER:$JUJU_MODEL" default-series="$SERIES"
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
          --overlay overlay.yaml \
          --force \

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -28,13 +28,15 @@ applications:
       channel: $SNAP_VERSION
 EOF
 
+    juju model-config -m "$JUJU_CONTROLLER:$JUJU_MODEL" default-series="$SERIES"
     juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
          --overlay overlay.yaml \
          --force \
          --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
-    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon
-    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd \
-         --storage osd-devices=32G,2 \
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-mon --channel="$CEPH_CHANNEL"
+    juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" -n 3 ceph-osd --channel="$CEPH_CHANNEL" \
+         --constraints="root-disk=32G" \
+         --storage osd-devices=8G,1 \
          --storage osd-journals=8G,1
     juju add-relation -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-osd ceph-mon
     juju add-relation -m "$JUJU_CONTROLLER:$JUJU_MODEL" ceph-mon:client kubernetes-control-plane
@@ -89,6 +91,7 @@ function ci::cleanup::before
 ###############################################################################
 SNAP_VERSION=${1:-1.26/edge}
 SERIES=${2:-jammy}
+CEPH_CHANNEL=${5:-quincy/stable}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-edge}
 JUJU_CLOUD=aws/us-east-1

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ markers =
     skip_arch
     on_model
     skip_if_apps
+    skip_if_version
     clouds
 log_cli = 1
 log_cli_level = INFO

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ markers =
     postupgrade: marks tests that run after a cluster upgrade (deselect with '-m "not postupgrade"')
     skip_arch
     on_model
-    skip_apps
+    skip_if_apps
     clouds
 log_cli = 1
 log_cli_level = INFO


### PR DESCRIPTION
* multus and sriov specifications both need ceph as a k8s storage platform
* don't need to run the ceph-test for these two job specification (it would remove ceph)
* refactor a pytest fixture `skip_by_app` to handle an application predicate

if a test is skipped with this fixture, it will look like this in the log

```
jobs/integration/validation.py::test_ceph SKIPPED ('lambda apps: all(a in apps for a in ["ceph-mon", "ceph-osd"])' was True)
```