### PR TITLE
1.27 binaries bumps to 1.20 go snap

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -44,7 +44,7 @@ K8S_CRI_TOOLS_SEMVER = "1.19"
 
 # Kubernetes build source to go version map
 K8S_GO_MAP = {
-    "1.27": "go/1.19/stable",
+    "1.27": "go/1.20/stable",
     "1.26": "go/1.19/stable",
     "1.25": "go/1.19/stable",
     "1.24": "go/1.19/stable",


### PR DESCRIPTION
Based on [upstream](https://github.com/kubernetes/kubernetes/commit/b9ddf07a75e728cd28582089ded406e5c15c90d3)