### PR TITLE
Adjust microk8s executors to remove `sh` deprecations

### DIFF
--- a/jobs/microk8s/executors/juju.py
+++ b/jobs/microk8s/executors/juju.py
@@ -2,7 +2,6 @@ import click
 import sh
 import os
 from subprocess import run, PIPE, STDOUT, CalledProcessError
-import shlex
 
 import configbag
 from executors.executor import ExecutorInterface

--- a/jobs/microk8s/executors/testflinger.py
+++ b/jobs/microk8s/executors/testflinger.py
@@ -8,8 +8,6 @@ from subprocess import run, PIPE, STDOUT
 
 from executors.executor import ExecutorInterface
 
-sh2 = sh(_iter=True, _err_to_out=True, _env=os.environ.copy())
-
 
 class TestFlingerExecutor(ExecutorInterface):
     """

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -1,14 +1,11 @@
 import click
 import configbag
-import sh
 import os
 from dateutil import parser
 from subprocess import CalledProcessError, run, PIPE, STDOUT
 from executors.juju import JujuExecutor
 from executors.local import LocalExecutor
 from executors.testflinger import TestFlingerExecutor
-
-sh2 = sh(_iter=True, _err_to_out=True, _env=os.environ.copy())
 
 
 class Microk8sSnap:


### PR DESCRIPTION
Having upgraded the version of `sh`  used in this repository, the mechanisms of sh have changed.  This alters some of the microk8s test executors which have yet to be adjusted. 

This PR is blocking the following job:
* release-microk8s-edge