### PR TITLE
Use ubuntu 20.04 to run microk8s tests on

### DIFF
--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -125,8 +125,8 @@ pipeline {
                                     --model-default resource-tags="owner=k8sci job=${job} stage=${stage}" \
                                     --bootstrap-constraints "mem=8G cores=2"
 
-                                // We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
-                                // that requires old cgroups.
+                                /* We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
+                                   that requires old cgroups. */
                                 juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu --base ubuntu@20.04
 
                                 juju-wait -e "${juju_full_model}" -w

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -127,7 +127,7 @@ pipeline {
 
                                 # We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
                                 # that requires old cgroups.
-                                juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu --base ubuntu@20.04
+                                juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu --series focal
 
                                 juju-wait -e "${juju_full_model}" -w
 

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -125,8 +125,8 @@ pipeline {
                                     --model-default resource-tags="owner=k8sci job=${job} stage=${stage}" \
                                     --bootstrap-constraints "mem=8G cores=2"
 
-                                /* We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
-                                   that requires old cgroups. */
+                                # We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
+                                # that requires old cgroups.
                                 juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu --base ubuntu@20.04
 
                                 juju-wait -e "${juju_full_model}" -w

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -125,7 +125,9 @@ pipeline {
                                     --model-default resource-tags="owner=k8sci job=${job} stage=${stage}" \
                                     --bootstrap-constraints "mem=8G cores=2"
 
-                                juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu
+                                // We deploy 20.04 because the upgrade-path test deploys K8s 1.19 onwards
+                                // that requires old cgroups.
+                                juju deploy -m "${juju_full_model}" --constraints "${constraints}" ubuntu --base ubuntu@20.04
 
                                 juju-wait -e "${juju_full_model}" -w
 


### PR DESCRIPTION
We want to run the MicroK8s tests on ubuntu 20.04 because the upgrade-path test deploys MicroK8s 1.19 and upgrades it all the way to the current release and 1.19 is failing with:
```
Μαΐ 29 18:32:26 aurora microk8s.daemon-containerd[3953675]: time="2023-05-29T18:32:26.673227098+03:00" level=error msg="loading cgroup for 3957680" error="cgroups: cgroup mountpoint does not exist"
``` 