### PR TITLE
Fix `test_dns_providers`

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -9,7 +9,6 @@ import json
 import os
 import requests
 import yaml
-import re
 import random
 import pytest
 import logging
@@ -1944,7 +1943,9 @@ async def test_dns_provider(model, k8s_model, tools):
             await tools.juju_wait()
 
             log("Waiting CoreDNS pod to be ready")
-            wait_for_pods_ready("app.kubernetes.io/name=coredns", ns=tools.k8s_model_name)
+            wait_for_pods_ready(
+                "app.kubernetes.io/name=coredns", ns=tools.k8s_model_name
+            )
 
             log("Verifying that stale pod doesn't pick up new DNS provider")
             await verify_no_dns_resolution(fresh=False)
@@ -1968,7 +1969,9 @@ async def test_dns_provider(model, k8s_model, tools):
                 "--force",
                 "coredns",
             )
-            await wait_for_pods_removal("app.kubernetes.io/name=coredns", ns=tools.k8s_model_name)
+            await wait_for_pods_removal(
+                "app.kubernetes.io/name=coredns", ns=tools.k8s_model_name
+            )
 
         log("Verifying that DNS is no longer working")
         await verify_no_dns_resolution(fresh=True)


### PR DESCRIPTION
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

## Changes
`test_dns_providers` has been failing for the last few runs. Upon further investigation, the labels used to wait the `CoreDNS` pods are incorrect. This PR changed these labels to the correct ones and validated on all supported versions that the labels still the same.

CoreDNS manifest frrom CDK Adddons:
```
apiVersion: v1                                                                                                                          
 kind: Pod                                                                                                                               
 metadata:                                                                                                                               
   creationTimestamp: "2022-12-01T21:30:35Z"                                                                                            
   generateName: coredns-77c75468db-                                                                                                     
   labels:                                                                                                                               
     app.kubernetes.io/name: coredns                                                                                                     
     k8s-app: kube-dns                                                                                                                   
     pod-template-hash: 77c75468db
```
CoreDNS manifest from Charmhub:
```
 apiVersion: v1                                                                                                                          
 kind: Pod                                                                                                                               
 metadata:                                                                                                                               
   annotations:                                                                                                                          
     controller.juju.is/id: 6bfba92a-097d-4ddd-8d94-daacc3a6012e                                                                         
     juju.is/version: 2.9.37                                                                                                             
     model.juju.is/id: b0c3e261-d7cb-4fc9-89a4-a02f077bb41d                                                                              
     unit.juju.is/id: coredns/0                                                                                                          
   creationTimestamp: "2022-12-01T21:38:07Z"                                                                                             
   generateName: coredns-                                                                                                                
   labels:                                                                                                                               
     app.kubernetes.io/name: coredns                                                                                                     
     controller-revision-hash: coredns-6cb7ff594b                                                                                        
     statefulset.kubernetes.io/pod-name: coredns-0                                                                                       
   name: coredns-0                                                                                                                       
   namespace: test-dns-provisioner-k8s
```