### PR TITLE
remove extra quotes that break declared envars

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -297,7 +297,7 @@
 
           rm -rf $WORKSPACE/.env || true
 
-          export GIT_SSH_COMMAND='"ssh -i $HOME/.ssh/cdkbot_rsa -oStrictHostKeyChecking=no"'
+          export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/cdkbot_rsa -oStrictHostKeyChecking=no"
           export CHARM_BASE_DIR="$WORKSPACE/.cache/charmbuild/$BUILD_TAG"
           export CHARM_BUILD_DIR="$CHARM_BASE_DIR/${{CHARM_BUILD_DIR:-build/charms}}"
           export CHARM_LAYERS_DIR="$CHARM_BASE_DIR/${{CHARM_LAYERS_DIR:-build/layers}}"
@@ -317,7 +317,7 @@
           mkdir -p "$CHARM_INTERFACES_DIR"
 
           export PATH=/snap/bin:$HOME/bin/:$PATH
-          export NODE_LABELS='"$NODE_LABELS"'
+          export NODE_LABELS="$NODE_LABELS"
           export TMPDIR="$WORKSPACE/tmp"
           export PATH=venv/bin:$PATH
           export PYTHONPATH=$WORKSPACE:"${{PYTHONPATH:-}}"


### PR DESCRIPTION
We used to save off the bash env with `env`, but that doesn't always give us a reusable env (e.g. sourcing the env stopped if that env contained a semicolon).  So we switched to `declare`:

https://github.com/charmed-kubernetes/jenkins/pull/1225/files#diff-83acee619e9a8e91b81f09f0ca1af8291fed3d3ff827ea1166af4ece7e67c9d3L280-R304

But that started complaining because extra quotes were found alive and well in the declared vars.  This led to eventual problems with things like `git` which did not take kindly to GIT_SSH_COMMAND having an extra pair of quotes in it:

```
$ git fetch --all
Fetching origin
"ssh -i /home/kwmonroe/.ssh/id_rsa": 1: ssh -i /home/kwmonroe/.ssh/id_rsa: not found
fatal: Could not read from remote repository.
```

`declare -px` is a nicer way to store the env, so let's fixup the places that had those extra pesky quotes.
