### PR TITLE
Retry `git ls-remote` calls

### DIFF
--- a/cilib/git.py
+++ b/cilib/git.py
@@ -8,6 +8,7 @@ from subprocess import run
 from .github_api import Repository
 import requests
 import requests.auth
+from retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +100,8 @@ def remote_tags(url, **subprocess_kwargs):
     return sorted(tags, key=_natural_sort_key)
 
 
+# retry because this fails often against git.launchpad.net
+@retry(delay=1, backoff=2, tries=7)  # exponential, fails after ~63 seconds
 def remote_branches(url, **subprocess_kwargs):
     """Returns a list of remote branches"""
     refs = sh.git("ls-remote", "-h", "--refs", url)


### PR DESCRIPTION
The sync-snaps job has failed on me 4 times in a row with failed `git ls-remote` calls. To hopefully fix, retry with exponential backoff for a minute or so.

Traceback:

```
15:40:13 Traceback (most recent call last):
15:40:13   File "jobs/sync-upstream/sync.py", line 442, in <module>
15:40:13     cli()
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
15:40:13     return self.main(*args, **kwargs)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/click/core.py", line 1055, in main
15:40:13     rv = self.invoke(ctx)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
15:40:13     return _process_result(sub_ctx.command.invoke(sub_ctx))
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
15:40:13     return ctx.invoke(self.callback, **ctx.params)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/click/core.py", line 760, in invoke
15:40:13     return __callback(*args, **kwargs)
15:40:13   File "jobs/sync-upstream/sync.py", line 407, in snaps
15:40:13     snap_service_obj.sync_all_track_snaps()
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/cilib/service/snap.py", line 145, in sync_all_track_snaps
15:40:13     self.snap_model.base.latest_branch_from_major_minor(
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/cilib/models/repos/__init__.py", line 65, in latest_branch_from_major_minor
15:40:13     return self._latest_from_semver(self.branches, major_minor, exclude_pre)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/cilib/models/repos/__init__.py", line 61, in branches
15:40:13     return git.remote_branches(self.repo, **subprocess_kwargs)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/cilib/git.py", line 104, in remote_branches
15:40:13     refs = sh.git("ls-remote", "-h", "--refs", url)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/sh.py", line 1524, in __call__
15:40:13     rc = self.__class__.RunningCommandCls(cmd, call_args, stdin, stdout, stderr)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/sh.py", line 750, in __init__
15:40:13     self.wait()
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/sh.py", line 812, in wait
15:40:13     self.handle_command_exit_code(exit_code)
15:40:13   File "/var/lib/jenkins/slaves/jenkins-slave-focal-3/workspace/sync-snaps/.tox/py38/lib/python3.8/site-packages/sh.py", line 839, in handle_command_exit_code
15:40:13     raise exc
15:40:13 sh.ErrorReturnCode_128: 
15:40:13 
15:40:13   RAN: /usr/bin/git ls-remote -h --refs git+ssh://k8s-team-ci@git.launchpad.net/snap-kube-proxy
15:40:13 
15:40:13   STDOUT:
15:40:13 
15:40:13 
15:40:13   STDERR:
15:40:13 Warning: Permanently added 'git.launchpad.net,185.125.188.45' (RSA) to the list of known hosts.
15:40:13 k8s-team-ci@git.launchpad.net: Permission denied (publickey).
15:40:13 fatal: Could not read from remote repository.
15:40:13 
15:40:13 Please make sure you have the correct access rights
15:40:13 and the repository exists.
```