### PR TITLE
Update AWS iam testing to be re-runnable

### DIFF
--- a/jobs/integration/test_aws_iam.py
+++ b/jobs/integration/test_aws_iam.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import pytest
 import random
 import json
@@ -85,6 +86,7 @@ async def verify_auth_failure(one_control_plane, args):
         "invalid user credentials" in error_text
         or "error" in error_text
         or "forbidden" in error_text
+        or "accessdenied" in error_text
     )
 
 
@@ -105,6 +107,23 @@ async def patch_kubeconfig_and_verify_aws_iam(one_control_plane, arn):
         log("Unable to find AWS IAM information in kubeconfig, retrying...")
         await asyncio.sleep(10)
     assert "aws-iam-user" in output.stdout
+
+
+@contextlib.asynccontextmanager
+async def aws_iam_charm(model, tools):
+    orig_deployed = "aws-iam" in model.applications
+    if not orig_deployed:
+        log("deploying aws-iam")
+        await model.deploy("aws-iam", channel=tools.charm_channel, num_units=0)
+        await model.add_relation("aws-iam", "kubernetes-control-plane")
+        await model.add_relation("aws-iam", "easyrsa")
+        log("waiting for cluster to settle...")
+    await tools.juju_wait()
+    try:
+        yield
+    finally:
+        if not orig_deployed:
+            await model.applications["aws-iam"].destroy()
 
 
 async def test_validate_aws_iam(model, tools):
@@ -130,16 +149,11 @@ async def test_validate_aws_iam(model, tools):
         return
 
     # 1) deploy
-    log("deploying aws-iam")
-    await model.deploy("aws-iam", channel=tools.charm_channel, num_units=0)
-    await model.add_relation("aws-iam", "kubernetes-control-plane")
-    await model.add_relation("aws-iam", "easyrsa")
-    log("waiting for cluster to settle...")
-    await tools.juju_wait()
-
-    # 2) deploy CRD for test
-    log("deploying crd")
-    cmd = """/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f - << EOF
+    await masters.set_config({"authorization-mode": "AlwaysAllow"})
+    async with aws_iam_charm(model, tools):
+        # 2) deploy CRD for test
+        log("deploying crd")
+        cmd = """/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f - << EOF
 apiVersion: iamauthenticator.k8s.aws/v1alpha1
 kind: IAMIdentityMapping
 metadata:
@@ -150,55 +164,55 @@ spec:
   groups:
   - view
 EOF""".format(
-        os.environ["AWSIAMARN"]
-    )
-    # Note that we patch a single master's kubeconfig to have the arn in it,
-    # so we need to use that one master for all commands
-    one_control_plane = random.choice(masters.units)
-    output = await juju_run(one_control_plane, cmd, check=False, timeout=15)
-    assert output.status == "completed"
+            os.environ["AWSIAMARN"]
+        )
+        # Note that we patch a single master's kubeconfig to have the arn in it,
+        # so we need to use that one master for all commands
+        one_control_plane = random.choice(masters.units)
+        output = await juju_run(one_control_plane, cmd, check=False, timeout=15)
+        assert output.status == "completed"
 
-    # 3 & 4) grab config and verify aws-iam is inside
-    log("verifying kubeconfig")
-    await patch_kubeconfig_and_verify_aws_iam(
-        one_control_plane, os.environ["AWSIAMARN"]
-    )
+        # 3 & 4) grab config and verify aws-iam is inside
+        log("verifying kubeconfig")
+        await patch_kubeconfig_and_verify_aws_iam(
+            one_control_plane, os.environ["AWSIAMARN"]
+        )
 
-    # 5) get aws-iam-authenticator binary
-    log("getting aws-iam binary")
-    cmd = "curl -s https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest"
-    data = json.loads(check_output(split(cmd)).decode("utf-8"))
-    for asset in data["assets"]:
-        if "linux_amd64" in asset["browser_download_url"]:
-            latest_release_url = asset["browser_download_url"]
-            break
+        # 5) get aws-iam-authenticator binary
+        log("getting aws-iam binary")
+        cmd = "curl -s https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest"
+        data = json.loads(check_output(split(cmd)).decode("utf-8"))
+        for asset in data["assets"]:
+            if "linux_amd64" in asset["browser_download_url"]:
+                latest_release_url = asset["browser_download_url"]
+                break
 
-    auth_bin = "/usr/local/bin/aws-iam-authenticator"
-    cmd = "wget -q -nv -O {} {}"
-    output = await juju_run(
-        one_control_plane, cmd.format(auth_bin, latest_release_url), timeout=15
-    )
-    assert output.status == "completed"
+        auth_bin = "/usr/local/bin/aws-iam-authenticator"
+        cmd = "wget -q -nv -O {} {}"
+        output = await juju_run(
+            one_control_plane, cmd.format(auth_bin, latest_release_url), timeout=15
+        )
+        assert output.status == "completed"
 
-    output = await juju_run(
-        one_control_plane, "chmod a+x {}".format(auth_bin), timeout=15
-    )
-    assert output.status == "completed"
+        output = await juju_run(
+            one_control_plane, "chmod a+x {}".format(auth_bin), timeout=15
+        )
+        assert output.status == "completed"
 
-    # 6) Auth as a user - note that creds come in the environment as a
-    #    jenkins secret
-    await verify_auth_success(one_control_plane, "get po")
+        # 6) Auth as a user - note that creds come in the environment as a
+        #    jenkins secret
+        await verify_auth_success(one_control_plane, "get po")
 
-    # 7) turn on RBAC and add a test user
-    await masters.set_config({"authorization-mode": "RBAC,Node"})
-    log("waiting for cluster to settle...")
-    await tools.juju_wait()
+        # 7) turn on RBAC and add a test user
+        await masters.set_config({"authorization-mode": "RBAC,Node"})
+        log("waiting for cluster to settle...")
+        await tools.juju_wait()
 
-    # 8) verify failure
-    await verify_auth_failure(one_control_plane, "get po")
+        # 8) verify failure
+        await verify_auth_failure(one_control_plane, "get po")
 
-    # 9) grant user access
-    cmd = """/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f - << EOF
+        # 9) grant user access
+        cmd = """/snap/bin/kubectl --kubeconfig /root/.kube/config apply -f - << EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -228,15 +242,11 @@ roleRef:
   name: pod-reader
   apiGroup: rbac.authorization.k8s.io
 EOF"""
-    output = await juju_run(one_control_plane, cmd, timeout=15)
-    assert output.status == "completed"
+        output = await juju_run(one_control_plane, cmd, timeout=15)
+        assert output.status == "completed"
 
-    # 10) verify success
-    await verify_auth_success(one_control_plane, "get po")
+        # 10) verify success
+        await verify_auth_success(one_control_plane, "get po")
 
-    # 11) verify overstep failure
-    await verify_auth_failure(one_control_plane, "get po -n kube-system")
-
-    # teardown
-    await masters.set_config({"authorization-mode": "AlwaysAllow"})
-    await model.applications["aws-iam"].destroy()
+        # 11) verify overstep failure
+        await verify_auth_failure(one_control_plane, "get po -n kube-system")


### PR DESCRIPTION
Monthly tests of aws-iam have been failing for a while due to [kubernetes deprecations](https://github.com/charmed-kubernetes/charm-aws-iam/pull/12)

These changes allowed me to re-run the test over and over without tearing down an already installed aws-iam-charm which was in the model. 

note the new error when trying to authenticate is `accessdenied` rather than `error` or `forbidden`