### PR TITLE
Handle fail cases where a k8s resource used in ceph tests wasn't created

### DIFF
--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -469,16 +469,11 @@ spec:
         raise
     finally:
         log.info(f"{test_name}: {sc_name} cleanup")
-        pods = "{0}-read-test {0}-write-test".format(sc_name)
+        kubectl_delete = "/snap/bin/kubectl --kubeconfig /root/.kube/config delete --ignore-not-found=true"
+        pods = f"{sc_name}-read-test {sc_name}-write-test"
         pvcs = f"{sc_name}-pvc"
-        pod_deleted = await juju_run(
-            control_plane,
-            f"/snap/bin/kubectl --kubeconfig /root/.kube/config delete po {pods}",
-        )
-        pvc_deleted = await juju_run(
-            control_plane,
-            f"/snap/bin/kubectl --kubeconfig /root/.kube/config delete pvc {pvcs}",
-        )
+        pod_deleted = await juju_run(control_plane, f"{kubectl_delete} po {pods}")
+        pvc_deleted = await juju_run(control_plane, f"{kubectl_delete} pvc {pvcs}")
         assert all(_.status == "completed" for _ in (pod_deleted, pvc_deleted))
 
         await retry_async_with_timeout(


### PR DESCRIPTION
I found situations where the `finally` case of the `test_ceph` raised assertions that it couldn't delete a `read-test` pod because it didn't exist.  Unfortunately there is a test failure, but it's hidden because of this failure in the `finally` section. 

The `finally` clause should ATTEMPT to delete what's there -- but ignore resources that aren't there. 