### PR TITLE
Revert "isolate ps5-12 for juju3 CI testing"

### DIFF
--- a/jobs/infra-ps5.yaml
+++ b/jobs/infra-ps5.yaml
@@ -2,7 +2,7 @@
 
 - project:
     name: infra-ps5
-    arch: ['amd64-8', 'amd64-9', 'amd64-11']
+    arch: ['amd64-8', 'amd64-9', 'amd64-11', 'amd64-12']
     jobs:
       - 'infra-maintain-ps5-{arch}'
 
@@ -18,7 +18,7 @@
       - default-job-wrapper
       - ci-creds
     triggers:
-      - timed: "H */6 * * *"
+        - timed: "H */6 * * *"
     properties:
       - block-on-build-release
       - build-discarder:
@@ -55,63 +55,3 @@
 
               venv/bin/pip install ansible
               venv/bin/ansible-playbook jobs/infra/playbook-jenkins.yml --limit localhost --tags 'jenkins' -i jobs/infra/hosts
-
-- job:
-    name: 'infra-maintain-ps5-amd64-12'
-    description: |
-      Temp job for testing juju3. This is just like the other infra jobs,
-      but exposes the ability to change the juju snap on the ps5-12 node.
-    node: runner-ps5-amd64-12
-    project-type: freestyle
-    scm:
-      - k8s-jenkins-jenkaas
-    parameters:
-      - string:
-          name: JUJU_CHANNEL
-          default: '3.1/stable'
-          description: |
-            Which juju snap channel to install on this node
-    wrappers:
-      - default-job-wrapper
-      - ci-creds
-    triggers:
-      - timed: "H */6 * * *"
-    properties:
-      - block-on-build-release
-      - build-discarder:
-          num-to-keep: 3
-    builders:
-      - set-env:
-          JOB_SPEC_DIR: "jobs/infra"
-      - shell: |
-          rm -rf /var/lib/jenkins/slaves/*/workspace/validate*
-
-          # infra job needs exclusive dpkg access to keep pkgs updated; kill
-          # and clean up if any dpkg procs/locks are found.
-          sudo pkill -9 -e -f ^/usr/bin/dpkg && sleep 5 || true
-          sudo fuser -v -k /var/cache/debconf/config.dat && sleep 5 || true
-          sudo dpkg --configure -a --force-confdef --force-confnew
-
-          sudo apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew -qy dist-upgrade
-          sudo apt install -qy python3-venv
-
-          # show worker characteristics (not fatal)
-          lscpu || true
-          free -h || true
-          df -h -x squashfs -x overlay | grep -vE ' /snap|^tmpfs|^shm' || true
-      - run-venv:
-          COMMAND: |
-              #!/bin/bash
-              set -eux
-              set -o allexport
-              [[ -f $WORKSPACE/.env ]] && source $WORKSPACE/.env
-              set +o allexport
-
-              bash jobs/infra/fixtures/cleanup-env.sh
-
-              venv/bin/pip install ansible
-              venv/bin/ansible-playbook jobs/infra/playbook-jenkins.yml --limit localhost --tags 'jenkins' -i jobs/infra/hosts
-
-              echo Overriding juju snap version
-              sudo snap refresh juju --channel $JUJU_CHANNEL


### PR DESCRIPTION
Reverts charmed-kubernetes/jenkins#1153

Back this out in favor of the better "run tests in a container" approach happening in #1225.  It'll need a `jjb` on infra.yaml after merge.