### PR TITLE
fix typo building autoscaler overlay

### DIFF
--- a/jobs/validate/autoscaler-spec
+++ b/jobs/validate/autoscaler-spec
@@ -17,7 +17,6 @@ set -x
 function juju::deploy::overlay
 {
     tee overlay.yaml <<EOF > /dev/null
-    cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
   kubernetes-control-plane:


### PR DESCRIPTION
to `tee` or not to `tee`, that is the question:

the answer is obviously to `tee` and definitely not `cat`