### PR TITLE
remove CSIMigrationvSphere=True in 1.26.0 and beyond

### DIFF
--- a/jobs/integration/templates/integrator-charm-data/vsphere/out-of-tree.yaml
+++ b/jobs/integration/templates/integrator-charm-data/vsphere/out-of-tree.yaml
@@ -14,3 +14,4 @@ in-relations:
     - kubernetes-control-plane:vsphere
   - - vsphere-integrator:clients
     - kubernetes-worker:vsphere
+in-tree-until: '1.25'


### PR DESCRIPTION
* remove in-tree vsphere testing at 1.26.0 and beyond
* similar to other cloud's [testing config](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/integration/templates/integrator-charm-data/gce/out-of-tree.yaml)