### PR TITLE
Log traceback for _semvers_from_point

### DIFF
--- a/cilib/models/repos/__init__.py
+++ b/cilib/models/repos/__init__.py
@@ -1,3 +1,5 @@
+import traceback
+
 from cilib import git, version, log
 from drypy.patterns import sham
 
@@ -127,7 +129,7 @@ class BaseRepoModel:
             try:
                 if version.greater(_semver, starting_semver):
                     _semvers.append(_semver)
-            except Exception as error:
-                print(error)
+            except Exception:
+                traceback.print_exc()
                 continue
         return _semvers


### PR DESCRIPTION
I noticed this in a recent sync-snaps run:

```
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
08:39:58 invalid literal for int() with base 10: 'gkk'
```

The `gkk` is almost certainly coming from branches I've created in the [snap-kubelet git repo](https://code.launchpad.net/snap-kubelet).

This didn't fail the job, something just printed it and moved on. I think I found where it gets printed, so let's make it a proper traceback, figure out where it's getting raised, and clean it up.