### PR TITLE
Appropriately parse secondary network interfaces

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -433,7 +433,7 @@ def deploy_bgp_router():
 
     log("Enabling secondary network interfaces")
     expected_nics = {f"ens{i+5}" for i in range(1, len(subnets))}
-    max_retries, current_nics = set(), 10
+    max_retries, current_nics = 10, set()
     while not expected_nics.issubset(current_nics) and max_retries:
         current_nics = {
             line.split("  ", 1)[0]


### PR DESCRIPTION
fixes python error during setup of calico-bgp-router tests

```
Enabling secondary network interfaces
Traceback (most recent call last):
  File "/home/ubuntu/workspace/jobs/integration/tigera_aws.py", line 586, in <module>
    main()
  File "/home/ubuntu/workspace/jobs/integration/tigera_aws.py", line 583, in main
    command_defs[args.command]()
  File "/home/ubuntu/workspace/jobs/integration/tigera_aws.py", line 437, in deploy_bgp_router
    while not expected_nics.issubset(current_nics) and max_retries:
TypeError: 'int' object is not iterable
```