### PR TITLE
Set kubelet-eks service install-mode to disable

### DIFF
--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -56,7 +56,7 @@ pipeline {
                         cd \${EKS_SNAP}
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
                                -e "s/^base: .*/base: ${EKS_BASE}/" \
-                               -e "s/install-mode: .*/install-mode: enable/" snapcraft.yaml
+                               -e "s/install-mode: .*/install-mode: disable/" snapcraft.yaml
 
                         # if we don't have any base defined at this point, add one
                         grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml


### PR DESCRIPTION
After further digging, the upstream issues seem to be caused by the refresh cycle, not this change specifically. So, reverting the revert. Please trigger rebuilds one more time once this is merged, thanks!

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
