### PR TITLE
Add metallb image resources to resource spec

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -26,6 +26,10 @@
   cni-s390x: '{out_path}/cni-s390x.tgz'
 'kube-ovn':
   kubectl-ko: '{src_path}/plugins/kubectl-ko'
+'metallb-controller':
+  metallb-controller-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
+'metallb-speaker':
+  metallb-speaker-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
 'tigera-secure-ee':
   calico-cni: '{out_path}/calico-cni-amd64.tar.gz'
   calico-cni-arm64: '{out_path}/calico-cni-arm64.tar.gz'


### PR DESCRIPTION
This should allow PRs like https://github.com/charmed-kubernetes/metallb-operator/pull/27 to actually update the MetalLB image.

The relevant code in CI is [here](https://github.com/charmed-kubernetes/jenkins/blob/077a8daedafb18d43b271efd76aa754978782bbd/jobs/build-charms/charms.py#L832-L843) and as far as I can tell, the key needs to be present in the resource spec, but the value does not matter.