### PR TITLE
ensure correct charm-matrix data

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -218,7 +218,7 @@
           description: Channel to publish charm from (only used in promote jobs)
       - string:
           name: FILTER_BY_TAG
-          default: 'k8s'
+          default: 'k8s,k8s-operator'
           description: |
             Filter the builds by tag (ie. k8s). A tag can also be the name of a
             charm you want to individually build.

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -34,9 +34,9 @@
       Deploys Container Storage Interface (CSI) plugin that
       enables Charmed Kubernetes to use ceph as a storage backend.
     tags:
-      - k8s
+      - k8s-operator
       - ceph-csi
-      - csi
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/ceph-csi-operator.git'
     channel-range:
       min: '1.25'
@@ -110,7 +110,8 @@
     tags:
       - k8s
       - kata
-      - core
+      - cri
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kata.git'
 - kube-ovn:
     bugs: 'https://bugs.launchpad.net/charm-kube-ovn'
@@ -214,6 +215,7 @@
     tags:
       - k8s
       - kubevirt
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kube-virt.git'
     channel-range:
       min: '1.27'
@@ -237,9 +239,8 @@
     subdir: src
     summary: Failover and monitoring daemon for LVS clusters
     tags:
-      - general
-      - keepalived
       - k8s
+      - keepalived
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-keepalived.git'
 - docker-registry:
@@ -249,9 +250,8 @@
     store: 'https://charmhub.io/docker-registry'
     summary: Registry for docker images
     tags:
-      - general
-      - docker-registry
       - k8s
+      - docker-registry
       - docs-extra
     upstream: 'https://github.com/CanonicalLtd/docker-registry-charm.git'
 - aws-iam:
@@ -446,9 +446,9 @@
     store: 'https://charmhub.io/coredns'
     summary: The CoreDNS domain name service provider
     tags:
-      - k8s
+      - k8s-operator
       - coredns
-      - cni
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-coredns.git'
 - gatekeeper-controller-manager:
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
@@ -460,6 +460,7 @@
     tags:
       - k8s-operator
       - gatekeeper-controller-manager
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - gatekeeper-audit:
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
@@ -471,6 +472,7 @@
     tags:
       - k8s-operator
       - gatekeeper-audit
+      - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - bird:
     bugs: 'https://bugs.launchpad.net/charm-bird'
@@ -480,7 +482,6 @@
     summary: A dynamic IP routing daemon
     tags:
       - bird
-      - cni
     upstream: 'https://github.com/charmed-kubernetes/bird-operator.git'
     channel-range:
       min: '999.0'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -485,6 +485,18 @@
     upstream: 'https://github.com/charmed-kubernetes/bird-operator.git'
     channel-range:
       min: '999.0'
+- kubernetes-dashboard:
+    bugs: 'https://github.com/jnsgruk/kubernetes-dashboard-operator/issues'
+    docs: 'https://charmhub.io/kubernetes-dashboard/docs'
+    downstream: charmed-kubernetes/kubernetes-dashboard-operator
+    store: 'https://charmhub.io/kubernetes-dashboard'
+    summary: A web-based Kubernetes user interface
+    tags:
+      - kubernetes-dashboard
+      - docs-extra
+    upstream: 'https://github.com/jnsgruk/kubernetes-dashboard-operator'
+    channel-range:
+      min: '999.0'
 
 # EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard
 # - k8s-dashboard:


### PR DESCRIPTION
Partial fix for https://github.com/charmed-kubernetes/kubernetes-docs/issues/754

- fix incorrect labels (e.g. coredns is not a cni)
- ensure `k8s-operator` for all our sidecar charms
- add `docs-extra` where needed to populate the [components page](https://ubuntu.com/kubernetes/docs/1.26/components#additional-charms)
- add k8s-dashboard; we don't build/maintain this charm yet, but reasonable people would expect this to be listed as a ck8s "additional charms"