### PR TITLE
unpin pip version now that pip 22.3.1 is available

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -272,10 +272,6 @@
           set +o allexport
 
           python3.8 -m venv venv
-
-          # le sigh. pin for https://github.com/jazzband/pip-tools/issues/1617
-          python3 -m pip install pip==22.0.4
-
           venv/bin/python -m pip install pip-tools wheel
           venv/bin/pip-sync requirements.txt
 

--- a/jobs/microk8s/tox.ini
+++ b/jobs/microk8s/tox.ini
@@ -5,8 +5,6 @@ temp_dir={toxworkdir}/.tmp
 
 [testenv]
 deps =
-     # le sigh. pin for https://github.com/jazzband/pip-tools/issues/1617
-     pip == 22.0.4
      pip-tools
 commands =
      pip-sync {toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ temp_dir={toxworkdir}/.tmp
 
 [testenv]
 deps =
-     # le sigh. pin for https://github.com/jazzband/pip-tools/issues/1617
-     pip == 22.0.4
      pip-tools
 commands =
      pip install cffi flake8


### PR DESCRIPTION
This pin is now getting in the way as pip-tools has moved on to wanting a new version

[LP#1998622](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1998622)

I confirmed this by starting with a fresh venv

```bash
❯ virtualenv -p python3 venv
❯ venv/bin/pip --version
pip 22.3.1 from /home/addyess/git/charmed-kubernetes/jenkins/venv/lib/python3.10/site-packages/pip (python 3.10)

## Downgrade pip to that pin
❯ venv/bin/pip install --upgrade pip==22.0.4 pip-tools
...
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.3.1
    Uninstalling pip-22.3.1:
      Successfully uninstalled pip-22.3.1
Successfully installed pip-22.0.4

## installing pip-tools upgrades pip again
❯ venv/bin/pip install pip-tools
...
Installing collected packages: tomli, pyparsing, pip, click, pep517, packaging, build, pip-tools
  Attempting uninstall: pip
    Found existing installation: pip 22.0.4
    Uninstalling pip-22.0.4:
      Successfully uninstalled pip-22.0.4
Successfully installed build-0.9.0 click-8.1.3 packaging-21.3 pep517-0.13.0 pip-22.3.1 pip-tools-6.11.0 pyparsing-3.0.9 tomli-2.0.1
```

It as stated in the bug may trigger: https://github.com/pypa/pip/issues/5599

I think if we just drop this pin now that pip-tools have resolved https://github.com/jazzband/pip-tools/issues/1617, things will go smoothly?

