### PR TITLE
adjust test runs based on the Kubernetes api server version 

### DIFF
--- a/jobs/integration/test_auth_webhook.py
+++ b/jobs/integration/test_auth_webhook.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 import random
 from .logger import log
 from yaml import safe_load

--- a/jobs/integration/test_auth_webhook.py
+++ b/jobs/integration/test_auth_webhook.py
@@ -63,16 +63,11 @@ async def verify_custom_auth(one_control_plane, cmd, endpoint):
     assert "Forwarding to: {}".format(endpoint) in output.stdout.strip()
 
 
+@pytest.mark.skip_if_version(lambda v: v < (1, 17))
 async def test_validate_auth_webhook(model, tools):
     # This test verifies the auth-webhook service is working
     log("starting auth-webhook test")
     masters = model.applications["kubernetes-control-plane"]
-    k8s_version_str = masters.data["workload-version"]
-    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
-    if k8s_minor_version < (1, 17):
-        log("skipping, k8s version v" + k8s_version_str)
-        return
-
     one_master = random.choice(masters.units)
     hostname = await get_hostname(one_master)
     await verify_service(one_master)

--- a/jobs/integration/test_aws_iam.py
+++ b/jobs/integration/test_aws_iam.py
@@ -126,6 +126,7 @@ async def aws_iam_charm(model, tools):
             await model.applications["aws-iam"].destroy()
 
 
+@pytest.mark.skip_if_version(lambda v: v < (1, 15))
 async def test_validate_aws_iam(model, tools):
     # This test verifies the aws-iam charm is working
     # properly. This requires:
@@ -142,11 +143,6 @@ async def test_validate_aws_iam(model, tools):
 
     log("starting aws-iam test")
     controllers = model.applications["kubernetes-control-plane"]
-    k8s_version_str = controllers.data["workload-version"]
-    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
-    if k8s_minor_version < (1, 15):
-        log("skipping, k8s version v" + k8s_version_str)
-        return
 
     # 1) deploy
     await controllers.set_config({"authorization-mode": "AlwaysAllow"})

--- a/jobs/integration/test_cis_benchmark.py
+++ b/jobs/integration/test_cis_benchmark.py
@@ -3,15 +3,11 @@ from utils import juju_run_action
 from .logger import log
 
 
+@pytest.mark.skip_if_version(lambda v: v < (1, 19))
 async def test_cis_benchmark(model, tools):
     """Validate cis benchmark passes on supported charms in 1.19+"""
     log("starting cis-benchmark test")
     masters = model.applications["kubernetes-control-plane"]
-    k8s_version_str = masters.data["workload-version"]
-    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
-    if k8s_minor_version < (1, 19):
-        log("skipping, k8s version v" + k8s_version_str)
-        return
 
     # Verify action on etcd
     log("verifying etcd")

--- a/jobs/integration/test_cis_benchmark.py
+++ b/jobs/integration/test_cis_benchmark.py
@@ -1,4 +1,5 @@
 import random
+import pytest
 from utils import juju_run_action
 from .logger import log
 

--- a/jobs/integration/test_hacluster.py
+++ b/jobs/integration/test_hacluster.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 import os
+import pytest
 from .logger import log
 from .utils import juju_run
 

--- a/jobs/integration/test_hacluster.py
+++ b/jobs/integration/test_hacluster.py
@@ -105,16 +105,10 @@ async def test_validate_existing_hacluster(model, tools):
         await do_verification(model, app, ip)
 
 
+@pytest.mark.skip_if_version(lambda v: v < (1, 14))
 async def test_validate_hacluster(model, tools):
     name = get_master_name(model)
     app = model.applications[name]
-
-    masters = model.applications["kubernetes-control-plane"]
-    k8s_version_str = masters.data["workload-version"]
-    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
-    if k8s_minor_version < (1, 14):
-        log("skipping, k8s version v" + k8s_version_str)
-        # return
 
     num_units = len(app.units)
     if num_units < 3:

--- a/jobs/integration/test_integrator_charm.py
+++ b/jobs/integration/test_integrator_charm.py
@@ -171,9 +171,7 @@ async def cloud_providers(tools: Tools, model, cloud, k8s_version):
     out_of_tree = out_of_tree_config(cloud)
     expected_apps = set(model.applications)
     for provider in (out_of_tree.storage, out_of_tree.cloud_controller):
-        await _resolve_provider(
-            model, provider, tools, k8s_version, expected_apps
-        )
+        await _resolve_provider(model, provider, tools, k8s_version, expected_apps)
 
     logger.info(f"Waiting for stable apps=[{', '.join(expected_apps)}].")
     await model.wait_for_idle(

--- a/jobs/integration/test_nagios.py
+++ b/jobs/integration/test_nagios.py
@@ -18,6 +18,7 @@ async def wait_for_no_errors(url, opener):
         await asyncio.sleep(30)
 
 
+@pytest.mark.skip_if_version(lambda v: v < (1, 17))
 async def test_nagios(model, tools):
     # This test verifies the nagios relation is working
     # properly. This requires:
@@ -33,11 +34,6 @@ async def test_nagios(model, tools):
 
     log("starting nagios test")
     masters = model.applications["kubernetes-control-plane"]
-    k8s_version_str = masters.data["workload-version"]
-    k8s_minor_version = tuple(int(i) for i in k8s_version_str.split(".")[:2])
-    if k8s_minor_version < (1, 17):
-        log("skipping, k8s version v" + k8s_version_str)
-        return
 
     # 1) deploy
     log("deploying nagios and nrpe")

--- a/jobs/integration/test_nagios.py
+++ b/jobs/integration/test_nagios.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 import urllib.request
 from .logger import log
 from bs4 import BeautifulSoup as bs


### PR DESCRIPTION
Due to https://github.com/juju/python-libjuju/issues/842 the validation suite can't determine the k8s_version reliably from the application `workload-status` field.  Until it is fixed, fall back in tests to using kubectl to determine the server version