### PR TITLE
add filter_by_tag to sync jobs

### DIFF
--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -199,6 +199,9 @@
       - string:
           name: BUNDLE_REV
           description: bundle revision to tag stable branches with
+      - string:
+          name: FILTER_BY_TAG
+          default: 'k8s,k8s-operator'
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/sync-upstream"
@@ -213,7 +216,7 @@
                      --charm-list jobs/includes/charm-support-matrix.inc \
                      --bundle-revision $BUNDLE_REV \
                      --k8s-version $K8S_VERSION \
-                     --filter-by-tag k8s
+                     --filter-by-tag $FILTER_BY_TAG
 
 - job:
     name: 'sync-stable-tag-bugfix-rev'
@@ -236,6 +239,9 @@
       - string:
           name: BUGFIX_REV
           description: bugfix revision to tag stable branches with, (ie ck1)
+      - string:
+          name: FILTER_BY_TAG
+          default: 'k8s,k8s-operator'
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/sync-upstream"
@@ -250,7 +256,7 @@
               --charm-list jobs/includes/charm-support-matrix.inc \
               --bundle-revision $BUGFIX_REV \
               --k8s-version $K8S_VERSION \
-              --filter-by-tag k8s \
+              --filter-by-tag $FILTER_BY_TAG \
               --bugfix
 
 - job:
@@ -263,9 +269,12 @@
       - k8s-jenkins-jenkaas
     properties:
       - build-discarder:
-          days-to-keep: 2
+          num-to-keep: 10
     parameters:
       - global-params
+      - string:
+          name: FILTER_BY_TAG
+          default: 'k8s,k8s-operator'
     wrappers:
       - default-job-wrapper
       - ci-creds
@@ -282,7 +291,7 @@
                --layer-list jobs/includes/charm-layer-list.inc \
                --charm-list jobs/includes/charm-support-matrix.inc \
                --ancillary-list jobs/includes/ancillary-list.inc \
-               --filter-by-tag k8s $IS_DRY_RUN
+               --filter-by-tag $FILTER_BY_TAG $IS_DRY_RUN
 
 - job:
     name: 'rename-branch'
@@ -307,6 +316,9 @@
           description: |
             Name of a branch present in supported layers + charms
             If the branch already exists in a repo, the entity is skipped
+      - string:
+          name: FILTER_BY_TAG
+          default: 'k8s,k8s-operator'
     wrappers:
       - default-job-wrapper
       - ci-creds
@@ -325,4 +337,4 @@
                --ancillary-list jobs/includes/ancillary-list.inc \
                --from-name $FROM_BRANCH \
                --to-name $TO_BRANCH \
-               --filter-by-tag k8s $IS_DRY_RUN
+               --filter-by-tag $FILTER_BY_TAG $IS_DRY_RUN

--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -63,7 +63,7 @@ def cli():
     help="Path to additional repos that need to be rebased.",
 )
 @click.option(
-    "--filter-by-tag", required=False, help="only build for tags", multiple=True
+    "--filter-by-tag", required=False, help="only build for tags"
 )
 @click.option("--dry-run", is_flag=True)
 def cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, dry_run):
@@ -81,6 +81,7 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
     layer_list = yaml.safe_load(Path(layer_list).read_text(encoding="utf8"))
     charm_list = yaml.safe_load(Path(charm_list).read_text(encoding="utf8"))
     ancillary_list = yaml.safe_load(Path(ancillary_list).read_text(encoding="utf8"))
+    filter_by_tag = filter_by_tag.split(",")
     stable_release, _ = SNAP_K8S_TRACK_LIST[-1]
     new_branch = f"release_{stable_release}"
 
@@ -99,7 +100,7 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
                 if not any(match in filter_by_tag for match in tags):
                     continue
 
-            if not stable_release in channel_range(params):
+            if stable_release not in channel_range(params):
                 log.info(
                     f"Skipping  :: {layer_name:^40} :: out of supported channel-range"
                 )
