### PR TITLE
kubernetes bundles require `scale` not `num_units`

### DIFF
--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -65,12 +65,12 @@ applications:
   sriov-cni:
     charm: sriov-cni
     channel: $JUJU_DEPLOY_CHANNEL
-    num_units: 1
+    scale: 1
     trust: true
   sriov-network-device-plugin:
     charm: sriov-network-device-plugin
     channel: $JUJU_DEPLOY_CHANNEL
-    num_units: 1
+    scale: 1
     trust: true
     options:
       resource-list: |-


### PR DESCRIPTION
within a kubernetes-model, we don't use `num_units` but `scale` instead

https://juju.is/docs/sdk/kubernetes-vs-non-kubernetes-bundles#heading--kubernetes-bundles