### PR TITLE
Use core20 base in k8s 1.27 pre-release builds

### DIFF
--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -68,7 +68,7 @@ class SnapService(DebugMixin):
                     ],
                 }
 
-                if semver.compare(str(k8s_major_minor), "1.27.0") >= 0:
+                if semver.compare(str(k8s_major_minor), "1.27.0-alpha.0") >= 0:
                     snapcraft_yml_context["base"] = "core20"
                 elif semver.compare(str(k8s_major_minor), "1.19.0") >= 0:
                     snapcraft_yml_context["base"] = "core18"


### PR DESCRIPTION
This comparison didn't quite work how we wanted; 1.27 pre-release builds are still building on core18.

To fix it, compare against the earliest pre-release version instead.