@@ -133,10 +134,10 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
 @click.option(
     "--ancillary-list",
     required=True,
-    help="Path to additionally repos that need to be rebased.",
+    help="Path to additional repos that need to be rebased.",
 )
 @click.option(
-    "--filter-by-tag", required=False, help="only build for tags", multiple=True
+    "--filter-by-tag", required=False, help="only build for tags"
 )
 @click.option("--dry-run", is_flag=True)
 @click.option("--from-name", required=True, help="Name of the original branch")
@@ -161,6 +162,7 @@ def _rename_branch(
     layer_list = yaml.safe_load(Path(layer_list).read_text(encoding="utf8"))
     charm_list = yaml.safe_load(Path(charm_list).read_text(encoding="utf8"))
     ancillary_list = yaml.safe_load(Path(ancillary_list).read_text(encoding="utf8"))
+    filter_by_tag = filter_by_tag.split(",")
     failed = []
     for layer_map in layer_list + charm_list + ancillary_list:
         for layer_name, params in layer_map.items():
@@ -212,6 +214,7 @@ def _tag_stable_forks(
     """
     layer_list = yaml.safe_load(Path(layer_list).read_text(encoding="utf8"))
     charm_list = yaml.safe_load(Path(charm_list).read_text(encoding="utf8"))
+    filter_by_tag = filter_by_tag.split(",")
     stable_branch = f"release_{k8s_version}"
 
     failed = []
@@ -226,7 +229,7 @@ def _tag_stable_forks(
                 log.info(f"Skipping  :: {layer_name:^40} :: does not require tagging")
                 continue
 
-            if not k8s_version in channel_range(params):
+            if k8s_version not in channel_range(params):
                 log.info(
                     f"Skipping  :: {layer_name:^40} :: out of supported channel-range"
                 )
@@ -263,7 +266,7 @@ def _tag_stable_forks(
     "--bundle-revision", required=True, help="Bundle revision to tag stable against"
 )
 @click.option(
-    "--filter-by-tag", required=False, help="only build for tags", multiple=True
+    "--filter-by-tag", required=False, help="only build for tags"
 )
 @click.option("--bugfix", is_flag=True)
 @click.option("--dry-run", is_flag=True)

--- a/jobs/sync-upstream/sync.py
+++ b/jobs/sync-upstream/sync.py
@@ -62,9 +62,7 @@ def cli():
     required=True,
     help="Path to additional repos that need to be rebased.",
 )
-@click.option(
-    "--filter-by-tag", required=False, help="only build for tags"
-)
+@click.option("--filter-by-tag", required=False, help="only build for tags")
 @click.option("--dry-run", is_flag=True)
 def cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, dry_run):
     return _cut_stable_release(
@@ -136,9 +134,7 @@ def _cut_stable_release(layer_list, charm_list, ancillary_list, filter_by_tag, d
     required=True,
     help="Path to additional repos that need to be rebased.",
 )
-@click.option(
-    "--filter-by-tag", required=False, help="only build for tags"
-)
+@click.option("--filter-by-tag", required=False, help="only build for tags")
 @click.option("--dry-run", is_flag=True)
 @click.option("--from-name", required=True, help="Name of the original branch")
 @click.option("--to-name", required=True, help="Name of the new branch")
@@ -265,9 +261,7 @@ def _tag_stable_forks(
 @click.option(
     "--bundle-revision", required=True, help="Bundle revision to tag stable against"
 )
-@click.option(
-    "--filter-by-tag", required=False, help="only build for tags"
-)
+@click.option("--filter-by-tag", required=False, help="only build for tags")
 @click.option("--bugfix", is_flag=True)
 @click.option("--dry-run", is_flag=True)
 def tag_stable(


### PR DESCRIPTION
Ensure our sync jobs process both k8s and k8s-operator tagged sources by default.

These jobs would previously take multiple `--filter-by-tag` click options, but we don't use that pattern in current jobs. Instead, other jobs rely on `FILTER_BY_TAG` being `.split(',')` and checked against the list of tags defined in our `includes/charm-support-matrix.inc`.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge: `sync.py`