### PR TITLE
Add Cilium to charm support matrix

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -8,6 +8,9 @@
   calico: '{out_path}/calico-amd64.tar.gz'
   calico-arm64: '{out_path}/calico-arm64.tar.gz'
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
+'cilium':
+  cilium: '{out_path}/cilium.tar.gz'
+  hubble: '{out_path}/hubble.tar.gz'
 'coredns':
   coredns-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
 'flannel':

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -40,6 +40,21 @@
     upstream: 'https://github.com/charmed-kubernetes/ceph-csi-operator.git'
     channel-range:
       min: '1.25'
+- cilium:
+    bugs: 'https://bugs.launchpad.net/charm-cilium'
+    build-resources: 'cd {out_path}; bash {src_path}/fetch-resources.sh'
+    docs: 'https://charmhub.io/cilium/docs'
+    downstream: charmed-kubernetes/charm-cilium.git
+    store: 'https://charmhub.io/cilium'
+    summary: eBPF-based Networking, Observability, Security
+    architectures: [amd64, arm64]
+    tags:
+      - k8s
+      - cilium
+      - cni
+    upstream: 'https://github.com/charmed-kubernetes/charm-cilium.git'
+    channel-range:
+      min: '1.26'
 - containerd:
     bugs: 'https://bugs.launchpad.net/charm-containerd'
     docs: 'https://charmhub.io/containerd/docs'


### PR DESCRIPTION
## Changes
- Include Cilium in `charm-support-matrix`
- Include Cilium resources in `resource-spec`
---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge
