### PR TITLE
reinclude `tomli` and `exceptiongroup` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,8 @@ docutils==0.15.2
     # via awscli
 drypy==1.0.1
     # via -r requirements.in
+exceptiongroup==1.1.1
+    # via pytest
 fasteners==0.16
     # via jenkins-job-builder
 flake8==6.0.0
@@ -313,6 +315,10 @@ surl==0.7.2
     # via -r requirements.in
 tabulate==0.8.7
     # via surl
+tomli==2.0.1
+    # via
+    #   black
+    #   pytest
 toposort==1.6
     # via juju
 typing-extensions==3.10.0.2
@@ -332,9 +338,9 @@ wcwidth==0.2.5
     # via prettytable
 websocket-client==1.2.3
     # via kubernetes
-websockets>=8.1,<9.0 ; python_version == "3.8"
+websockets==8.1 ; python_version == "3.8"
 websockets>=9.0,<10.0 ; python_version == "3.9"
-websockets>=10.0 ; python_version > "3.9"
+websockets==10.4 ; python_version > "3.9"
     # via
     #   -r requirements.in
     #   juju


### PR DESCRIPTION
[LP#1997593](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1997593)

Resolving missing dependency when tests are run using `pip-sync -r requirements.txt`