### PR TITLE
1.26 (non-SQA) job updates

### DIFF
--- a/jobs/arc-conformance.yaml
+++ b/jobs/arc-conformance.yaml
@@ -20,7 +20,7 @@
     parameters:
       - string:
           name: CK_VERSION
-          default: '1.25'
+          default: '1.26'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.
@@ -44,6 +44,6 @@
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/arc-conformance"
-      - run-tox:
+      - run-venv:
           COMMAND: |
-           tox -e py38 -- bash jobs/arc-conformance/conformance-spec
+            bash jobs/arc-conformance/conformance-spec

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -19,7 +19,7 @@
     parameters:
       - string:
           name: CK_VERSION
-          default: '1.25'
+          default: '1.26'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.
@@ -38,6 +38,6 @@
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/cncf-conformance"
-      - run-tox:
+      - run-venv:
           COMMAND: |
-           tox -e py38 -- bash jobs/cncf-conformance/conformance-spec
+            bash jobs/cncf-conformance/conformance-spec

--- a/jobs/infra.yaml
+++ b/jobs/infra.yaml
@@ -2,7 +2,7 @@
 
 - project:
     name: infra
-    arch: ['amd64-0', 'amd64-1', 'amd64-2', 'amd64-3', 's390x', 'arm64']
+    arch: ['amd64-2', 'amd64-3', 'arm64', 's390x']
     jobs:
       - 'infra-maintain-nodes-{arch}'
 

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -8,11 +8,6 @@
     arm64: "{{ lookup('env', 'NEADER') }}"
     columbo_version: 0.0.4
   tasks:
-    - name: add golang ppa
-      apt_repository:
-        repo: "ppa:longsleep/golang-backports"
-      tags:
-        - jenkins
     - name: update /etc/environment
       copy:
         src: "fixtures/environment"
@@ -58,6 +53,7 @@
         apt-get install -qyf \
           build-essential \
           fakeroot \
+          cargo \
           curl \
           dh-systemd \
           debhelper \
@@ -105,14 +101,15 @@
     - name: remove unused debs
       shell: |
         sudo apt-get remove -qyf \
+          golang \
           python-pip \
           juju \
+          juju-wait \
           lxd \
           lxd-client \
           lxcfs \
           lxc-common \
           liblxc1 \
-          juju-wait \
           libsodium-dev \
           snapcraft
       tags:

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -113,14 +113,14 @@
           type: user-defined
           name: upgrade_snap
           values:
-            - 1.25/beta
+            - 1.26/beta
       - axis:
           # each value represents the snap channel before the upgrade
           type: user-defined
           name: deploy_snap
           values:
+            - 1.25/stable
             - 1.24/stable
-            - 1.23/stable
       - axis:
           type: user-defined
           name: series


### PR DESCRIPTION
These changes won't affect SQA for 1.26, but we'll need to make them sooner or later:

- update conformance jobs
  - 1.26 by default
  - fix issue running `tox -- bash`; we could whitelist bash, but these jobs don't need to run with tox, so just bash 'em directly
  - jobs with this branch: https://jenkins.canonical.com/k8s/view/Conformance/

- update infra jobs
  - drop our dead agents (amd-0 and amd-1 were replaces by ps5-amd-*)
  - remove the golang apt pkg and ppa (we get go from the snap store)
  - include rust/cargo to build recent pip `cryptography` package; binary wheels are available for amd64, but we have to build this on other arches

- update release job
  - the job was manually updated/run in jenkins; need this PR to ensure the job source matches what we actually ran
---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge: arc-conformance.yaml, cncf-conformance.yaml, infra.yaml, release.yaml