### PR TITLE
cncf-conformance job needs help

### DIFF
--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -54,7 +54,7 @@ function test::execute
     export RBAC_ENABLED=$(kubectl api-versions | grep "rbac.authorization.k8s.io/v1" -c)
 
     timeout -s INT 3h ./sonobuoy run --mode=certified-conformance --wait \
-      --plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=node-role.kubernetes.io/control-plane 2>&1
+      --plugin-env=e2e.E2E_EXTRA_ARGS="--non-blocking-taints=node-role.kubernetes.io/control-plane --ginkgo.v" 2>&1
     ret=$?
     is_pass="True"
     if (( $ret > 0 )); then

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -48,7 +48,6 @@ function test::execute
         cat config | tee $HOME/.kube/config >/dev/null
     if ! kubectl version; then
         echo ERROR: Cluster is unreachable
-        cat $HOME/.kube/config
         exit 1
     fi
     export RBAC_ENABLED=$(kubectl api-versions | grep "rbac.authorization.k8s.io/v1" -c)

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -44,9 +44,14 @@ function test::execute
     declare -n is_pass=$1
 
     mkdir -p $HOME/.kube
-    juju ssh -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-control-plane/leader -- cat config > $HOME/.kube/config
+    juju ssh -m $JUJU_CONTROLLER:$JUJU_MODEL kubernetes-control-plane/leader -- \
+        cat config | tee $HOME/.kube/config >/dev/null
+    if ! kubectl version; then
+        echo ERROR: Cluster is unreachable
+        cat $HOME/.kube/config
+        exit 1
+    fi
     export RBAC_ENABLED=$(kubectl api-versions | grep "rbac.authorization.k8s.io/v1" -c)
-    kubectl version
 
     timeout -s INT 3h ./sonobuoy run --mode=certified-conformance --wait \
       --plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=node-role.kubernetes.io/control-plane 2>&1


### PR DESCRIPTION
I dunno why, but the following stdout redirection wasn't working:
```
juju ssh <model> kubernetes-control-plane/leader -- cat config > $HOME/.kube/config
```
This works fine in other juju envs, but not in the `jenkins -> sh -> lxc -> bash` env that this job uses. I confirmed `cat` showed valid data, but `$HOME/.kube/config` on the jenkins builder always ended up as a 0-byte file. [Job 74](https://jenkins.canonical.com/k8s/job/conformance-cncf-ck/74/consoleFull), for example:
```
19:06:30 [cncf-ck-jammy-1.27-candidate] + juju ssh -m cncf-ck-247396d7:cncf-ck kubernetes-control-plane/leader -- cat config
19:06:33 [cncf-ck-jammy-1.27-candidate] apiVersion: v1
19:06:33 [cncf-ck-jammy-1.27-candidate] clusters:
19:06:33 [cncf-ck-jammy-1.27-candidate] - cluster:

<snip> ^^ this is good config, now run it again with > $HOME/.kube/config

19:06:38 [cncf-ck-jammy-1.27-candidate] + ls -la /home/ubuntu/.kube
19:06:38 [cncf-ck-jammy-1.27-candidate] total 8
19:06:38 [cncf-ck-jammy-1.27-candidate] drwxr-xr-x  2 ubuntu ubuntu 4096 Apr 18 00:06 .
19:06:38 [cncf-ck-jammy-1.27-candidate] drwxr-x--- 10 ubuntu ubuntu 4096 Apr 18 00:06 ..
19:06:38 [cncf-ck-jammy-1.27-candidate] -rw-r--r--  1 ubuntu ubuntu    0 Apr 18 00:06 config

<snip> ^^ nothing in there
```
I tried forcing a tty (`juju --pty=true`) in case stdout was going somewhere else, and i tried `/tmp` in case there was something wrong with the `$HOME` path.  Nada.  `tee` worked, so here we are.

I added a `kubectl version` check which will fail if we can't reach our cluster-under-test.  No sense in running the tests without that.