### PR TITLE
Adjust pod scaling and timeouts

### DIFF
--- a/jobs/integration/test_autoscaler.py
+++ b/jobs/integration/test_autoscaler.py
@@ -34,8 +34,8 @@ async def deployment(kubectl, namespace):
 
 @pytest.fixture
 def scaled_up_deployment(kubectl, namespace, deployment):
-    log.info("Scaling nginx deployment up to 200 units...")
-    kubectl.scale(f=deployment, replicas=200, namespace=namespace)
+    log.info("Scaling nginx deployment up to 115 units...")
+    kubectl.scale(f=deployment, replicas=115, namespace=namespace)
 
 
 @pytest.fixture
@@ -64,18 +64,18 @@ async def wait_for_worker_count(model, expected_workers):
             log.info(f"Worker count reached {unit_count}")
         return unit_count == expected_workers
 
-    await model.block_until(condition, timeout=15 * 60)
+    await model.block_until(condition, timeout=25 * 60)
 
 
 async def test_scale_up(scaled_up_deployment, model):
     log.info("Watching workers expand...")
     assert len(model.applications["kubernetes-worker"].units) == 1
     await wait_for_worker_count(model, 2)
-    await model.wait_for_idle(status="active", timeout=15 * 60)
+    await model.wait_for_idle(status="active", timeout=25 * 60)
 
 
 async def test_scale_down(scaled_down_deployment, model):
     log.info("Watching workers contract...")
     assert len(model.applications["kubernetes-worker"].units) == 2
     await wait_for_worker_count(model, 1)
-    await model.wait_for_idle(status="active", timeout=15 * 60)
+    await model.wait_for_idle(status="active", timeout=25 * 60)


### PR DESCRIPTION
This PR adjust the autoscaler tests to use less pods for testing scale up/scale down. Previously we used 200, which puts us dangerously close to needing an additional worker (we expect to end up with 2 workers after scale up, and with 200 we might end up getting 3 depending on how many pods are running on the cluster before the nginx pods are deployed). This was decreased to 115 to guarantee an additional worker is needed, but not put things super close to the threshold. I also increased the timeouts by 10 minutes just to give the model some breathing room when waiting for active/idle conditions. It can take some time for the workers and control plane to reach active/idle after scaling up and down as the control plane essentially reboots everything. 

Successful test run is [here](https://jenkins.canonical.com/k8s/job/validate-ck-autoscaler/node=runner-validate/8/console)

---
Mark below if this PR requires a job refresh (`jjb`) after merge:
- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
