### PR TITLE
stop pretending to clean up /tmp on the infra nodes

### DIFF
--- a/jobs/infra/fixtures/cleanup-env.sh
+++ b/jobs/infra/fixtures/cleanup-env.sh
@@ -35,7 +35,7 @@ docker image prune -a --filter until=24h --force
 docker container prune --filter until=24h --force
 rm -rf /var/lib/jenkins/venvs
 rm -rf /var/lib/jenkins/.tox
-tmpreaper -t 5h /tmp
+tmpreaper 5h /tmp
 
 purge::aws
 purge::gce


### PR DESCRIPTION
`-t` switch just runs `tmpreaper` in test-mode, not actually deleting anything.  Let's clean up the leftover bits on the infra nodes