### PR TITLE
Replace install-mode with "disable" for kubelet-eks

### DIFF
--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -55,7 +55,8 @@ pipeline {
                         # eks snaps have a suffix and different base than ck; adjust snapcraft.yaml
                         cd \${EKS_SNAP}
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
-                               -e "s/^base: .*/base: ${EKS_BASE}/" snapcraft.yaml
+                               -e "s/^base: .*/base: ${EKS_BASE}/" \
+                               -e "s/install-mode: .*/install-mode: disable/" snapcraft.yaml
 
                         # if we don't have any base defined at this point, add one
                         grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml


### PR DESCRIPTION
When the kubelet-eks service is automatically started after installation, it will fail because the service is usually not correctly configured.
This results in lots of logs with error messages and also with restart rate-limit problems with systemd.
So "disable" the service by default and enable it when ready.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge
