### PR TITLE
Ensure install-mode enable for kubelet-eks

### DIFF
--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -56,7 +56,7 @@ pipeline {
                         cd \${EKS_SNAP}
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
                                -e "s/^base: .*/base: ${EKS_BASE}/" \
-                               -e "s/install-mode: .*/install-mode: disable/" snapcraft.yaml
+                               -e "s/install-mode: .*/install-mode: enable/" snapcraft.yaml
 
                         # if we don't have any base defined at this point, add one
                         grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml


### PR DESCRIPTION
This seems to have [introduced regressions](https://bugs.launchpad.net/cloud-images/+bug/2020072) in live clusters and new images. We'll need to dig into this further before going this route.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
