### PR TITLE
Use mem and cpu based constraints where possible

### DIFF
--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -105,11 +105,9 @@ pipeline {
                                 }
 
                                 if (arch == "arm64") {
-                                    instance_type = "a1.2xlarge"
-                                    constraints = "instance-type=${instance_type} root-disk=80G arch=${arch}"
+                                    constraints = "mem=16G cores=8 root-disk=80G arch=${arch}"
                                     eksd_instance_type = "m6g.large"
                                 } else if (arch == "amd64") {
-                                    instance_type = "m5.large"
                                     if ("${channel}" == "stable") {
                                         constraints = "instance-type=g3s.xlarge root-disk=80G arch=${arch}"
                                     } else {
@@ -125,7 +123,7 @@ pipeline {
                                     -d "${juju_model}" \
                                     --model-default test-mode=true \
                                     --model-default resource-tags="owner=k8sci job=${job} stage=${stage}" \
-                                    --bootstrap-constraints "instance-type=${instance_type}"
+                                    --bootstrap-constraints "mem=8G cores=2"
 
                                 juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu
 


### PR DESCRIPTION
We started getting the following error so this is a workaround to let juju decide on the instances.
```
17:43:14  + juju bootstrap aws/us-east-1 release-microk8s-beta-amd64 -d release-microk8s-beta-amd64-model --model-default test-mode=true --model-default 'resource-tags=owner=k8sci job=release-microk8s stage=beta-amd64' --bootstrap-constraints instance-type=m5.large
17:43:16  Creating Juju controller "release-microk8s-beta-amd64" on aws/us-east-1
17:43:31  ERROR invalid constraint value: instance-type=m5.large
23:35:53  valid values are: [c1.medium c1.medium c1.medium c1.xlarge c1.xlarge c1.xlarge c3.large c3.xlarge c3.2xlarge c3.8xlarge c3.4xlarge c3.large c3.4xlarge c3.xlarge c3.4xlarge c3.2xlarge c3.large c3.xlarge c3.xlarge c3.2xlarge c3.4xlarge c3.8xlarge c3.8xlarge cc2.8xlarge cc2.8xlarge cc2.8xlarge d2.2xlarge d2.xlarge d2.4xlarge d2.2xlarge d2.8xlarge d2.8xlarge d2.xlarge d2.8xlarge d2.2xlarge d2.8xlarge d2.2xlarge d2.4xlarge d2.8xlarge d2.4xlarge d2.4xlarge d2.xlarge d2.2xlarge d2.4xlarge g2.8xlarge g2.8xlarge g2.2xlarge g2.8xlarge g2.2xlarge g2.2xlarge g2.2xlarge i2.xlarge i2.xlarge i2.4xlarge i2.4xlarge i2.2xlarge i2.4xlarge i2.8xlarge i2.2xlarge i2.xlarge i2.8xlarge i2.8xlarge i2.4xlarge i2.xlarge i2.2xlarge i2.xlarge i2.8xlarge i2.2xlarge i2.8xlarge m1.small m1.medium m1.large m1.medium m1.large m1.xlarge m1.large m1.small m1.medium m1.small m1.medium m1.large m1.xlarge m1.small m1.xlarge m2.2xlarge m2.4xlarge m2.xlarge m2.xlarge m2.2xlarge m2.xlarge m2.4xlarge m2.xlarge m2.4xlarge m2.4xlarge m2.2xlarge m3.medium m3.xlarge m3.large m3.large m3.large m3.xlarge m3.xlarge m3.2xlarge m3.medium m3.medium m3.xlarge m3.2xlarge m3.2xlarge r3.2xlarge r3.2xlarge r3.xlarge r3.2xlarge r3.xlarge r3.4xlarge r3.4xlarge r3.large r3.4xlarge r3.2xlarge r3.8xlarge r3.large r3.large r3.4xlarge r3.8xlarge r3.xlarge r3.8xlarge r3.large t1.micro t1.micro t1.micro t1.micro]
```