### PR TITLE
Crash if k8s version is missing from K8S_GO_MAP

### DIFF
--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -63,10 +63,9 @@ class SnapService(DebugMixin):
                 snapcraft_yml_context = {
                     "snap_version": branch.lstrip("v"),
                     "patches": [],
-                    "go_version": enums.K8S_GO_MAP.get(
-                        f"{k8s_major_minor.major}.{k8s_major_minor.minor}",
-                        "go/1.19/stable",
-                    ),
+                    "go_version": enums.K8S_GO_MAP[
+                        f"{k8s_major_minor.major}.{k8s_major_minor.minor}"
+                    ]
                 }
 
                 # Starting with 1.19 and beyond, build snaps with a base snap of core18 or

--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -65,7 +65,7 @@ class SnapService(DebugMixin):
                     "patches": [],
                     "go_version": enums.K8S_GO_MAP[
                         f"{k8s_major_minor.major}.{k8s_major_minor.minor}"
-                    ]
+                    ],
                 }
 
                 # Starting with 1.19 and beyond, build snaps with a base snap of core18 or


### PR DESCRIPTION
I get nervous that we're gonna accidentally build something with the wrong golang version because a k8s version is missing from K8S_GO_MAP. I propose instead of continuing with a potentially wrong golang version, just crash instead.