### PR TITLE
Update series upgrade automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ custom options:
   --snapd-upgrade       run tests with upgraded snapd
   --snapd-channel=SNAPD_CHANNEL
                         Snap channel to install snapcore from
+  --vault-unseal-command=VAULT_UNSEAL_COMMAND
+                        Command to run to unseal vault after a series upgrade
 ```
 
 This tells us what the commandline is to run this test and what parameters we

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -102,6 +102,14 @@ def pytest_addoption(parser):
         help="This test should perform a series upgrade",
     )
 
+    parser.addoption(
+        "--vault-unseal-command",
+        action="store",
+        required=False,
+        default="",
+        help="Command to run to unseal vault after a series upgrade",
+    )
+
 
 class Tools:
     """Utility class for accessing juju related tools"""
@@ -127,6 +135,7 @@ class Tools:
         self.k8s_connection = f"{self.controller_name}:{self.k8s_model_name_full}"
         self.is_series_upgrade = request.config.getoption("--is-series-upgrade")
         self.charm_channel = request.config.getoption("--charm-channel")
+        self.vault_unseal_command = request.config.getoption("--vault-unseal-command")
 
     async def run(self, cmd: str, *args: str, stdin=None, _tee=False):
         """

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -3,10 +3,12 @@ import functools
 import ipaddress
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import time
 import traceback
+import yaml
 from pathlib import Path
 
 from contextlib import contextmanager
@@ -473,6 +475,12 @@ def _units(machine: Machine):
     ]
 
 
+def _primary_unit(machine: Machine):
+    for unit in _units(machine):
+        if not unit.subordinate:
+            return unit
+
+
 async def wait_for_status(workload_status: str, units: Union[Unit, Sequence[Unit]]):
     """
     Wait for unit or units to reach a specific workload_state or fail in 120s.
@@ -513,6 +521,45 @@ async def wait_for_application_status(model, app_name, status="active"):
         raise AssertionError(f"Application has unexpected status: {app.status.status}")
 
 
+async def refresh_openstack_charms(machine, new_series, tools):
+    """The openstack charms (ceph, hacluster, mysql) have to switch to a newer channel
+    before they can do a series upgrade.
+    """
+    get_series = lambda charm_info, channel: {
+        p["series"] for p in charm_info["channel-map"][channel]["platforms"]
+    }
+
+    for unit in _units(machine):
+        app = unit.machine.model.applications[unit.application]
+        charm_name = "-".join(app.data["charm-url"].split("/")[-1].split("-")[:-1])
+        charm_info = await unit.machine.model.charmhub.info(charm_name)
+        if charm_info["publisher"] != "OpenStack Charmers":
+            continue
+
+        app_info = await app._facade().GetCharmURLOrigin(application=app.name)
+        app_info = app_info.charm_origin
+        current_channel = "/".join((app_info["track"] or "latest", app_info["risk"]))
+        if new_series in get_series(charm_info, current_channel):
+            continue
+
+        for channel, channel_info in charm_info["channel-map"].items():
+            if (
+                app_info["risk"] == channel_info["risk"]
+                and new_series in get_series(charm_info, channel)
+                and app_info["series"] in get_series(charm_info, channel)
+            ):
+                new_channel = channel
+                break
+        else:
+            raise ValueError(
+                f"{app.name} on channel {current_channel} does not support {new_series}"
+                " and no channel is found to upgrade to."
+            )
+
+        log.info(f"Upgrading {app.name} to {new_channel} to suport {new_series}")
+        await app.refresh(channel=new_channel)
+
+
 async def prep_series_upgrade(machine, new_series, tools):
     log.info(f"preparing series upgrade for machine {machine.id}")
     await tools.run(
@@ -525,7 +572,16 @@ async def prep_series_upgrade(machine, new_series, tools):
         "prepare",
         new_series,
     )
-    await wait_for_status("blocked", _units(machine))
+    try:
+        await wait_for_status("blocked", _units(machine))
+    except AssertionError:
+        for unit in _units(machine):
+            # not all subordinates will go into "blocked", so also accept active idle
+            if unit.workload_status == "blocked" or (
+                unit.workload_status == "active" and unit.agent_status == "idle"
+            ):
+                continue
+            raise
 
 
 async def do_series_upgrade(machine):
@@ -548,7 +604,7 @@ async def do_series_upgrade(machine):
         pass
 
 
-async def finish_series_upgrade(machine, tools):
+async def finish_series_upgrade(machine, tools, new_series):
     log.info(f"completing series upgrade for machine {machine.id}")
     await tools.run(
         "juju",
@@ -559,7 +615,11 @@ async def finish_series_upgrade(machine, tools):
         machine.id,
         "complete",
     )
+    if _primary_unit(machine).application == "vault" and tools.vault_unseal_command:
+        tools.run(shlex.split(tools.vault_unseal_command))
     await wait_for_status("active", _units(machine))
+    series = await machine.ssh("lsb_release -cs")
+    assert series.strip() == new_series
 
 
 class JujuRunError(AssertionError):

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -35,6 +35,7 @@ from .utils import (
     is_localhost,
     validate_storage_class,
     SERIES_ORDER,
+    refresh_openstack_charms,
     prep_series_upgrade,
     do_series_upgrade,
     finish_series_upgrade,
@@ -2579,19 +2580,24 @@ async def test_ceph(model, tools):
 async def test_series_upgrade(model, tools):
     if not tools.is_series_upgrade:
         pytest.skip("No series upgrade argument found")
-    worker = model.applications["kubernetes-worker"].units[0]
-    old_series = worker.machine.series
-    try:
-        new_series = SERIES_ORDER[SERIES_ORDER.index(old_series) + 1]
-    except IndexError:
-        pytest.skip("no supported series to upgrade to")
-    except ValueError:
-        pytest.skip("unrecognized series to upgrade from: {old_series}")
+    skipped = True
     for machine in model.machines.values():
+        old_series = machine.series
+        try:
+            new_series = SERIES_ORDER[SERIES_ORDER.index(old_series) + 1]
+            skipped = False
+        except IndexError:
+            log(f"no supported series to upgrade machine {machine} to")
+            continue
+        except ValueError:
+            log(f"unrecognized series to upgrade machine {machine} from: {old_series}")
+            continue
+        await refresh_openstack_charms(machine, new_series, tools)
         await prep_series_upgrade(machine, new_series, tools)
         await do_series_upgrade(machine)
-        await finish_series_upgrade(machine, tools)
-        assert machine.series == new_series
+        await finish_series_upgrade(machine, tools, new_series)
+    if skipped:
+        pytest.skip(f"no supported series to upgrade to")
     expected_messages = {
         "kubernetes-control-plane": "Kubernetes control-plane running.",
         "kubernetes-worker": "Kubernetes worker running.",


### PR DESCRIPTION
Update series upgrade automation:
- Add an option for a custom command to unseal vault after upgrade
- Switch channels of OpenStack charms before upgrading
- Don't skip upgrading if some machine are upgraded already