### PR TITLE
disable the validate-ck-390x job

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -305,6 +305,7 @@
     node: runner-validate
     description: |
       Validates CK edge for n-1 releases on s390x localhost.
+    disabled: true
     project-type: matrix
     scm:
       - k8s-jenkins-jenkaas


### PR DESCRIPTION
Disables the validate-ck-390x job

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ x ] Needs `jjb` after merge

