### PR TITLE
Skip `test_service_cidr_expansion` when testing kubeovn and multus

### DIFF
--- a/jobs/validate/ovn-multus-spec
+++ b/jobs/validate/ovn-multus-spec
@@ -93,7 +93,8 @@ function test::execute
                 --cloud "$JUJU_CLOUD" \
                 --model "$JUJU_MODEL" \
                 --controller "$JUJU_CONTROLLER" \
-                --addons-model addons
+                --addons-model addons \
+                -k "not test_service_cidr_expansion"  # Skipped due to LP#2020704
     ret=$?
     is_pass="True"
     if (( $ret > 0 )); then


### PR DESCRIPTION
[LP#2020704](https://bugs.launchpad.net/charm-multus/+bug/2020704) Multus DaemonSet should be restarted during cidr expansion

* since it isn't restarted, lets skip this test until its fixed