### PR TITLE
Revert juju to 2.9 temporarily

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -128,7 +128,7 @@
         - jenkins
         - adhoc
     - name: upgrade juju
-      command: "snap refresh juju --channel 3.1/stable --classic"
+      command: "snap refresh juju --channel 2.9/stable --classic"
       ignore_errors: yes
       tags:
         - jenkins


### PR DESCRIPTION
Revert juju to 2.9 temporarily due to the `/home` issue with 3.1.