### PR TITLE
include volcano image resources when releasing charm

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -42,3 +42,9 @@
   calico-cni-arm64: '{out_path}/calico-cni-arm64.tar.gz'
   calicoctl-image: '{out_path}/calicoctl-image.tar.gz'
   calico-node-image: '{out_path}/calico-node-image.tar.gz'
+'volcano-admission':
+  volcano-admission-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
+'volcano-controllers':
+  volcano-controller-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
+'volcano-scheduler':
+  volcano-scheduler-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source


### PR DESCRIPTION
I've pushed some initial resources to charmhub for these charms, so builds will succeed, but any new charm changes should trigger resource pushes