### PR TITLE
cephfs validation should collect logs from cephfs provisioner

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -118,6 +118,13 @@ def pytest_addoption(parser):
         help="Proxy Juju SSH and SCP commands through the Juju controller",
     )
 
+    parser.addoption(
+        "--use-existing-ceph-apps",
+        action="store_true",
+        default=False,
+        help="Run ceph tests against existing ceph apps in the model",
+    )
+
 
 class Tools:
     """Utility class for accessing juju related tools"""
@@ -148,6 +155,9 @@ class Tools:
         self.charm_channel = request.config.getoption("--charm-channel")
         self.vault_unseal_command = request.config.getoption("--vault-unseal-command")
         self.juju_ssh_proxy = request.config.getoption("--juju-ssh-proxy")
+        self.use_existing_ceph_apps = request.config.getoption(
+            "--use-existing-ceph-apps"
+        )
 
     def juju_base(self, series):
         """Retrieve juju 3.1 base from series."""

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1045,14 +1045,15 @@ async def test_service_cidr_expansion(model):
     await app.set_config(new_config)
     await wait_for_process(model, service_cluster_ip_range)
 
-    cmd = "/snap/bin/kubectl --kubeconfig /root/.kube/config get service kubernetes"
-    control_plane = model.applications["kubernetes-control-plane"].units[0]
-    output = await juju_run(control_plane, cmd, check=False)
+    output = await kubectl(model, "get service kubernetes")
     assert output.status == "completed"
 
     # Check if k8s service ip is changed as per new service cidr
     raw_output = output.stdout
     assert new_service_ip_str in raw_output
+
+    # Wait for the model to be stable
+    await model.wait_for_idle(status="active", timeout=10 * 60)
 
 
 async def test_sans(model):

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2527,6 +2527,9 @@ async def ceph_apps(model, tools):
 
     all_apps = ["ceph-mon", "ceph-osd", "ceph-fs"]
     if any(a in model.applications for a in all_apps):
+        if not tools.use_existing_ceph_apps:
+            pytest.skip("Skipped since ceph apps are already installed")
+
         # allow currently deployed ceph apps to run tests
         mon, osd, fs = (model.applications[a] for a in all_apps)
         await model.wait_for_idle(status="active", timeout=20 * 60)


### PR DESCRIPTION
in order to appropriately collect logs from cephfs failures, the correct cephfs provisioner logs should be acquired

These changes also allow the ceph tests to run against models where ceph-fs, ceph-mon, and ceph-osd are currently installed and idle