### PR TITLE
Use nagios_hostname_type='unit' on nrpe to ensure hostnames match expected unit names

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2321,6 +2321,7 @@ async def nagios(model, tools):
             series=series,
             config=dict(
                 ro_filesystem_excludes=",".join(excludes),
+                nagios_hostname_type="unit",  # always use unit names for hostnames in nagios
                 space_check="check: disabled",  # don't run the space_check
                 swap="",
                 swap_activity="",


### PR DESCRIPTION
All nagios validation tests have been failing on arm64 units running focal.  

Ultimately, it's because this change to [systemd](https://github.com/systemd/systemd/issues/18929) wasn't backported for ubuntu focal, whereas it is available in jammy

This fix helps the nrpe charm identify Amazon EC2 instnaces as "VMs" rather than metal.  In these tests we don't really care, we want the hostnames in the nagios checks to appear as unit names.  A quick config of the charm patches that right up