### PR TITLE
1.26 ga tweaks

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -8,7 +8,7 @@ JOBS_PATH = Path("jobs")
 # Current supported STABLE K8s MAJOR.MINOR release. This determines what the
 # latest/stable channel is set to. It should be updated whenever a new CK
 # major.minor is GA.
-K8S_STABLE_VERSION = "1.26"
+K8S_STABLE_VERSION = "1.25"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
@@ -49,26 +49,12 @@ K8S_GO_MAP = {
     "1.25": "go/1.19/stable",
     "1.24": "go/1.18/stable",
     "1.23": "go/1.17/stable",
-    "1.22": "go/1.16/stable",
-    "1.21": "go/1.16/stable",
-    "1.20": "go/1.15/stable",
-    "1.19": "go/1.15/stable",
-    "1.18": "go/1.13/stable",
-    "1.17": "go/1.13/stable",
-    "1.16": "go/1.13/stable",
 }
 
 # Snap k8s version <-> track mapping
 # Allows us to be specific in which tracks should get what major.minor and dictate
 # when a release should be put into the latest track.
 SNAP_K8S_TRACK_LIST = [
-    ("1.16", ["1.16/stable", "1.16/candidate", "1.16/beta", "1.16/edge"]),
-    ("1.17", ["1.17/stable", "1.17/candidate", "1.17/beta", "1.17/edge"]),
-    ("1.18", ["1.18/stable", "1.18/candidate", "1.18/beta", "1.18/edge"]),
-    ("1.19", ["1.19/stable", "1.19/candidate", "1.19/beta", "1.19/edge"]),
-    ("1.20", ["1.20/stable", "1.20/candidate", "1.20/beta", "1.20/edge"]),
-    ("1.21", ["1.21/stable", "1.21/candidate", "1.21/beta", "1.21/edge"]),
-    ("1.22", ["1.22/stable", "1.22/candidate", "1.22/beta", "1.22/edge"]),
     ("1.23", ["1.23/stable", "1.23/candidate", "1.23/beta", "1.23/edge"]),
     ("1.24", ["1.24/stable", "1.24/candidate", "1.24/beta", "1.24/edge"]),
     ("1.25", ["1.25/stable", "1.25/candidate", "1.25/beta", "1.25/edge"]),
@@ -79,17 +65,11 @@ SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 
 # Deb k8s version <-> ppa mapping
 DEB_K8S_TRACK_MAP = {
-    "1.16": "ppa:k8s-maintainers/1.16",
-    "1.17": "ppa:k8s-maintainers/1.17",
-    "1.18": "ppa:k8s-maintainers/1.18",
-    "1.19": "ppa:k8s-maintainers/1.19",
-    "1.20": "ppa:k8s-maintainers/1.20",
-    "1.21": "ppa:k8s-maintainers/1.21",
-    "1.22": "ppa:k8s-maintainers/1.22",
     "1.23": "ppa:k8s-maintainers/1.23",
     "1.24": "ppa:k8s-maintainers/1.24",
     "1.25": "ppa:k8s-maintainers/1.25",
     "1.26": "ppa:k8s-maintainers/1.26",
+    "1.27": "ppa:k8s-maintainers/1.27",
 }
 
 

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -8,7 +8,7 @@ JOBS_PATH = Path("jobs")
 # Current supported STABLE K8s MAJOR.MINOR release. This determines what the
 # latest/stable channel is set to. It should be updated whenever a new CK
 # major.minor is GA.
-K8S_STABLE_VERSION = "1.25"
+K8S_STABLE_VERSION = "1.26"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -137,7 +137,7 @@ the same time will use the `candidate` channel for staging.
 K8s snap promotion is handled by the `sync-snaps` job and will happen
 automatically after following the `Prepare CI` section above. If for some
 reason you need to manually build K8s snaps from a specific branch, use the
-above job with a `branch` parameter like `1.25.0`.
+above job with a `branch` parameter like `1.26.0`.
 
 The `branch` parameter gets translated to `v$branch` by
 [snap.py](https://github.com/charmed-kubernetes/jenkins/blob/0b334c52b2c4f816b03ff866c44301724b8b471c/cilib/service/snap.py#L172)
@@ -157,8 +157,8 @@ then performing an upgrade to latest/beta channel. The tests are parameterized
 to run on multiple series and with multiple snap channels.
 
 Before running this job, confirm that the defined variables in the job are
-* `upgrade_snap` - this CK release's beta snap (1.25/beta)
-* `deploy_snap` - the previous 2 CK releases' stable snaps (1.24/stable, 1.23/stable)
+* `upgrade_snap` - this CK release's beta snap (1.26/beta)
+* `deploy_snap` - the previous 2 CK releases' stable snaps (1.25/stable, 1.24/stable)
 
 ### Notify Solutions QA
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -35,14 +35,31 @@ to the respective release branches.
 
 ## Prepare CI
 
+### $next++ release
+
+It may feel early, but part of releasing the next stable version requires
+preparing for the release that will follow. This requires opening tracks and
+building relevant snaps and charms that will be used in the new `edge` channel.
+
+For example, we requested 1.27 snap tracks while preparing for the 1.26 release:
+
+- https://forum.snapcraft.io/t/kubernetes-1-27-snap-tracks/32937
+
+Charm track requests are made by contacting
+[~snapstore](https://chat.canonical.com/canonical/channels/snapstore)
+and asking for new tracks to be opened for every neccessary
+[charm](https://charmhub.io/charm) and [bundle](https://charmhub.io/bundle)
+owned by `Canonical Kubernetes` on [charmhub.io](https://charmhub.io). For example:
+
+- https://chat.canonical.com/canonical/pl/fbmk7ochxfgdifyehomeds44qy
+
 ### $next release
 
 If not done already, add the upcoming release to the CI enumerations
 as well as our custom snap jobs. For example, see the additions made
-for the 1.25 release:
+for the 1.26 release:
 
-- https://github.com/charmed-kubernetes/jenkins/pull/974
-- https://github.com/charmed-kubernetes/jenkins/commit/2416d9e98f9f9c6b26b5b94215c43650a9b241e4
+- https://github.com/charmed-kubernetes/jenkins/pull/1141
 
 > **Note**: Nightly charm and bundle builds will target both
 `latest/edge` and `$next/edge` channels.
@@ -55,28 +72,10 @@ with 1.xx.0 instead of 1.xx.1-alpha.0. For example:
 
 Additionally, if not done already, CI should include 1.xx in the version matrix
 and config for relevant jobs. For example, see these updates where we adjusted
-tests for our 1.25 release:
+tests for our 1.26 release:
 
-- https://github.com/charmed-kubernetes/jenkins/pull/997
-- https://github.com/charmed-kubernetes/jenkins/pull/1005
-
-### $next++ release
-
-It may feel early, but part of releasing the next stable version requires
-preparing for the release that will follow. This requires opening tracks and
-building relevant snaps and charms that will be used in the new `edge` channel.
-
-For example, we requested 1.26 snap tracks while preparing for the 1.25 release:
-
-- https://forum.snapcraft.io/t/kubernetes-1-26-snap-tracks/31491
-
-Charm track requests are made by contacting
-[~snapstore](https://chat.canonical.com/canonical/channels/snapstore)
-and asking for new tracks to be opened for every neccessary
-[charm](https://charmhub.io/charm) and [bundle](https://charmhub.io/bundle)
-owned by `Canonical Kubernetes` on [charmhub.io](https://charmhub.io). For example:
-
-- https://chat.canonical.com/canonical/pl/mbyp1gkfrtryube18pti7dsray
+- https://github.com/charmed-kubernetes/jenkins/pull/1110
+- https://github.com/charmed-kubernetes/jenkins/pull/1107
 
 ## Preparing the release
 
@@ -92,21 +91,24 @@ from which we test, fix, and subsequently promote to the new release.
 
 We need to make sure that the bundle fragments and kubernetes-worker/control-plane/e2e
 have `1.xx/stable` set as the default snap channel. This should be done on each of
-the relevant git `release_1.xx` branches. For example, for the 1.25 GA:
+the relevant git `release_1.xx` branches. For example, for the 1.26 GA:
 
-- https://github.com/charmed-kubernetes/bundle/pull/858
-- https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/24
-- https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/243
-- https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/129
+- https://github.com/charmed-kubernetes/bundle/pull/867
+- https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/26
+- https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/262
+- https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/133
 
-> **Note**: Changes to the above charms are required as some of our customers
+> **Note**: Changes to the above repos are required as some of our customers
 do not use our bundles for deployment.
+
+> **Note**: Dont miss our [badges](https://github.com/charmed-kubernetes/bundle/pull/868)
+from the bundle repo like we always do!
 
 ### Bump snap channel to next minor release
 
-Once the rebase has occurred we need to bump the same charms and bundle
+Once the rebase has occurred we should bump the same charms and bundle
 fragments in the `main` git branches to the next k8s minor version,
-e.g. `1.26/edge`. You don't have to do this right away; in fact, you
+e.g. `1.27/edge`. You don't have to do this right away; in fact, you
 should wait until you actually have snaps in the `$next++/edge` channels
 before making this change.
 
@@ -144,7 +146,7 @@ which must correspond to a valid tag in our
 
 > **Note**: Currently, the **CDK-ADDONS** snap needs to be manually built for
 > the appropriate channels:
-> - https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-1.25/
+> - https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-1.26/
 
 ### Run **validate-charm-release-upgrade** job
 

--- a/jobs/validate-offline/spec.yml
+++ b/jobs/validate-offline/spec.yml
@@ -1,7 +1,7 @@
 plan:
   - &BASE_JOB
     env:
-      - SNAP_VERSION=1.25/edge
+      - SNAP_VERSION=1.26/edge
       - JUJU_DEPLOY_BUNDLE=charmed-kubernetes
       - JUJU_DEPLOY_CHANNEL=edge
       - JUJU_CLOUD=aws/us-east-1


### PR DESCRIPTION
- Drop anything less than n-4 from our supported enums; upstream k8s doesn't release new things there, so there's no reason for us to keep checking those branches.

- Update the GA release doc with references to what we did for the 1.26 GA.

- Drive by to bump our validate-offline job to use `1.26/edge` (even though it's not a current job; it might become one in the future)