### PR TITLE
Fix latest snap tracks get stuck when released rev > desired rev

### DIFF
--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -101,7 +101,7 @@ class SnapService(DebugMixin):
             max_stable_rev = self.snap_model.latest_revision(
                 track=f"latest/stable", arch=arch
             )
-            if max_stable_rev < max_track_rev:
+            if max_stable_rev != max_track_rev:
                 self.log(
                     f"Track revisions do not match {max_track_rev} != {max_stable_rev}, syncing stable snaps to latest track"
                 )


### PR DESCRIPTION
A few of our snaps are stuck have their latest channels stuck on 1.24, e.g.:

```
$ snap info kubelet
...
channels:
  latest/stable:    1.24.9         2023-01-04 (2776) 22MB classic
  latest/candidate: 1.24.9         2023-01-04 (2776) 22MB classic
  latest/beta:      1.24.9         2023-01-04 (2776) 22MB classic
  latest/edge:      1.24.9         2023-01-04 (2776) 22MB classic
```

The sync-snaps job is refusing to put 1.26 revs here because the 1.24 rev is greater:

```
20:13:59 02:13:59 | INFO [kubelet] Checking snaps in version 1.26 for arch amd64
20:13:59 02:13:59 | INFO [kubelet] kubelet revision 2776 == 2773, no promotion needed.
20:13:59 02:13:59 | INFO [kubelet] Checking snaps in version 1.26 for arch ppc64el
20:13:59 02:13:59 | INFO [kubelet] kubelet revision 2786 == 2783, no promotion needed.
20:13:59 02:13:59 | INFO [kubelet] Checking snaps in version 1.26 for arch s390x
20:13:59 02:13:59 | INFO [kubelet] kubelet revision 2791 == 2788, no promotion needed.
20:13:59 02:13:59 | INFO [kubelet] Checking snaps in version 1.26 for arch arm64
20:13:59 02:13:59 | INFO [kubelet] kubelet revision 2796 == 2795, no promotion needed.
```

I think if we change this condition to an actual `!=` then it should put 1.26 in there and restore latest/stable to what we want.