### PR TITLE
use generic `ctr content fetch` rather than `ctr image pull` when syncing images

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -193,11 +193,11 @@ pipeline {
                             echo "Dry run; would have pulled: \${STAGING_IMAGE}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${STAGING_IMAGE} --all-platforms --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
+                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch \${STAGING_IMAGE} --all-platforms --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image pull \${STAGING_IMAGE} --all-platforms --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
+                                sudo lxc exec ${lxc_name} -- ctr content fetch \${STAGING_IMAGE} --all-platforms --user "${env.REGISTRY_CREDS_USR}:${env.REGISTRY_CREDS_PSW}" >/dev/null
                             fi
                         fi
 

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -163,11 +163,11 @@ pipeline {
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
+                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
+                                sudo lxc exec ${lxc_name} -- ctr content fetch \${i} --all-platforms >/dev/null
                             fi
                         fi
 
@@ -250,11 +250,11 @@ pipeline {
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
+                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr image pull \${i} --all-platforms >/dev/null
+                                sudo lxc exec ${lxc_name} -- ctr content fetch \${i} --all-platforms >/dev/null
                             fi
                         fi
 


### PR DESCRIPTION
i've been seeing issues crop up with images that have likely been handled with a newish version of docker. 

the main symptom is pulling such an image with containerd yields a message like this:
```
ctr: failed to extract layer sha256:5d3ca636a2578939609b5325681f5523297bbbe9582621eef178bf92810cbfa0: failed to get stream processor for application/vnd.in-toto+json: no processor for media-type: unknown
```

I see a number of issues surrounding this with microk8s
* [Issue #1](https://stackoverflow.com/questions/75206791/createcontainererror-with-microk8s-ghrc-io-image)
* [Issue #2](https://github.com/canonical/microk8s/issues/3687)

I can EASILY pull the same image with `docker pull` so i'm suspecting something is wrong in containerd

[docker docs](https://docs.docker.com/build/attestations/attestation-storage/) claim this is part of an attestation manifest in the oci image, and that 

> Any unknown mediaTypes should be ignored

I was suggested to try using `ctr content fetch` rather than `ctr image pull` in order to ignore those media-types

- [ ] Needs `jjb` after merge