### PR TITLE
capture logs from journalctl when running juju-crashdump

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -168,11 +168,11 @@ function test::capture
 {
     if which juju-crashdump; then
         juju-crashdump \
-            -s                   # small crashdump by skipping /var/lib/juju \
-            -a debug-layer       # included debug-layer addon \
-            -a config            # included config addon \
-            -j snap.kube*        # included logs from all kube* daemons \
-            -j snap.cdk-addons*  # included logs from cdk-addons*  \
+            -s \                   # small crashdump by skipping /var/lib/juju
+            -a debug-layer \       # included debug-layer addon
+            -a config \            # included config addon
+            -j snap.kube* \        # included logs from all kube* daemons
+            -j snap.cdk-addons* \  # included logs from cdk-addons*
             -m "$JUJU_CONTROLLER:$JUJU_MODEL"
     fi
     tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* || true

--- a/ci.bash
+++ b/ci.bash
@@ -167,7 +167,13 @@ function test::report
 function test::capture
 {
     if which juju-crashdump; then
-        juju-crashdump -s -a debug-layer -a config -m "$JUJU_CONTROLLER:$JUJU_MODEL"
+        juju-crashdump \
+            -s                   # small crashdump by skipping /var/lib/juju \
+            -a debug-layer       # included debug-layer addon \
+            -a config            # included config addon \
+            -j snap.kube*        # included logs from all kube* daemons \
+            -j snap.cdk-addons*  # included logs from cdk-addons*  \
+            -m "$JUJU_CONTROLLER:$JUJU_MODEL"
     fi
     tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* || true
     /usr/local/bin/columbo -r columbo.yaml -o "_out" "artifacts.tar.gz" || true


### PR DESCRIPTION
ensure the crashdump logs include logs from things like `snap.kubelet.daemon` and other kubernetes services

```
❯ juju-crashdump --help                
usage: juju-crashdump [-h] [-d] [-m MODEL] [-f MAX_FILE_SIZE] [-b BUG]
                      [-x EXCLUDE] [-c COMPRESSION] [-o OUTPUT_DIR] [-u UNIQ]
                      [-s] [-a ADDON] [-t TIMEOUT] [--addons-file ADDONS_FILE]
                      [-j JOURNALCTL] [-l LOGGING_LEVEL]
                      [--unit-dump-location UNIT_DUMP_LOCATION] [--as-root]
                      [extra_dir [extra_dir ...]]

...

  -j JOURNALCTL, --journalctl JOURNALCTL
                        Collect the journalctl logs for the systemd unit with the given name
```