### PR TITLE
upload oci-image resources by `<image-id>` rather than `<name:tag>`

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -854,7 +854,7 @@ class BuildEntity:
                     # Pulls only the amd64 image locally
                     docker.pull(upstream_source)
                     # Use the local image-id from `docker images <upstream-source> -q`
-                    resource_fmt = docker.images(upstream_source, "-q")
+                    resource_fmt = docker.images(upstream_source, "-q").strip()
                 resource_spec[name] = ("image", resource_fmt)
             elif details["type"] == "file":
                 resource_spec[name] = (


### PR DESCRIPTION
`charmcraft` command now requires either the local image-id or a local/remote digest. 
uploading oci-image resources by tag is no longer permitted.

this can effectively be implemented by 

```bash
docker pull <image-tag>
image_id=$(docker images <image-tag> -q)
charmcraft upload-resource <charm> <resource-name> --image=${image_id} -v
```

I wrapped the docker command here with `DockerCmd` so the jenkins build logs would tee the command results to the logs
