### PR TITLE
[Reporting] successfully deployed tests should report such

### DIFF
--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -43,7 +43,8 @@ function juju::bootstrap
 
       ret=$?
       if (( ret > 0 )); then
-          juju::deploy-failure $ret
+          # Fail Deploy Early
+          juju::deploy-report $ret
       fi
     fi
 }
@@ -104,10 +105,7 @@ function juju::deploy
         python $WORKSPACE/jobs/integration/tigera_aws.py configure-bgp
       fi
     )
-    ret=$?
-    if (( ret > 0 )); then
-        juju::deploy-failure $ret
-    fi
+    juju::deploy-report $?
 }
 
 ###############################################################################

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -26,11 +26,7 @@ function juju::deploy
         juju relate ubuntu ci-setup
     )
 
-    ret=$?
-    if (( ret > 0 )); then
-        juju::deploy-failure $ret
-    fi
-
+    juju::deploy-report $?
 }
 
 function juju::deploy::after


### PR DESCRIPTION
This is a partial reversion of https://github.com/charmed-kubernetes/jenkins/pull/1131

It's important that the `meta/deployresult-<True|False>` file exist in the archive.  Without it, failed tests will appear as "red' looking like they failed to deploy rather than "yellow" where they just fail a test"