### PR TITLE
autoscaler needs to be scheduled on control-plane nodes

### DIFF
--- a/jobs/validate/autoscaler-spec
+++ b/jobs/validate/autoscaler-spec
@@ -78,9 +78,20 @@ applications:
       juju_scale: '- {min: 1, max: 3, application: kubernetes-worker}'
       autoscaler_extra_args: '{v: 5, scale-down-delay-after-add: 3m0s, scale-down-unneeded-time: 3m0s}'
 EOF
+    
+    # Untaint scheduling for control-plane nodes so that the autoscaler can be scheduled to it
+    for node in $(kubectl get nodes | grep control-plane | cut -d' ' -f1); do
+        kubectl taint node $NODE node-role.kubernetes.io/control-plane=:NoSchedule-
+    done
 
     juju deploy -m "${JUJU_CONTROLLER}:addons" ./k8s_overlay.yaml --trust
     timeout 45m juju-wait -e "${JUJU_CONTROLLER}:addons" -w
+    juju::deploy-report $?
+
+    # Retaint control-plane nodes
+    for node in $(kubectl get nodes | grep control-plane | cut -d' ' -f1); do
+        kubectl taint node $NODE node-role.kubernetes.io/control-plane=:NoSchedule
+    done
 }
 
 function test::execute


### PR DESCRIPTION
So, it requires those nodes to not be tainted with `NoSchedule`
But during the test performance, they SHOULD be `NoSchedule`

during the juju deployment of the charm, make sure the taint isn't present

[Autoscaler Docs](https://github.com/charmed-kubernetes/charm-kubernetes-autoscaler/blob/main/README.md?plain=1#L54-L64)