### PR TITLE
Tested basic validation on vsphere with juju 3.0/stable channel

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -149,7 +149,7 @@ class Tools:
             "focal": "ubuntu@20.04",
             "jammy": "ubuntu@22.04",
         }
-        return f"--series={mapping[series]}"
+        return f"--base={mapping[series]}"
 
     async def run(self, cmd: str, *args: str, stdin=None, _tee=False):
         """

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -209,7 +209,7 @@ class Tools:
         return_code = await proc.wait()
         if return_code != 0:
             raise Exception(
-                f"Problem with run command {' ',join((cmd, *args))} (exit {return_code}):\n"
+                f"Problem with run command {' '.join((cmd, *args))} (exit {return_code}):\n"
                 f"stdout:\n{str(stdout, 'utf8')}\n"
                 f"stderr:\n{str(stderr, 'utf8')}\n"
             )


### PR DESCRIPTION
This PR allows for validation testing to run with a juju 2.9 or juju 3.0 client/controller pair.  
The snap which is used to bootstrap the controller, should be the same snap version used while running the tests. 

There's even a bit of preparation in this PR for juju 3.1 though it's not yet fully tested

Other tests may still be failing with juju 3.0 -- only the basic ck-validation on vsphere was tested

Depends on the successful merge and  build of a kubernetes-control-plane charm 
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/267