### PR TITLE
Cloud Provider Integration Testing

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -167,12 +167,17 @@ function test::report
 function test::capture
 {
     if which juju-crashdump; then
+        # -s                     small crashdump by skipping /var/lib/juju
+        # -a debug-layer         included debug-layer addon
+        # -a config              included config addon
+        # -j snap.kube*          included logs from all kube* daemons
+        # -j snap.cdk-addons*    included logs from cdk-addons*
         juju-crashdump \
-            -s                    # small crashdump by skipping /var/lib/juju \
-            -a debug-layer        # included debug-layer addon \
-            -a config             # included config addon \
-            -j snap.kube*         # included logs from all kube* daemons \
-            -j snap.cdk-addons*   # included logs from cdk-addons* \
+            -s \
+            -a debug-layer \
+            -a config \
+            -j snap.kube* \
+            -j snap.cdk-addons* \
             -m "$JUJU_CONTROLLER:$JUJU_MODEL"
     fi
     tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* || true

--- a/ci.bash
+++ b/ci.bash
@@ -168,11 +168,11 @@ function test::capture
 {
     if which juju-crashdump; then
         juju-crashdump \
-            -s \                   # small crashdump by skipping /var/lib/juju
-            -a debug-layer \       # included debug-layer addon
-            -a config \            # included config addon
-            -j snap.kube* \        # included logs from all kube* daemons
-            -j snap.cdk-addons* \  # included logs from cdk-addons*
+            -s                    # small crashdump by skipping /var/lib/juju \
+            -a debug-layer        # included debug-layer addon \
+            -a config             # included config addon \
+            -j snap.kube*         # included logs from all kube* daemons \
+            -j snap.cdk-addons*   # included logs from cdk-addons* \
             -m "$JUJU_CONTROLLER:$JUJU_MODEL"
     fi
     tar -cvzf artifacts.tar.gz ci.log _out meta juju-crashdump* report.* failures* || true

--- a/cilib.sh
+++ b/cilib.sh
@@ -54,7 +54,7 @@ ci_lxc_launch()
     printf "uid $(id -u) 1000\ngid $(id -g) 1000" | sudo lxc config set ${lxc_container} raw.idmap -
     sudo lxc start ${lxc_container}
     sleep 10
-    ci_lxc_apt_install ${lxc_container} build-essential snapd
+    ci_lxc_apt_install_retry ${lxc_container} build-essential snapd
 }
 
 ci_lxc_mount()
@@ -106,6 +106,16 @@ ci_lxc_snap_install()
     # install a single snap in a container
     local lxc_container=$1
     ci_lxc_exec ${lxc_container} -- snap install ${@:2}
+}
+
+ci_lxc_apt_install_retry()
+{
+    local next_wait=5
+    until [ ${next_wait} -eq 10 ] || ci_lxc_apt_install $@; do
+        echo "Retrying lxc apt-install in ${next_wait}s..."
+        sleep $(( next_wait++ ))
+    done
+    [ ${next_wait} -lt 10 ]
 }
 
 ci_lxc_snap_install_retry()

--- a/jobs/integration/templates/integrator-charm-data/gce/out-of-tree.yaml
+++ b/jobs/integration/templates/integrator-charm-data/gce/out-of-tree.yaml
@@ -15,3 +15,4 @@ storage:
     image-registry: k8s.gcr.io
 cloud-controller:
   application: null
+  in-tree-until: '999.0'

--- a/jobs/integration/test_integrator_charm.py
+++ b/jobs/integration/test_integrator_charm.py
@@ -66,8 +66,10 @@ def _prepare_relation(linkage, model, add=True):
     app = model.applications[left_app]
     right_endpoints = [
         endpoint
-        for rel in app.relations if left in str(rel)
-        for endpoint in rel.endpoints if left not in str(endpoint)
+        for rel in app.relations
+        if left in str(rel)
+        for endpoint in rel.endpoints
+        if left not in str(endpoint)
     ]
     exists = any(right in str(_) for _ in right_endpoints)
     if add and not exists:

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -127,6 +127,17 @@ function juju::deploy
     fi
 }
 
+function juju::wait
+{
+    # overriding since we're waiting for the deployment
+    # to be active/idle except for the kubernetes-control-plane
+    # which could be waiting/idle on pending kube-system pods
+    # until the additional cloud-provider charms are installed.
+    echo "Waiting for deployment to settle..."
+    timeout 45m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w -x kubernetes-control-plane
+
+    juju::deploy-report $?
+}
 
 function test::execute
 {

--- a/lxc_runner.sh
+++ b/lxc_runner.sh
@@ -47,7 +47,7 @@ ci_lxc_init_runner()
 
     # Install runtime dependencies in the container
     # Install debs, replacing semicolons with spaces
-    ci_lxc_apt_install ${lxc_container} ${lxc_apt_list//,/ }
+    ci_lxc_apt_install_retry ${lxc_container} ${lxc_apt_list//,/ }
 
     # Install snaps and push paths and mount paths
     _IFS=${IFS} # restore IFS

--- a/requirements-2.9.txt
+++ b/requirements-2.9.txt
@@ -75,7 +75,7 @@ docutils==0.15.2
     # via awscli
 drypy==1.0.1
     # via -r requirements.in
-exceptiongroup==1.0.4
+exceptiongroup==1.1.1
     # via pytest
 fasteners==0.16
     # via jenkins-job-builder
@@ -182,7 +182,7 @@ pbr==5.5.1
     #   jenkins-job-builder
     #   python-jenkins
     #   stevedore
-platformdirs==3.1.1
+platformdirs==2.5.1
     # via black
 pluggy==0.13.1
     # via pytest
@@ -292,7 +292,7 @@ s3transfer==0.3.6
     #   boto3
 semver==2.13.0
     # via -r requirements.in
-sh==2.0.3
+sh==1.14.3
     # via -r requirements.in
 six==1.15.0
     # via


### PR DESCRIPTION
Rectifies the following situations:
* juju-crashdump missed called arguments during test failures
* apt-install in a container occurs too quickly after container startup
* a `cloud-provider` or `storage-provider` doesn't include a charm to install/remove
* a `cloud-provider` and `storage-provider` are in the same charm (by sequentially deploying)
*  the original overlay creates a situation where a missing cloud provider would result in a **waiting/idle** `kubernetes-control-plane` unit