### PR TITLE
Start building 1.28 microk8s

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -31,6 +31,7 @@ def get_tracks(all=False):
         "1.26-strict",
         "1.27",
         "1.27-strict",
+        "1.28",
     ]
 
 


### PR DESCRIPTION
1.27 is out and 1.28 tracks are in place, we can start building 1.28