### PR TITLE
Update tag format in CAPI release

### DIFF
--- a/jobs/release-microk8s-capi.yaml
+++ b/jobs/release-microk8s-capi.yaml
@@ -31,7 +31,7 @@
       - string:
           name: RELEASE_TAG
           description: |
-            Tag used to release the providers.
+            Tag used to release the providers (Tag Format: vX.Y.X).
       - string:
           name: BOOTSTRAP_PROVIDER_CHECKOUT
           default: "main"


### PR DESCRIPTION
Updating the tag description to use the correct version format when doing a CAPI release.