### PR TITLE
handle failure of multiarch coredns resources

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -265,8 +265,8 @@ async def k8s_model(k8s_cloud, tools):
         await tools.run("juju-crashdump", "-a", "config", "-m", tools.k8s_connection)
         click.echo("Cleaning up k8s model")
         try:
-            for name, relation in k8s_model.state.relations.items():
-                click.echo(f"Removing relation {name} from k8s model")
+            for relation in k8s_model.relations:
+                click.echo(f"Removing relation {relation.name} from k8s model")
                 await relation.destroy()
 
             for name, offer in k8s_model.application_offers.items():

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1938,7 +1938,9 @@ async def test_dns_provider(model, k8s_model, tools):
         # See LP#1998607
         worker_arch = os.environ.get("ARCH", "amd64")
         with NamedTemporaryFile("w") as f:
-            f.write('{"ImageName": "rocks.canonical.com:443/cdk/coredns/coredns:1.6.7"}')
+            f.write(
+                '{"ImageName": "rocks.canonical.com:443/cdk/coredns/coredns:1.6.7"}'
+            )
             f.flush()
             await tools.run(
                 "juju",
@@ -1950,7 +1952,7 @@ async def test_dns_provider(model, k8s_model, tools):
                 "coredns",
                 "--trust",
                 "--resource",
-                f"coredns-image={f.name}"
+                f"coredns-image={f.name}",
             )
             await k8s_model.block_until(lambda: "coredns" in k8s_model.applications)
             coredns = k8s_model.applications["coredns"]


### PR DESCRIPTION
* Applying [LP#1998607](https://launchpad.net/bugs/1998607) workaround
  * This bug details a failure to deploy `coredns` charm on any architecture other than amd64 due to limitations in charmcraft to support arch agnostic image resources. 

* deploying keystone with the correct series for the model