### PR TITLE
test coredns with version 1.10.0 resource

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1927,7 +1927,7 @@ async def test_dns_provider(model, k8s_model, tools):
         series = os.environ["SERIES"]
         with NamedTemporaryFile("w") as f:
             f.write(
-                '{"ImageName": "rocks.canonical.com:443/cdk/coredns/coredns:1.6.7"}'
+                '{"ImageName": "rocks.canonical.com:443/cdk/coredns/coredns:1.10.0"}'
             )
             f.flush()
             await tools.run(


### PR DESCRIPTION
Override the resource to use `1.6.7` -> `1.10.0`
* verified it works on `arm64` and `amd64` workers