### PR TITLE
remove nightly builds of metallb-speaker/controller charms

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -439,7 +439,6 @@
     summary: Controller charm for the metallb loadbalancer
     tags:
       - docs-extra
-      - metallb
       - metallb-controller
     upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
     channel-range:

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -452,7 +452,6 @@
     summary: Speaker charm for the metallb loadbalancer
     tags:
       - docs-extra
-      - metallb
       - metallb-speaker
     upstream: 'https://github.com/charmed-kubernetes/metallb-operator.git'
     channel-range:

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -438,7 +438,6 @@
     subdir: charms/metallb-controller
     summary: Controller charm for the metallb loadbalancer
     tags:
-      - k8s
       - docs-extra
       - metallb
       - metallb-controller
@@ -453,7 +452,6 @@
     subdir: charms/metallb-speaker
     summary: Speaker charm for the metallb loadbalancer
     tags:
-      - k8s
       - docs-extra
       - metallb
       - metallb-speaker


### PR DESCRIPTION
metallb is now a single charm, rather than 2 independent charms.

Remove the nightly build tag (it can still be built using the `metallb` tag if targeting an older branch (like 1.27 or prior)
