### PR TITLE
Update k8s 1.23 and 1.24 to build with golang 1.19

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -47,8 +47,8 @@ K8S_GO_MAP = {
     "1.27": "go/1.19/stable",
     "1.26": "go/1.19/stable",
     "1.25": "go/1.19/stable",
-    "1.24": "go/1.18/stable",
-    "1.23": "go/1.17/stable",
+    "1.24": "go/1.19/stable",
+    "1.23": "go/1.19/stable",
 }
 
 # Snap k8s version <-> track mapping


### PR DESCRIPTION
Rationale: https://groups.google.com/a/kubernetes.io/g/dev/c/RollV1z4fNQ/m/nbTi3AhNCgAJ

> We updated Kubernetes 1.24 (release-1.24) and 1.23 (release-1.23) release branches to Go 1.19. The upcoming 1.24.10 and 1.23.16 patch releases scheduled for January 18 will be built with Go 1.19.5.