### PR TITLE
Build the metallb unified ops charm starting in 1.28

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -390,6 +390,19 @@
     upstream: 'https://github.com/charmed-kubernetes/vsphere-cloud-provider.git'
     channel-range:
       min: '1.25'
+- metallb:
+    bugs: 'https://bugs.launchpad.net/operator-metallb'
+    docs: 'https://charmhub.io/metallb/docs'
+    downstream: charmed-kubernetes/metallb-operator
+    store: 'https://charmhub.io/metallb'
+    summary: Metallb loadbalancer charm
+    tags:
+      - k8s
+      - docs-extra
+      - metallb
+    upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
+    channel-range:
+      min: '1.28'
 - metallb-controller:
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb-controller/docs'
@@ -403,6 +416,8 @@
       - metallb
       - metallb-controller
     upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
+    channel-range:
+      max: '1.27'
 - metallb-speaker:
     bugs: https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb-speaker/docs'
@@ -416,6 +431,8 @@
       - metallb
       - metallb-speaker
     upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
+    channel-range:
+      max: '1.27'
 - multus:
     bugs: 'https://bugs.launchpad.net/charm-multus'
     docs: 'https://charmhub.io/multus/docs'


### PR DESCRIPTION
`1.27` is the last release with metallb, begin building unfied `1.28` metallb charm.  

Depends on merge completion
* https://github.com/charmed-kubernetes/metallb-operator/pull/32