### PR TITLE
Sync `prometheus-manual` interface from upstream source

### DIFF
--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -23,7 +23,7 @@
         - interface:prometheus
 - interface:prometheus-manual:
     downstream: 'charmed-kubernetes/interface-prometheus-manual.git'
-    upstream: 'https://github.com/charmed-kubernetes/interface-prometheus-manual'
+    upstream: 'https://github.com/juju-solutions/interface-prometheus-manual'
     tags:
         - k8s
         - interface


### PR DESCRIPTION
charms like `etcd` use this interface to sync with `prometheus2` charm, but were missing some key commits in `charmed-kubernetes` org