### PR TITLE
handle dockerhub rate limits better

### DIFF
--- a/cilib.sh
+++ b/cilib.sh
@@ -69,6 +69,8 @@ scriptPath() {
 ci_docker_status()
 {
     # Get details of an authenticated dockerhub request
+
+    set +x
     local user=$1
     local pass=$2
     local token=$(curl --user "${user}:${pass}" \
@@ -76,6 +78,7 @@ ci_docker_status()
         jq -r .token)
     curl --head -H "Authorization: Bearer ${token}" \
         https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest 2>&1
+    set -x
 }
 
 ci_lxc_launch()

--- a/cilib.sh
+++ b/cilib.sh
@@ -66,6 +66,18 @@ scriptPath() {
     env python3 -c "import os,sys; print(os.path.dirname(os.path.abspath(\"$0\")))"
 }
 
+ci_docker_status()
+{
+    # Get details of an authenticated dockerhub request
+    local user=$1
+    local pass=$2
+    local token=$(curl --user "${user}:${pass}" \
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | \
+        jq -r .token)
+    curl --head -H "Authorization: Bearer ${token}" \
+        https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest 2>&1
+}
+
 ci_lxc_launch()
 {
     # Launch local LXD container to publish to charmcraft

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -43,7 +43,7 @@ pipeline {
 
                     # The line we care about should look like this:
                     #   ratelimit-remaining: 191;w=21600
-                    LIMIT=\$(echo \${STATUS} | grep -i remaining | grep -o '[0-9]*' | head -n1)
+                    LIMIT=\$(echo "\${STATUS}" | grep -i remaining | grep -o '[0-9]*' | head -n1)
                     if [[ -n \${LIMIT} && \${LIMIT} -le 250 ]]; then
                         echo Docker Hub rate limit is too low
                         exit 1

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -38,18 +38,18 @@ pipeline {
                 sh """#!/usr/bin/env bash
                     . \${WORKSPACE}/cilib.sh
 
-                    # Check rate limit; fail fast if we can't pull at least 25 images
+                    # Check rate limit; fail fast if we can't pull at least 50 images
                     STATUS=\$(ci_docker_status ${env.DOCKERHUB_CREDS_USR} ${env.DOCKERHUB_CREDS_PSW})
 
                     # The line we care about should look like this:
                     #   ratelimit-remaining: 191;w=21600
                     LIMIT=\$(echo "\${STATUS}" | grep -i remaining | grep -o '[0-9]*' | head -n1)
-                    if [[ -n \${LIMIT} && \${LIMIT} -le 250 ]]; then
+                    if [[ -n \${LIMIT} && \${LIMIT} -le 50 ]]; then
                         echo Docker Hub rate limit is too low
                         exit 1
                     else
-                        # couldn't get a valid limit, but maybe we'll squeak by with anon pulls
-                        echo Unknown Docker Hub rate limit...YOLO!
+                        # Either we didn't get a good limit, or it's seems big enough
+                        echo Go for it!
                     fi
 
                     git config --global user.email "cdkbot@juju.solutions"

--- a/jobs/sync-oci-images/sync-oci-images.groovy
+++ b/jobs/sync-oci-images/sync-oci-images.groovy
@@ -176,17 +176,25 @@ pipeline {
                             continue
                         fi
 
+                        # Authn dockerhub images
+                        if echo \${i} | grep -qi -e 'docker.io'
+                        then
+                            PULL_CREDS="-u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW}"
+                        else
+                            PULL_CREDS=
+                        fi
+
                         # Pull upstream image
                         if ${params.dry_run}
                         then
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch -u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW} \${i} --all-platforms >/dev/null
+                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch \${PULL_CREDS} \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr content fetch -u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW} \${i} --all-platforms >/dev/null
+                                sudo lxc exec ${lxc_name} -- ctr content fetch \${PULL_CREDS} \${i} --all-platforms >/dev/null
                             fi
                         fi
 
@@ -257,17 +265,25 @@ pipeline {
                             continue
                         fi
 
+                        # Authn dockerhub images
+                        if echo \${i} | grep -qi -e 'docker.io'
+                        then
+                            PULL_CREDS="-u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW}"
+                        else
+                            PULL_CREDS=
+                        fi
+
                         # Pull upstream image
                         if ${params.dry_run}
                         then
                             echo "Dry run; would have pulled: \${i}"
                         else
                             # simple retry if initial pull fails
-                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch -u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW} \${i} --all-platforms >/dev/null
+                            if ! sudo lxc exec ${lxc_name} -- ctr content fetch \${PULL_CREDS} \${i} --all-platforms >/dev/null
                             then
                                 echo "Retrying pull"
                                 sleep 5
-                                sudo lxc exec ${lxc_name} -- ctr content fetch -u ${env.DOCKERHUB_CREDS_USR}:${env.DOCKERHUB_CREDS_PSW} \${i} --all-platforms >/dev/null
+                                sudo lxc exec ${lxc_name} -- ctr content fetch \${PULL_CREDS} \${i} --all-platforms >/dev/null
                             fi
                         fi
 


### PR DESCRIPTION
Our sync-oci job wasn't authenticating requests, so we were limited to 100-hits-per-6-hr.  Authenticate the `ctr content fetch` to double this limit.

While we're at it, don't even start pulling if we know the limit is gonna be too low (we have at least 50 docker.io images once you include all the multiarch variants, so let's set the limit there for now).

**Reviewer**: stop short of merge; i'll reset the `sync-oci-images` job branch and merge on approval.