### PR TITLE
calico ops charm needs aws-cloud-provider to appropriately rename nod…

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.28/edge   # development channel snaps
-            - 1.27/stable # previous stable snaps
+            - 1.28/edge
+            - 1.27/edge
       - axis:
           type: user-defined
           name: cloud

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.28/edge
-            - 1.27/edge
+            - 1.28/edge   # development channel snaps
+            - 1.27/stable # previous stable snaps
       - axis:
           type: user-defined
           name: cloud

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -75,9 +75,16 @@ EOF
     channel: $JUJU_DEPLOY_CHANNEL
     num_units: 1
     trust: true
+  aws-cloud-provider:
+    charm: aws-cloud-provider
+    channel: $JUJU_DEPLOY_CHANNEL
 relations:
   - ['aws-integrator', 'kubernetes-control-plane:aws']
   - ['aws-integrator', 'kubernetes-worker:aws']
+  - ['aws-cloud-provider:certificates', 'easyrsa:client']
+  - ['aws-cloud-provider:kube-control', 'kubernetes-control-plane:kube-control']
+  - ['aws-cloud-provider:aws-integration', 'aws-integrator:aws']
+  - ['aws-cloud-provider:external-cloud-provider', 'kubernetes-control-plane:external-cloud-provider']
 EOF
     elif [ "$JUJU_CLOUD" = "google/us-east1" ]; then
       # Deploy google


### PR DESCRIPTION
`aws-cloud-provider` is a required service starting in Kubernetes 1.26 when using the external-cloud-provider.  We might as well start with it deployed before running the tests. Without it -- calico app cannot get to active/idle

Also, let's run these tests with snaps from the dev channel and previous stable channel