### PR TITLE
Remove cffi dependency from microk8s

### DIFF
--- a/jobs/microk8s/requirements.txt
+++ b/jobs/microk8s/requirements.txt
@@ -6,8 +6,6 @@
 #
 certifi==2022.12.7
     # via requests
-cffi==1.14.5
-    # via cryptography
 charset-normalizer==3.1.0
     # via requests
 click==7.1.2

--- a/jobs/microk8s/requirements.txt
+++ b/jobs/microk8s/requirements.txt
@@ -6,6 +6,8 @@
 #
 certifi==2022.12.7
     # via requests
+cffi==1.14.5
+    # via cryptography
 charset-normalizer==3.1.0
     # via requests
 click==7.1.2

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -68,7 +68,7 @@ pipeline {
         stage("Setup tox environment") {
             steps {
                 sh """
-                tox -c jobs/microk8s/tox.ini --workdir jobs/microk8s/.tox -e py38 -- python -c 'print("Tox Environment Ready")'
+                tox -c jobs/microk8s/tox.ini -e py38 -- python -c 'print("Tox Environment Ready")'
                 """
             }
         }
@@ -94,7 +94,7 @@ pipeline {
 
                                 try {
                                     sh """
-                                    . .tox/py38/bin/activate
+                                    . jobs/microk8s/.tox/py38/bin/activate
                                     ALWAYS_RELEASE=${params.ALWAYS_RELEASE}\
                                         TRACKS=${params.TRACKS}\
                                         CHANNEL=${channel}\
@@ -153,7 +153,7 @@ pipeline {
                                 }
                                 try {
                                     sh """
-                                    . .tox/py38/bin/activate
+                                    . jobs/microk8s/.tox/py38/bin/activate
                                     DRY_RUN=${params.DRY_RUN} ALWAYS_RELEASE=${params.ALWAYS_RELEASE}\
                                         TESTS_BRANCH=${params.TESTS_BRANCH} TRACKS=${params.TRACKS}\
                                         PROXY=${params.PROXY} JUJU_UNIT=ubuntu/0\

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -68,7 +68,7 @@ pipeline {
         stage("Setup tox environment") {
             steps {
                 sh """
-                tox -e py38 -- python -c 'print("Tox Environment Ready")'
+                tox -c jobs/microk8s/tox.ini --workdir .tox -e py38 -- python -c 'print("Tox Environment Ready")'
                 """
             }
         }

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -1,5 +1,3 @@
-@Library('juju-pipeline@master') _
-
 
 def destroy_controller(controller) {
     return """#!/bin/bash
@@ -22,7 +20,7 @@ pipeline {
      https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh
      */
     environment {
-        PATH                 = "${utils.cipaths}"
+        PATH                 = "/var/lib/jenkins/venvs/ci/bin:/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"
         AWS_REGION           = "us-east-1"
         JUJU_CLOUD           = "aws/us-east-1"
         K8STEAMCI            = credentials('k8s_team_ci_lp')

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -68,7 +68,7 @@ pipeline {
         stage("Setup tox environment") {
             steps {
                 sh """
-                tox -c jobs/microk8s/tox.ini --workdir .tox -e py38 -- python -c 'print("Tox Environment Ready")'
+                tox -c jobs/microk8s/tox.ini --workdir jobs/microk8s/.tox -e py38 -- python -c 'print("Tox Environment Ready")'
                 """
             }
         }


### PR DESCRIPTION
cffi dependency was moved to the top level tox.ini so it is failing in microk8s jobs with:
```
17:57:40  ERROR: could not install deps [cffi, flake8, pip-tools, cython<3.0.0, -r/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/requirements.txt]; v = InvocationError("/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/.tox/py38/bin/python -I -m pip install --no-build-isolation cffi flake8 pip-tools 'cython<3.0.0' -r/var/lib/jenkins/slaves/jenkins-slave-focal-ps5-8/workspace/release-microk8s-arch-amd64/requirements.txt", 1)
```