### PR TITLE
Revert "let lp builders infer the snap series from snapcraft.yaml"

### DIFF
--- a/cilib/lp.py
+++ b/cilib/lp.py
@@ -95,6 +95,7 @@ class Client:
             snap = self.snaps.new(
                 name=lp_snap_name,
                 owner=lp_owner,
+                distro_series=self.distro_series(),
                 git_repository=self.snap_git_repo(lp_owner, lp_snap_project_name),
                 git_path=branch,
                 store_upload=True,


### PR DESCRIPTION
Reverts charmed-kubernetes/jenkins#1209

Reverting this until we understand this error better:
```
+ make WHAT=cmd/kube-proxy
error: no curl, wget, or fetch found
```

This is new since the series changed and I do not like that we are now publishing snaps where this error occurs in the build. What is failing to fetch? Is something missing in the snap?