### PR TITLE
Remove calico-node-image

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -7,7 +7,6 @@
 'calico':
   calico: '{out_path}/calico-amd64.tar.gz'
   calico-arm64: '{out_path}/calico-arm64.tar.gz'
-  calico-node-image: '{out_path}/calico-node-image.tar.gz'
 'cilium':
   cilium: '{out_path}/cilium.tar.gz'
   hubble: '{out_path}/hubble.tar.gz'


### PR DESCRIPTION
## Summary

Remove `calico-node-image` from the resource spec yaml.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge
