### PR TITLE
test_audit_* tests should cleanup on failures, and simplify test reso…

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1247,7 +1247,6 @@ async def test_audit_default_config(model, tools):
 
 async def test_audit_custom_policy(model, tools):
     app = model.applications["kubernetes-control-plane"]
-    unit = app.units[0]
 
     # Set a custom policy that only logs requests to a special namespace
     namespace = "validate-audit-custom-policy"
@@ -1336,7 +1335,7 @@ async def test_audit_webhook(model, tools):
         before_count = await get_webhook_server_entry_count()
         await kubectl(model, "get po")
         after_count = await get_webhook_server_entry_count()
-        assert after_count > before_count, f"Audit Webhook isn't receiving audit logs"
+        assert after_count > before_count, "Audit Webhook isn't receiving audit logs"
 
     finally:
         # Clean up


### PR DESCRIPTION
replacing the `run_until_success` calls that never timeout with simpler `kubectl` calls that will fail the test on failed `kubectl` is a safer way to ensure the suite of tests do not get stuck on an unresponsive API. 

testing of snap `1.28.0-alpha0` results in `test_audit_webhook` [failure](https://paste.ubuntu.com/p/64S3B97Qts/)