### PR TITLE
ensure special `juju-wait` arguments aren't hyphenated when called

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -201,6 +201,13 @@ class Tools:
         """
         if "m" not in kwargs:
             kwargs["m"] = self.connection
+
+        # max_wait and retry_errors are special
+        # kwargs that shouldn't be hyphenated when calling `juju-wait`
+        # swap the long form arg for its shortened version
+        for arg, short in [("max_wait", "t"), ("retry_errors", "r")]:
+            if arg in kwargs:
+                kwargs[short] = kwargs.pop(arg)
         kwargs.update(dict(w=True, v=True))  # workload + verbose
         juju_wait = sh.Command("/snap/bin/juju-wait")
         command = shlex.split(str(juju_wait.bake(**kwargs)))


### PR DESCRIPTION
Prior adjustments to juju-wait using the `sh` class began invoking juju-wait like this:

```bash
[validate-ck-vsphere-amd64-focal-1.25-edge] jobs/integration/validation.py::test_toggle_metrics usage: juju-wait [-h] [-e MODEL] [--description] [-q] [-v] [-w] [-t MAX_WAIT]
[validate-ck-vsphere-amd64-focal-1.25-edge]                  [-r N] [-x EXCLUDE] [--machine-exclude MACHINE_EXCLUDE]
[validate-ck-vsphere-amd64-focal-1.25-edge]                  [--machine-error-timeout MACHINE_ERROR_TIMEOUT]
[validate-ck-vsphere-amd64-focal-1.25-edge]                  [--machine-pending-timeout MACHINE_PENDING_TIMEOUT]
[validate-ck-vsphere-amd64-focal-1.25-edge]                  [--version]
[validate-ck-vsphere-amd64-focal-1.25-edge] juju-wait: error: unrecognized arguments: --max-wait=600
```

it turns out that two long-form arguments don't use hyphenated keywords: `max_wait` and `retry_errors`

Let's handle those in the `conftest.py`