### PR TITLE
Back out 1.28/candidate from from k8s track list

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -75,7 +75,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.25", ["1.25/stable", "1.25/candidate", "1.25/beta", "1.25/edge"]),
     ("1.26", ["1.26/stable", "1.26/candidate", "1.26/beta", "1.26/edge"]),
     ("1.27", ["1.27/stable", "1.27/candidate", "1.27/beta", "1.27/edge"]),
-    ("1.28", ["1.28/candidate", "1.28/beta", "1.28/edge"]),
+    ("1.28", ["1.28/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 


### PR DESCRIPTION
As I understand it, the inclusion of `1.28/candidate` in the k8s track list  is causing build-charms, when targeted to channel `candidate`, to publish to `1.28/candidate` instead of `1.27/candidate`. This is creating a lot of confusion within our team for the release process.

Is it something we can just back out now and re-add later?