### PR TITLE
Validation specs should deploy using the current specified arch

### DIFF
--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -36,6 +36,11 @@ function juju::deploy::overlay
     cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
+  easyrsa:
+    constraints: $constraints
+    to: null
+  etcd:
+    constraints: $constraints
   kubernetes-control-plane:
     constraints: $constraints
     options:
@@ -65,8 +70,6 @@ EOF
     elif [ "$JUJU_CLOUD" = "aws/us-east-1" ]; then
       # Deploy aws
       cat <<EOF >> overlay.yaml
-  easyrsa:
-    to: null
   aws-integrator:
     charm: aws-integrator
     channel: $JUJU_DEPLOY_CHANNEL
@@ -79,8 +82,6 @@ EOF
     elif [ "$JUJU_CLOUD" = "google/us-east1" ]; then
       # Deploy google
       cat <<EOF >> overlay.yaml
-  easyrsa:
-    to: null
   gcp-integrator:
     charm: gcp-integrator
     channel: $JUJU_DEPLOY_CHANNEL
@@ -96,8 +97,6 @@ EOF
   calico:
     options:
       cidr: 172.22.0.0/16
-  easyrsa:
-    to: null
   azure-integrator:
     charm: azure-integrator
     channel: $JUJU_DEPLOY_CHANNEL

--- a/jobs/validate/spec
+++ b/jobs/validate/spec
@@ -14,24 +14,6 @@ set -x
 ###############################################################################
 # FUNCTION OVERRIDES
 ###############################################################################
-function juju::deploy::overlay
-{
-    local constraints
-    constraints="arch=$ARCH cores=2 mem=8G root-disk=16G"
-
-    cat <<EOF > overlay.yaml
-series: $SERIES
-applications:
-  kubernetes-control-plane:
-    constraints: $constraints
-    options:
-      channel: $SNAP_VERSION
-  kubernetes-worker:
-    constraints: $constraints
-    options:
-      channel: $SNAP_VERSION
-EOF
-}
 
 ###############################################################################
 # ENV

--- a/juju.bash
+++ b/juju.bash
@@ -100,13 +100,18 @@ function juju::deploy::after
 
 function juju::deploy::overlay
 {
+    local constraints
+    constraints="arch=${ARCH:-amd64} cores=2 mem=8G root-disk=16G"
+
     cat <<EOF > overlay.yaml
 series: $SERIES
 applications:
   kubernetes-control-plane:
+    constraints: $constraints
     options:
       channel: $SNAP_VERSION
   kubernetes-worker:
+    constraints: $constraints
     options:
       channel: $SNAP_VERSION
 EOF


### PR DESCRIPTION
The upgrade-spec tests for arm64 were failing due to deploying a coredns charm with an arch=arm64 but all the workers were ACTUALLY running `amd64`.  This PR ensures the workers and control-planes start up with the specified architectures


* the `bootstrap-architecture` specified during bootstrapping doesn't select the arch for the entire cluster
* only by specifying the arch in the constraint for the application or machine will actually set the correct arch on the deployed machine.
* all but one `spec` uses `charmed-kubernetes` bundle where the `easyrsa` application is on a separate machine
* `integrator-spec` uses `kubernetes-core` bundles overlayed where `easyrsa`  is moved a separate machine


