### PR TITLE
adjust snapcraft call for core20

### DIFF
--- a/jobs/build-snaps/build-release-cdk-addons.groovy
+++ b/jobs/build-snaps/build-release-cdk-addons.groovy
@@ -132,7 +132,8 @@ pipeline {
 
                         echo "Build cdk-addons (\${arch}) snap."
                         sudo lxc shell ${lxc_name} -- bash -c \
-                            "cd /cdk-addons/build; SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft --target-arch=\${arch}"
+                            "cd /cdk-addons/build; \
+                            snapcraft --destructive-mode --enable-experimental-target-arch --target-arch=\${arch}"
                         sudo lxc shell ${lxc_name} -- bash -c "mv /cdk-addons/build/*.snap /"
                     done
                     cd -

--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -108,7 +108,7 @@ pipeline {
                         # is functionally equivalent to the alias. Single quote
                         # it because we need literal vars passed to 'bash -c'.
                         sudo lxc shell ${lxc_name} -- bash -c \
-                            'set -a; add-arg() { \$SNAPCRAFT_PART_BUILD/shared/add-arg-to-configure-hook \$@; }; set +a; '"cd /\${EKS_SNAP};"' SNAPCRAFT_BUILD_ENVIRONMENT=host snapcraft'
+                            'set -a; add-arg() { \$SNAPCRAFT_PART_BUILD/shared/add-arg-to-configure-hook \$@; }; set +a; '"cd /\${EKS_SNAP};"' snapcraft --destructive-mode'
                     done
                 """
             }


### PR DESCRIPTION
Set new lxd host params per the [Building Manually docs](https://snapcraft.io/docs/build-providers).  `core20` snaps also need an experimental target flag that `core18` snaps did not.

Looks good with cdk-addons and eks:

https://jenkins.canonical.com/k8s/job/build-release-cdk-addons-1.27/67/
https://jenkins.canonical.com/k8s/job/build-release-eks-snaps-amd64/70/

Review: stop short of merge as I'll need to reconfigure the above jobs to run from the `main` branch once this is approved.