### PR TITLE
Revert "Revert "let lp builders infer the snap series from snapcraft.yaml""

### DIFF
--- a/cilib/lp.py
+++ b/cilib/lp.py
@@ -95,7 +95,6 @@ class Client:
             snap = self.snaps.new(
                 name=lp_snap_name,
                 owner=lp_owner,
-                distro_series=self.distro_series(),
                 git_repository=self.snap_git_repo(lp_owner, lp_snap_project_name),
                 git_path=branch,
                 store_upload=True,


### PR DESCRIPTION
Reverts charmed-kubernetes/jenkins#1210

... and reintroduces @kwmonroe's much-appreciated #1209.

The error comes from new behavior in k8s 1.27 ([upstream PR](https://github.com/kubernetes/kubernetes/pull/115377)) and is harmless since the build continues using the host's go toolchain. Nothing to do with the changed distribution, so we can safely re-introduce this.