### PR TITLE
let lp builders infer the snap series from snapcraft.yaml

### DIFF
--- a/cilib/lp.py
+++ b/cilib/lp.py
@@ -95,7 +95,6 @@ class Client:
             snap = self.snaps.new(
                 name=lp_snap_name,
                 owner=lp_owner,
-                distro_series=self.distro_series(),
                 git_repository=self.snap_git_repo(lp_owner, lp_snap_project_name),
                 git_path=branch,
                 store_upload=True,


### PR DESCRIPTION
All of our snap recipes have `xenial` set as the distro series ([example](https://launchpad.net/~k8s-jenkaas-admins/+snap/kube-apiserver-1.26/+edit)).  While this doesn't seem to have any effect on the contents of the snap, it is confusing to see 'xenial' when looking through the snap recipes of our core18/core20 snaps.

According to the [lp snap.new api](https://launchpad.net/+apidoc/devel.html#snaps), `distro_series` is optional and will be inferred from snapcraft.yaml.  Let's let that happen for future k8s versions (existing snap recipes will remain as they are).