### PR TITLE
Change Calico upstream repo

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -3,7 +3,7 @@
     bugs: 'https://bugs.launchpad.net/charm-calico'
     build-resources: 'cd {out_path}; bash {src_path}/build-calico-resource.sh'
     docs: 'https://charmhub.io/calico/docs'
-    downstream: charmed-kubernetes/calico-charm.git
+    downstream: charmed-kubernetes/charm-calico.git
     store: 'https://charmhub.io/calico'
     summary: A robust Software Defined Network from Project Calico
     architectures: [amd64, arm64]
@@ -12,7 +12,7 @@
       - calico
       - core
       - cni
-    upstream: 'https://github.com/charmed-kubernetes/calico-charm.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-calico.git'
 - canal:
     bugs: 'https://bugs.launchpad.net/charm-canal'
     build-resources: 'cd {out_path}; bash {src_path}/build-canal-resources.sh'

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -3,7 +3,7 @@
     bugs: 'https://bugs.launchpad.net/charm-calico'
     build-resources: 'cd {out_path}; bash {src_path}/build-calico-resource.sh'
     docs: 'https://charmhub.io/calico/docs'
-    downstream: charmed-kubernetes/layer-calico.git
+    downstream: charmed-kubernetes/calico-charm.git
     store: 'https://charmhub.io/calico'
     summary: A robust Software Defined Network from Project Calico
     architectures: [amd64, arm64]
@@ -12,7 +12,7 @@
       - calico
       - core
       - cni
-    upstream: 'https://github.com/charmed-kubernetes/layer-calico.git'
+    upstream: 'https://github.com/charmed-kubernetes/calico-charm.git'
 - canal:
     bugs: 'https://bugs.launchpad.net/charm-canal'
     build-resources: 'cd {out_path}; bash {src_path}/build-canal-resources.sh'


### PR DESCRIPTION
## Changes

Now that Calico has been rewritten in ops, we have renamed the repository to `calico-charm` instead of `layer-calico`.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code: