### PR TITLE
Adjustments to enable building on launchpad

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -35,7 +35,7 @@
           COMMAND: |
             #!/bin/bash
             set -eux
-            tox -e py38 -- python jobs/build-charms/charms.py promote \
+            tox -e py38 -- python jobs/build-charms/main.py promote \
                 --from-channel $FROM_CHANNEL \
                 --to-channel $TO_CHANNEL \
                 --charm-list $CHARM_LIST \
@@ -77,7 +77,7 @@
           COMMAND: |
             #!/bin/bash
             set -eux
-            tox -e py38 -- python jobs/build-charms/charms.py promote \
+            tox -e py38 -- python jobs/build-charms/main.py promote \
                 --to-channel $TO_CHANNEL \
                 --from-channel $FROM_CHANNEL \
                 --charm-list $BUNDLE_LIST \
@@ -132,7 +132,7 @@
             set +e
 
             EXIT_STATUS=0
-            tox -e py38 -- python jobs/build-charms/charms.py build \
+            tox -e py38 -- python jobs/build-charms/main.py build \
               --charm-list "$CHARM_LIST" \
               --to-channel "$TO_CHANNEL" \
               --resource-spec "$RESOURCE_SPEC" \
@@ -143,7 +143,7 @@
               $WITH_CHARM_BRANCH \
               $IS_FORCE || EXIT_STATUS=$?
 
-            tox -e py38 -- python jobs/build-charms/charms.py build-bundles \
+            tox -e py38 -- python jobs/build-charms/main.py build-bundles \
                 --to-channel "$TO_CHANNEL" \
                 --bundle-list "$BUNDLE_LIST" \
                 --bundle-branch "$BUNDLE_BRANCH" \

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -1,0 +1,186 @@
+""" Launchpad Charm Builder
+"""
+
+import zlib
+import os
+import re
+import time
+import urllib.request
+import zipfile
+
+from functools import cached_property
+from pathlib import Path
+
+from launchpadlib.launchpad import Launchpad
+from lazr.restfulclient.errors import NotFound
+
+from builder_local import Arch, Artifact, BuildEntity, BuildException
+
+
+class LPBuildEntity(BuildEntity):
+    """The launchpad build data class.
+
+    Builds charms on launchpad with charm recipes
+    """
+
+    SNAP_CHANNEL = {"charmcraft": "latest/stable"}
+    BUILD_STATES_PENDING = {
+        "Needs building",
+        "Currently building",
+        "Uploading build",
+        "Cancelling build",
+    }
+    BUILD_STATES_SUCCESS = {
+        "Successfully built",
+    }
+
+    @staticmethod
+    def _recipe_from_branch(branch: str):
+        """Recipe names must be lowercase alphanumerics with allowed +, -, and ."""
+        subbed = re.sub("[^0-9a-zA-Z\+\-\.]+", "-", branch)
+        return subbed.lower()
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._lp_bugs = self.opts.get("bugs", "")
+        self._lp_branch = self.branch
+        self._lp_project_name = self._lp_bugs.rsplit("/")[-1]
+        self._lp_recipe_name = self._recipe_from_branch(self._lp_branch)
+
+        assert self.type == "Charm", "Only supports charm builds"
+        assert "launchpad.net" in self._lp_bugs, "No associated with launchpad"
+
+    @cached_property
+    def _lp(self):
+        creds = os.environ.get("LPCREDS", None)
+        return Launchpad.login_with(
+            application_name="k8s-jenkaas-bot",
+            service_root="production",
+            version="devel",
+            credentials_file=creds,
+        )
+
+    @cached_property
+    def _lp_project(self):
+        """Link to the charm project in launchpad."""
+        return self._lp.projects[self._lp_project_name]
+
+    @cached_property
+    def _lp_owner(self):
+        """Link to the charm project's owner in launchpad."""
+        return self._lp.people[self._lp_project.owner.name]
+
+    @cached_property
+    def _lp_recipe(self):
+        """Lookup or create the charm recipe."""
+        try:
+            rec = self._lp.charm_recipes.getByName(
+                owner=self._lp_owner,
+                project=self._lp_project,
+                name=self._lp_recipe_name,
+            )
+        except NotFound:
+            self.echo(f"Creating recipe for branch :{self._lp_branch}")
+            repo = self._lp.git_repositories.getDefaultRepository(
+                target=self._lp_project
+            )
+            ref = repo.refs_collection_link.replace("refs", f"+ref/{self._lp_branch}")
+            rec = self._lp.charm_recipes.new(
+                name=self._lp_recipe_name,
+                auto_build=False,
+                auto_build_channels=self.SNAP_CHANNEL,
+                git_ref=ref,
+                owner=self._lp_owner,
+                project=self._lp_project,
+                store_channels=[],
+                store_upload=False,
+            )
+        return rec
+
+    def _lp_request_builds(self):
+        """Request a charm build for this charm."""
+        req = self._lp_recipe.requestBuilds(channels=self.SNAP_CHANNEL)
+        self.echo("Waiting for charm recipe request")
+        timeout = 5 * 60
+        for _ in range(timeout):
+            status = req.status
+            if status == "Failed":
+                raise BuildException(
+                    f"Failed to request build {self.name} on launchpad"
+                )
+            if status == "Completed":
+                break
+            time.sleep(1.0)
+            req.lp_refresh()
+        return req.builds
+
+    def _lp_complete_builds(self, builds):
+        """Ensure that all the builds of a specified charm are completed."""
+        incomplete_builds = {_.self_link for _ in builds}
+        while incomplete_builds:
+            for build in builds:
+                if build.self_link not in incomplete_builds:
+                    continue
+                if (status := build.buildstate) in self.BUILD_STATES_PENDING:
+                    self.echo(f"Waiting for {build.title}: build={status}")
+                    build.lp_refresh()
+                else:
+                    self.echo(f"Completed {build.title}: build={status}")
+                    incomplete_builds.remove(build.self_link)
+            if incomplete_builds:
+                time.sleep(30.0)
+        for build in builds:
+            if build.buildstate not in self.BUILD_STATES_SUCCESS:
+                raise BuildException(f"Failed to build {build.title} on launchpad")
+        return builds
+
+    @staticmethod
+    def _lp_charm_filename_from_build(build):
+        """Read the build_log to determine the charm file name.
+
+        Currently, this is accomplished by reading the buildlog
+        and looking for a keyword, knowing the next line is the charm name
+        """
+
+        def find_packed_charm(lines):
+            found, keyword = False, b"Charms packed:"
+            for line in lines:
+                if line.startswith(keyword):
+                    found |= True
+                elif found:
+                    yield line.decode().strip()
+                    found = False
+
+        with urllib.request.urlopen(build.build_log_url) as f:
+            fp = find_packed_charm(
+                zlib.decompress(f.read(), 16 + zlib.MAX_WBITS).splitlines()
+            )
+            return next(fp)
+
+    def _lp_build_download(self, build, dst_target: Path) -> Artifact:
+        charm_file = self._lp_charm_filename_from_build(build)
+        dl_link = build.web_link + f"/+files/{charm_file}"
+        with urllib.request.urlopen(dl_link) as src:
+            target = dst_target / charm_file
+            with target.open("wb") as dst:
+                dst.write(src.read())
+            self.echo(f"Downloaded {build.title}")
+            return Artifact(Arch[build.title.split(" ")[0].upper()], target)
+
+    def _lp_amend_git_version(self):
+        """Write the git sha into the charm."""
+        git_sha = self.commit(short=True)
+        for artifact in self.artifacts:
+            zip = zipfile.ZipFile(artifact.charm_or_bundle, "a")
+            zip.writestr("version", git_sha + "\n")
+
+    def charm_build(self):
+        """Perform a build using a launchpad charm recipe."""
+        self.echo(f"Starting a build of {self.name} on launchpad")
+        request = self._lp_request_builds()
+        builds = self._lp_complete_builds(request)
+        download_path = Path(self.src_path)
+        self.artifacts = [
+            self._lp_build_download(build, download_path) for build in builds
+        ]
+        self._lp_amend_git_version()

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -37,7 +37,7 @@ class LPBuildEntity(BuildEntity):
     @staticmethod
     def _recipe_from_branch(branch: str):
         """Recipe names must be lowercase alphanumerics with allowed +, -, and ."""
-        subbed = re.sub("[^0-9a-zA-Z\+\-\.]+", "-", branch)
+        subbed = re.sub(r"[^0-9a-zA-Z\+\-\.]+", "-", branch)
         return subbed.lower()
 
     def __init__(self, *args, **kwargs) -> None:

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -23,7 +23,7 @@ from io import BytesIO
 import zipfile
 from pathlib import Path
 from cilib.github_api import Repository
-from enum import StrEnum, auto
+from enum import Enum, unique
 from sh.contrib import git
 from cilib.git import default_gh_branch
 from cilib.enums import SNAP_K8S_TRACK_MAP, K8S_SERIES_MAP, K8S_CHARM_SUPPORT_ARCHES
@@ -33,7 +33,6 @@ from cilib.version import ChannelRange, Release, RISKS
 from dataclasses import dataclass, field
 from functools import partial
 from datetime import datetime
-from enum import Enum
 from types import SimpleNamespace
 from typing import List, Mapping, Optional, Set
 
@@ -118,6 +117,7 @@ class BuildException(Exception):
     """Define build Exception."""
 
 
+@unique
 class BuildType(Enum):
     """Enumeration for the build type."""
 
@@ -125,6 +125,7 @@ class BuildType(Enum):
     BUNDLE = 2
 
 
+@unique
 class LayerType(Enum):
     """Enumeration for the layer type."""
 
@@ -546,18 +547,20 @@ class BuildEnv:
         self.db["pull_layer_manifest"] = list(results)
 
 
-class Arch(StrEnum):
-    ALL = auto()
-    AMD64 = auto()
-    ARM64 = auto()
-    ARMHF = auto()
-    PPC64EL = auto()
-    S390X = auto()
+@unique
+class Arch(Enum):
+    ALL = "all"
+    AMD64 = "amd64"
+    ARM64 = "arm64"
+    ARMHF = "armhf"
+    PPC64EL = "ppc64el"
+    S390X = "s390x"
 
 
-class ResourceKind(StrEnum):
-    FILEPATH = auto()
-    IMAGE = auto()
+@unique
+class ResourceKind(Enum):
+    FILEPATH = "filepath"
+    IMAGE = "image"
 
 
 @dataclass

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -23,12 +23,15 @@ from io import BytesIO
 import zipfile
 from pathlib import Path
 from cilib.github_api import Repository
+from collections import defaultdict
+from enum import StrEnum, auto
 from sh.contrib import git
 from cilib.git import default_gh_branch
 from cilib.enums import SNAP_K8S_TRACK_MAP, K8S_SERIES_MAP, K8S_CHARM_SUPPORT_ARCHES
 from cilib.service.aws import Store
 from cilib.run import script
 from cilib.version import ChannelRange, Release, RISKS
+from dataclasses import dataclass, field
 from functools import partial
 from datetime import datetime
 from enum import Enum
@@ -190,7 +193,7 @@ class _CharmHub(Charmcraft):
     BASE_RE = re.compile(r"(\S+) (\S+) \((\S+)\)")
 
     @staticmethod
-    def _table_to_list(header, body):
+    def _table_to_list(header, body) -> List[Mapping[str, str]]:
         if not body:
             return []
         rows = []
@@ -284,19 +287,25 @@ class _CharmHub(Charmcraft):
             charm_status = [unpublished_rev]
         return charm_status
 
+    def release(self, entity: str, artifact: "Artifact", to_channels: List[str]):
+        self._echo(f"Releasing :: {entity:^35} :: to: {to_channels}")
+        rev_args = f"--revision={artifact.rev}"
+        channel_args = [f"--channel={chan}" for chan in to_channels]
+        resource_rev_args = [
+            f"--resource={rsc.name}:{rsc.rev}" for rsc in artifact.resources
+        ]
+        args = [entity, rev_args] + resource_rev_args + channel_args
+        self.charmcraft.release(*args)
+
     def promote(self, charm_entity, from_channel, to_channels):
         self._echo(
             f"Promoting :: {charm_entity:^35} :: from:{from_channel} to: {to_channels}"
         )
-        if "unpublished" == from_channel:
-            charm_status = self._unpublished_revisions(charm_entity)
-        else:
-            charm_status = [
-                row
-                for row in self.status(charm_entity)
-                if row["Revision"]
-                and f"{row['Track']}/{row['Channel']}" == from_channel
-            ]
+        charm_status = [
+            row
+            for row in self.status(charm_entity)
+            if row["Revision"] and f"{row['Track']}/{row['Channel']}" == from_channel
+        ]
 
         calls = set()
         for row in charm_status:
@@ -320,15 +329,18 @@ class _CharmHub(Charmcraft):
             # self._echo(" ".join(["charmcraft", "release", *args]))
             self.charmcraft.release(*args)
 
-    def upload(self, dst_path):
+    def upload(self, dst_path) -> int:
         out = self.charmcraft.upload(dst_path)
-        (revision,) = re.findall(r"Revision (\d+) of ", out, re.MULTILINE)
-        self._echo(f"Pushing   :: returns {out}")
-        return revision
+        self._echo(f"Upload   :: returns {out}")
+        (revision,) = re.findall(r"Revision (\d+) ", out, re.MULTILINE)
+        return int(revision)
 
-    def upload_resource(self, charm_entity, resource_name, resource):
-        kwargs = dict([resource])
-        self.charmcraft("upload-resource", charm_entity, resource_name, **kwargs)
+    def upload_resource(self, charm_entity, resource: "CharmResource") -> int:
+        kwargs = resource.upload_args
+        out = self.charmcraft("upload-resource", charm_entity, resource.name, **kwargs)
+        self._echo(f"Upload Resource   :: returns {out}")
+        (revision,) = re.findall(r"Revision (\d+) ", out, re.MULTILINE)
+        return int(revision)
 
 
 class BuildEnv:
@@ -402,10 +414,10 @@ class BuildEnv:
         )
 
     @property
-    def artifacts(self):
+    def job_list(self):
         """List of charms or bundles to process."""
         return yaml.safe_load(
-            Path(self.db["build_args"]["artifact_list"]).read_text(encoding="utf8")
+            Path(self.db["build_args"]["job_list"]).read_text(encoding="utf8")
         )
 
     @property
@@ -447,11 +459,11 @@ class BuildEnv:
         """
         Applies boundaries to a charm or bundle's target channel.
 
-        Uses the channel-range.min and channel-range.max arguments in self.artifacts
+        Uses the channel-range.min and channel-range.max arguments in self.job_list
         to filter the channels list.
         """
 
-        entity = next((_[name] for _ in self.artifacts if name in _.keys()), {})
+        entity = next((_[name] for _ in self.job_list if name in _.keys()), {})
         range_def = entity.get("channel-range", {})
         definitions = range_def.get("min"), range_def.get("max")
         assert all(isinstance(_, (str, type(None))) for _ in definitions)
@@ -480,7 +492,7 @@ class BuildEnv:
         self.store.put_item(Item=dict(self.db))
 
     def promote_all(self, from_channel="beta", to_channels=("edge",)):
-        """Promote set of charm artifacts in charmhub."""
+        """Promote set of charms in charmhub."""
         track = self.db["build_args"].get("track") or "latest"
         if from_channel.lower() in RISKS:
             from_channel = f"{track}/{from_channel.lower()}"
@@ -492,7 +504,7 @@ class BuildEnv:
             for chan in to_channels
         ]
         failed_entities = []
-        for charm_map in self.artifacts:
+        for charm_map in self.job_list:
             for charm_name, charm_opts in charm_map.items():
                 if not any(tag in self.filter_by_tag for tag in charm_opts["tags"]):
                     continue
@@ -533,6 +545,50 @@ class BuildEnv:
         results = pool.map(self.download, layers_to_pull)
 
         self.db["pull_layer_manifest"] = list(results)
+
+
+class Arch(StrEnum):
+    ALL = auto()
+    AMD64 = auto()
+    ARM64 = auto()
+    ARMHF = auto()
+    PPC64EL = auto()
+    S390X = auto()
+
+
+class ResourceKind(StrEnum):
+    FILEPATH = auto()
+    IMAGE = auto()
+
+
+@dataclass
+class CharmResource:
+    name: str
+    kind: Optional[ResourceKind] = None
+    value: Optional[str] = None  # location (filepath or image-id)
+    rev: Optional[int] = None  # set when uploaded or when lookedup
+
+    @property
+    def upload_args(self) -> Mapping[str, str]:
+        return {self.kind.value: str(self.value)}
+
+
+@dataclass
+class Artifact:
+    arch: Arch
+    charm_or_bundle: Path
+    rev: int = None  # set when uploaded
+    resources: List[CharmResource] = field(default_factory=list)
+
+    @property
+    def arch_docker(self) -> str:
+        """manage docker platforms with slightly different identifiers."""
+        if self.arch == Arch.PPC64EL:
+            return "ppc64le"
+        elif self.arch == Arch.ALL:
+            return Arch.AMD64.value
+        else:
+            return self.arch.value
 
 
 class BuildEntity:
@@ -580,7 +636,7 @@ class BuildEntity:
 
         self.layer_path = src_path / "layer.yaml"
         self.src_path = str(src_path.absolute())
-        self.dst_path = str(Path(self.src_path) / f"{self.name}.charm")
+        self.artifacts: List[Artifact] = []
 
         # Bundle or charm opts as defined in the layer include
         self.opts = opts
@@ -694,10 +750,7 @@ class BuildEntity:
         return git_commit.strip()
 
     def _read_metadata_resources(self):
-        if self.dst_path.endswith(".charm"):
-            metadata_path = zipfile.Path(self.dst_path) / "metadata.yaml"
-        else:
-            metadata_path = Path(self.dst_path) / "metadata.yaml"
+        metadata_path = Path(self.src_path) / "metadata.yaml"
         metadata = yaml.safe_load(metadata_path.read_text())
         return metadata.get("resources", {})
 
@@ -725,6 +778,7 @@ class BuildEntity:
         """Perform a build against charm/bundle."""
         lxc = os.environ.get("charmcraft_lxc")
         ret = SimpleNamespace(ok=False)
+        charm_path = str(Path(self.src_path, f"{self.name}.charm"))
         if "override-build" in self.opts:
             self.echo("Override build found, running in place of charm build.")
             ret = script(
@@ -756,7 +810,7 @@ class BuildEntity:
                 "#!/bin/bash -eux\n"
                 f"source {Path(__file__).parent / 'charmcraft-lib.sh'}\n"
                 f"ci_charmcraft_pack {lxc} {repository} {self.branch} {self.opts.get('subdir', '')}\n"
-                f"ci_charmcraft_copy {lxc} {self.dst_path}\n"
+                f"ci_charmcraft_copy {lxc} {charm_path}\n"
             )
             ret = script(charmcraft_script, echo=self.echo)
         else:
@@ -765,6 +819,7 @@ class BuildEntity:
         if not ret.ok:
             self.echo("Failed to build, aborting")
             raise BuildException(f"Failed to build {self.name}")
+        self.artifacts.append(Artifact(Arch.ALL, charm_path))
 
     @property
     def repository(self) -> Optional[Repository]:
@@ -772,10 +827,10 @@ class BuildEntity:
         if self.downstream:
             return Repository.with_session(*self.downstream.split("/"))
 
-    def push(self):
+    def push(self, artifact: Artifact):
         """Pushes a built charm to Charmhub."""
         if "override-push" in self.opts:
-            self.echo("Override push found, running in place of charm push.")
+            self.echo("Override push found, running in place of charmcraft upload.")
             args = dict(
                 cwd=self.src_path,
                 charm=self.name,
@@ -787,10 +842,10 @@ class BuildEntity:
             return
 
         self.echo(
-            f"Pushing {self.type}({self.name}) from {self.dst_path} to {self.entity}"
+            f"Uploading {self.type}({self.name}) from {artifact.charm_or_bundle} to {self.entity}"
         )
-        self.new_entity = _CharmHub(self).upload(self.dst_path)
-        self.tag(f"{self.name}-{self.new_entity}")
+        artifact.rev = _CharmHub(self).upload(artifact.charm_or_bundle)
+        self.tag(f"{self.name}-{artifact.rev}")
 
     def tag(self, tag: str) -> bool:
         """Tag current commit in this repo with a lightweigh tag."""
@@ -814,20 +869,25 @@ class BuildEntity:
                 )
         return tagged
 
-    def attach_resources(self):
-        """Assemble charm's resources and associate in charmhub."""
-        out_path = Path(self.src_path) / "tmp"
-        os.makedirs(str(out_path), exist_ok=True)
+    @property
+    def _resource_path(self) -> Path:
+        out_path = Path(self.src_path, "tmp")
+        out_path.mkdir(parents=True, exist_ok=True)
+        return out_path
+
+    @property
+    def _resource_spec(self):
         resource_spec = yaml.safe_load(Path(self.build.resource_spec).read_text())
-        resource_spec = resource_spec.get(self.name, {})
+        return resource_spec.get(self.name, {})
+
+    def resource_build(self):
+        """Build all charm custom resources."""
         context = dict(
             src_path=self.src_path,
-            out_path=out_path,
+            out_path=self._resource_path,
         )
-
-        # Build any custom resources.
         resource_builder = self.opts.get("build-resources", None)
-        if resource_builder and not resource_spec:
+        if resource_builder and not self._resource_spec:
             raise BuildException(
                 f"Custom build-resources specified for {self.name} but no spec found"
             )
@@ -838,44 +898,52 @@ class BuildEntity:
             if not ret.ok:
                 raise BuildException("Failed to build custom resources")
 
+    def assemble_resources(self, artifact: Artifact):
+        """Assemble charm's resources and associate in charmhub.
+
+        Upload oci-images and any built-resource, gathering their revision
+        Use the latest available for any other charm resource
+        """
+        context = dict(
+            src_path=self.src_path,
+            out_path=self._resource_path,
+        )
+
         for name, details in self._read_metadata_resources().items():
-            resource_fmt = resource_spec.get(name)
+            resource_fmt = self._resource_spec.get(name)
             if not resource_fmt:
-                # ignore pushing a resource not defined in `resource_spec`
-                continue
-            if details["type"] == "oci-image":
-                upstream_source = details.get("upstream-source")
-                if upstream_source:
+                # Reuse most recently uploaded resource
+                revs = _CharmHub(self).status(self.entity, name)
+                resource = CharmResource(name, rev=revs[0]["Revision"])
+            elif details["type"] == "oci-image":
+                if upstream_source := details.get("upstream-source"):
                     # Pull any `upstream-image` annotated resources.
-                    self.echo(f"Pulling {upstream_source}...")
+                    self.echo(f"Pulling {upstream_source} for {artifact.arch}...")
                     docker = Docker(self)
-                    # Pulls only the amd64 image locally
-                    docker.pull(upstream_source)
+                    docker.pull(upstream_source, platform=artifact.arch_docker)
                     # Use the local image-id from `docker images <upstream-source> -q`
                     resource_fmt = docker.images(upstream_source, "-q").strip()
-                resource_spec[name] = ("image", resource_fmt)
+                resource = CharmResource(name, ResourceKind.IMAGE, resource_fmt)
             elif details["type"] == "file":
-                resource_spec[name] = (
-                    "filepath",
-                    resource_fmt.format(**context),
+                resource = CharmResource(
+                    name, ResourceKind.FILEPATH, resource_fmt.format(**context)
                 )
+            artifact.resources.append(resource)
 
-        self.echo(f"Attaching resources:\n{pformat(resource_spec)}")
-        # Attach all resources.
-        for resource_name, resource in resource_spec.items():
-            _CharmHub(self).upload_resource(self.entity, resource_name, resource)
+        for resource in artifact.resources:
+            if resource.rev is None and resource.value:
+                self.echo(f"Uploading resource:\n{pformat(resource)}")
+                resource.rev = _CharmHub(self).upload_resource(self.entity, resource)
 
-    def promote(self, from_channel="unpublished", to_channels=("edge",)):
-        """Promote charm and its resources from a channel to another."""
+    def release(self, artifact: Artifact, to_channels=("edge",)):
+        """Release charm and its resources to channels."""
         track = self.build.db["build_args"].get("track") or "latest"
         ch_channels = [
-            f"{track}/{chan.lower()}"
-            if (chan.lower() in RISKS and from_channel == "unpublished")
-            else chan
+            f"{track}/{chan.lower()}" if (chan.lower() in RISKS) else chan
             for chan in to_channels
         ]
         ch_channels = self.build.apply_channel_bounds(self.entity, ch_channels)
-        _CharmHub(self).promote(self.entity, from_channel, ch_channels)
+        _CharmHub(self).release(self.entity, artifact, ch_channels)
 
 
 class BundleBuildEntity(BuildEntity):
@@ -886,15 +954,13 @@ class BundleBuildEntity(BuildEntity):
         super().__init__(*args, **kwargs)
         self.type = "Bundle"
         self.src_path = str(self.opts["src_path"])
-        self.dst_path = str(self.opts["dst_path"])
 
-    @property
-    def has_changed(self):
+    def has_changes(self, artifact: Artifact):
         """Determine if this bundle has changes to include in a new push."""
         remote_bundle = self.download(None)
         if not remote_bundle:
             return True
-        local_bundle = zipfile.ZipFile(self.dst_path)
+        local_bundle = zipfile.ZipFile(artifact.charm_or_bundle)
 
         def _crc_list(bundle_zip):
             return sorted(
@@ -913,13 +979,14 @@ class BundleBuildEntity(BuildEntity):
         return False
 
     def bundle_build(self, to_channel):
+        outputdir = Path(self.opts["dst_path"])
         if not self.opts.get("skip-build"):
             build = sh.Command(f"{self.src_path}/bundle")
             build(
                 "-n",
                 self.name,
                 "-o",
-                self.dst_path,
+                str(outputdir),
                 "-c",
                 to_channel,
                 *self.opts["fragments"].split(),
@@ -930,20 +997,19 @@ class BundleBuildEntity(BuildEntity):
             # If we're not building the bundle from the repo, we have
             # to copy it to the expected output location instead.
             shutil.copytree(
-                Path(self.src_path) / self.opts.get("subdir", ""), self.dst_path
+                Path(self.src_path) / self.opts.get("subdir", ""), outputdir
             )
 
         # If we're building for charmhub, it needs to be packed
-        dst_path = Path(self.dst_path)
-        charmcraft_yaml = dst_path / "charmcraft.yaml"
+        charmcraft_yaml = outputdir / "charmcraft.yaml"
         if not charmcraft_yaml.exists():
             contents = {
                 "type": "bundle",
                 "parts": {
                     "bundle": {
                         "prime": [
-                            str(_.relative_to(dst_path))
-                            for _ in dst_path.glob("**/*")
+                            str(_.relative_to(outputdir))
+                            for _ in outputdir.glob("**/*")
                             if _.is_file()
                         ]
                     }
@@ -951,259 +1017,22 @@ class BundleBuildEntity(BuildEntity):
             }
             with charmcraft_yaml.open("w") as fp:
                 yaml.safe_dump(contents, fp)
-        self.dst_path = str(Charmcraft(self).pack(_cwd=dst_path))
+        bundle_path = str(Charmcraft(self).pack(_cwd=outputdir))
         self.channel = to_channel
+        self.artifacts.append(Artifact(Arch.ALL, bundle_path))
 
-    def reset_dst_path(self):
-        """Reset the dst_path in order to facilitate multiple bundle builds by the same entity."""
+    def reset_artifacts(self):
+        """Reset the artifacts in order to facilitate multiple bundle builds by the same entity."""
 
-        def delete_file_or_dir(d):
-            cur_dst_path = Path(d)
+        def delete_file_or_dir(file_or_dir):
             try:
-                cur_dst_path.unlink(missing_ok=True)
+                file_or_dir.unlink(missing_ok=True)
             except IsADirectoryError:
-                shutil.rmtree(cur_dst_path)
+                shutil.rmtree(file_or_dir)
 
-        delete_file_or_dir(self.dst_path)  # delete any zip'd bundle file
-        self.dst_path = str(self.opts["dst_path"])  # reset the state
+        outputdir = Path(self.opts["dst_path"])
         self.channel = self.build.db["build_args"]["to_channel"]  # reset the channel
-        delete_file_or_dir(self.dst_path)  # delete any unzipped bundle directory
-
-
-@click.group()
-def cli():
-    """Define click group."""
-
-
-@cli.command()
-@click.option(
-    "--charm-list", required=True, help="path to a file with list of charms in YAML"
-)
-@click.option("--layer-list", required=True, help="list of layers in YAML format")
-@click.option("--layer-index", required=True, help="Charm layer index")
-@click.option(
-    "--charm-branch",
-    required=True,
-    help="Git branch to build charm from",
-    default="",
-)
-@click.option(
-    "--layer-branch",
-    required=True,
-    help="Git branch to pull layers/interfaces from",
-    default="main",
-)
-@click.option(
-    "--resource-spec", required=True, help="YAML Spec of resource keys and filenames"
-)
-@click.option(
-    "--filter-by-tag",
-    required=True,
-    help="only build for charms matching a tag, comma separate list",
-)
-@click.option(
-    "--track", required=True, help="track to promote charm to", default="latest"
-)
-@click.option(
-    "--to-channel", required=True, help="channel to promote charm to", default="edge"
-)
-@click.option("--force", is_flag=True)
-def build(
-    charm_list,
-    layer_list,
-    layer_index,
-    charm_branch,
-    layer_branch,
-    resource_spec,
-    filter_by_tag,
-    track,
-    to_channel,
-    force,
-):
-    """Build a set of charms and publish with their resources."""
-    sh.which.charm(_tee=True, _out=lambda m: click.echo(f"charm -> {m}"))
-    sh.which.charmcraft(_tee=True, _out=lambda m: click.echo(f"charmcraft -> {m}"))
-    sh.snap.list(_tee=True, _out=lambda m: click.echo(f"snap list -> {m}"))
-
-    build_env = BuildEnv(build_type=BuildType.CHARM)
-    build_env.db["build_args"] = {
-        "artifact_list": charm_list,
-        "layer_list": layer_list,
-        "layer_index": layer_index,
-        "branch": charm_branch,
-        "layer_branch": layer_branch,
-        "resource_spec": resource_spec,
-        "filter_by_tag": filter_by_tag.split(","),
-        "track": track,
-        "to_channel": to_channel,
-        "force": force,
-    }
-    build_env.clean()
-    build_env.pull_layers()
-
-    entities = []
-    for charm_map in build_env.artifacts:
-        for charm_name, charm_opts in charm_map.items():
-            if any(tag in build_env.filter_by_tag for tag in charm_opts["tags"]):
-                charm_entity = BuildEntity(build_env, charm_name, charm_opts)
-                entities.append(charm_entity)
-                build_env.echo(f"Queued {charm_entity.entity} for building")
-
-    failed_entities = []
-
-    for entity in entities:
-        entity.echo("Starting")
-        try:
-            entity.setup()
-            entity.echo(f"Details: {entity}")
-
-            if not build_env.force:
-                if not entity.has_changed:
-                    continue
-            else:
-                entity.echo("Build forced.")
-
-            entity.charm_build()
-
-            entity.push()
-            entity.attach_resources()
-            entity.promote(to_channels=build_env.to_channels)
-        except Exception:
-            entity.echo(traceback.format_exc())
-            failed_entities.append(entity)
-        finally:
-            entity.echo("Stopping")
-
-    if any(failed_entities):
-        count = len(failed_entities)
-        plural = "s" if count > 1 else ""
-        raise SystemExit(
-            f"Encountered {count} Charm Build Failure{plural}:\n\t"
-            + ", ".join(ch.name for ch in failed_entities)
-        )
-
-    build_env.save()
-
-
-@cli.command()
-@click.option("--bundle-list", required=True, help="list of bundles in YAML format")
-@click.option(
-    "--bundle-branch",
-    default="main",
-    required=True,
-    help="Upstream branch to build bundles from",
-)
-@click.option(
-    "--filter-by-tag",
-    required=True,
-    help="only build for charms matching a tag, comma separate list",
-)
-@click.option(
-    "--bundle-repo",
-    required=True,
-    help="upstream repo for bundle builder",
-    default="https://github.com/charmed-kubernetes/bundle.git",
-)
-@click.option(
-    "--track", required=True, help="track to promote charm to", default="latest"
-)
-@click.option(
-    "--to-channel", required=True, help="channels to promote bundle to", default="edge"
-)
-@click.option("--force", is_flag=True)
-def build_bundles(
-    bundle_list, bundle_branch, filter_by_tag, bundle_repo, track, to_channel, force
-):
-    """Build list of bundles from a specific branch according to filters."""
-    build_env = BuildEnv(build_type=BuildType.BUNDLE)
-    build_env.db["build_args"] = {
-        "artifact_list": bundle_list,
-        "branch": bundle_branch,
-        "filter_by_tag": filter_by_tag.split(","),
-        "track": track,
-        "to_channel": to_channel,
-        "force": force,
-    }
-
-    build_env.clean()
-    default_repo_dir = build_env.default_repo_dir
-    git("clone", bundle_repo, default_repo_dir, branch=bundle_branch)
-
-    entities = []
-    for bundle_map in build_env.artifacts:
-        for bundle_name, bundle_opts in bundle_map.items():
-            if any(tag in build_env.filter_by_tag for tag in bundle_opts["tags"]):
-                if "downstream" in bundle_opts:
-                    bundle_opts["sub-repo"] = bundle_name
-                    bundle_opts["src_path"] = build_env.repos_dir / bundle_name
-                else:
-                    bundle_opts["src_path"] = build_env.default_repo_dir
-                bundle_opts["dst_path"] = build_env.bundles_dir / bundle_name
-
-                build_entity = BundleBuildEntity(build_env, bundle_name, bundle_opts)
-                entities.append(build_entity)
-
-    for entity in entities:
-        entity.echo("Starting")
-        try:
-            if "downstream" in entity.opts:
-                # clone bundle repo override
-                entity.setup()
-
-            entity.echo(f"Details: {entity}")
-            for channel in build_env.to_channels:
-                entity.bundle_build(channel)
-
-                # Bundles are built easily, but it's pointless to push the bundle
-                # if the crcs of each file in the bundle zips are the same
-                if build_env.force or entity.has_changed:
-                    entity.echo(
-                        f"Pushing built bundle for channel={channel} (forced={build_env.force})."
-                    )
-                    entity.push()
-                    entity.promote(to_channels=[channel])
-
-                entity.reset_dst_path()
-        finally:
-            entity.echo("Stopping")
-
-    build_env.save()
-
-
-@cli.command()
-@click.option("--charm-list", required=True, help="path to charm list YAML")
-@click.option(
-    "--filter-by-tag",
-    required=True,
-    help="only build for charms matching a tag, comma separate list",
-)
-@click.option(
-    "--track", required=True, help="track to promote charm to", default="latest"
-)
-@click.option(
-    "--from-channel",
-    default="unpublished",
-    required=True,
-    help="Charm channel to publish from",
-)
-@click.option("--to-channel", required=True, help="Charm channel to publish to")
-def promote(charm_list, filter_by_tag, track, from_channel, to_channel):
-    """
-    Promote channel for a set of charms filtered by tag.
-    """
-    build_env = BuildEnv(build_type=BuildType.CHARM)
-    build_env.db["build_args"] = {
-        "artifact_list": charm_list,
-        "filter_by_tag": filter_by_tag.split(","),
-        "to_channel": to_channel,
-        "from_channel": from_channel,
-        "track": track,
-    }
-    build_env.clean()
-    return build_env.promote_all(
-        from_channel=from_channel, to_channels=build_env.to_channels
-    )
-
-
-if __name__ == "__main__":
-    cli()
+        delete_file_or_dir(outputdir)  # delete any unzipped bundle directory
+        for each in self.artifacts:
+            delete_file_or_dir(each.charm_or_bundle)  # delete any zip'd bundle file
+        self.artifacts = []

--- a/jobs/build-charms/main.py
+++ b/jobs/build-charms/main.py
@@ -108,7 +108,6 @@ def build(
             entity.resource_build()
             for each in entity.artifacts:
                 entity.push(each)
-                entity.resource_build(each)
                 entity.assemble_resources(each)
                 entity.release(each, to_channels=build_env.to_channels)
         except Exception:

--- a/jobs/build-charms/main.py
+++ b/jobs/build-charms/main.py
@@ -1,0 +1,250 @@
+import click
+import sh
+import traceback
+from sh.contrib import git
+
+from builder_local import BundleBuildEntity, BuildEnv, BuildEntity, BuildType
+from builder_launchpad import LPBuildEntity
+
+
+@click.group()
+def cli():
+    """Define click group."""
+
+
+@cli.command()
+@click.option(
+    "--charm-list", required=True, help="path to a file with list of charms in YAML"
+)
+@click.option("--layer-list", required=True, help="list of layers in YAML format")
+@click.option("--layer-index", required=True, help="Charm layer index")
+@click.option(
+    "--charm-branch",
+    required=True,
+    help="Git branch to build charm from",
+    default="",
+)
+@click.option(
+    "--layer-branch",
+    required=True,
+    help="Git branch to pull layers/interfaces from",
+    default="main",
+)
+@click.option(
+    "--resource-spec", required=True, help="YAML Spec of resource keys and filenames"
+)
+@click.option(
+    "--filter-by-tag",
+    required=True,
+    help="only build for charms matching a tag, comma separate list",
+)
+@click.option(
+    "--track", required=True, help="track to promote charm to", default="latest"
+)
+@click.option(
+    "--to-channel", required=True, help="channel to promote charm to", default="edge"
+)
+@click.option("--force", is_flag=True)
+def build(
+    charm_list,
+    layer_list,
+    layer_index,
+    charm_branch,
+    layer_branch,
+    resource_spec,
+    filter_by_tag,
+    track,
+    to_channel,
+    force,
+):
+    """Build a set of charms and publish with their resources."""
+    # sh.which.charm(_tee=True, _out=lambda m: click.echo(f"charm -> {m}"))
+    # sh.which.charmcraft(_tee=True, _out=lambda m: click.echo(f"charmcraft -> {m}"))
+    # sh.snap.list(_tee=True, _out=lambda m: click.echo(f"snap list -> {m}"))
+
+    build_env = BuildEnv(build_type=BuildType.CHARM)
+    build_env.db["build_args"] = {
+        "job_list": charm_list,
+        "layer_list": layer_list,
+        "layer_index": layer_index,
+        "branch": charm_branch,
+        "layer_branch": layer_branch,
+        "resource_spec": resource_spec,
+        "filter_by_tag": filter_by_tag.split(","),
+        "track": track,
+        "to_channel": to_channel,
+        "force": force,
+    }
+    build_env.clean()
+    # build_env.pull_layers()
+
+    entities = []
+    for charm_map in build_env.job_list:
+        for charm_name, charm_opts in charm_map.items():
+            if any(tag in build_env.filter_by_tag for tag in charm_opts["tags"]):
+                cls = (
+                    LPBuildEntity if charm_opts.get("builder") == "launchpad" else BuildEntity
+                )
+                charm_entity = cls(build_env, charm_name, charm_opts)
+                entities.append(charm_entity)
+                build_env.echo(f"Queued {charm_entity.entity} for building")
+
+    failed_entities = []
+
+    for entity in entities:
+        entity.echo("Starting")
+        try:
+            entity.setup()
+            entity.echo(f"Details: {entity}")
+
+            if not build_env.force:
+                if not entity.has_changed:
+                    continue
+            else:
+                entity.echo("Build forced.")
+
+            entity.charm_build()
+            entity.resource_build()
+            for each in entity.artifacts:
+                entity.push(each)
+                entity.assemble_resources(each)
+                entity.release(each, to_channels=build_env.to_channels)
+        except Exception:
+            entity.echo(traceback.format_exc())
+            failed_entities.append(entity)
+        finally:
+            entity.echo("Stopping")
+
+    if any(failed_entities):
+        count = len(failed_entities)
+        plural = "s" if count > 1 else ""
+        raise SystemExit(
+            f"Encountered {count} Charm Build Failure{plural}:\n\t"
+            + ", ".join(ch.name for ch in failed_entities)
+        )
+
+    build_env.save()
+
+
+@cli.command()
+@click.option("--bundle-list", required=True, help="list of bundles in YAML format")
+@click.option(
+    "--bundle-branch",
+    default="main",
+    required=True,
+    help="Upstream branch to build bundles from",
+)
+@click.option(
+    "--filter-by-tag",
+    required=True,
+    help="only build for charms matching a tag, comma separate list",
+)
+@click.option(
+    "--bundle-repo",
+    required=True,
+    help="upstream repo for bundle builder",
+    default="https://github.com/charmed-kubernetes/bundle.git",
+)
+@click.option(
+    "--track", required=True, help="track to promote charm to", default="latest"
+)
+@click.option(
+    "--to-channel", required=True, help="channels to promote bundle to", default="edge"
+)
+@click.option("--force", is_flag=True)
+def build_bundles(
+    bundle_list, bundle_branch, filter_by_tag, bundle_repo, track, to_channel, force
+):
+    """Build list of bundles from a specific branch according to filters."""
+    build_env = BuildEnv(build_type=BuildType.BUNDLE)
+    build_env.db["build_args"] = {
+        "job_list": bundle_list,
+        "branch": bundle_branch,
+        "filter_by_tag": filter_by_tag.split(","),
+        "track": track,
+        "to_channel": to_channel,
+        "force": force,
+    }
+
+    build_env.clean()
+    default_repo_dir = build_env.default_repo_dir
+    git("clone", bundle_repo, default_repo_dir, branch=bundle_branch)
+
+    entities = []
+    for bundle_map in build_env.job_list:
+        for bundle_name, bundle_opts in bundle_map.items():
+            if any(tag in build_env.filter_by_tag for tag in bundle_opts["tags"]):
+                if "downstream" in bundle_opts:
+                    bundle_opts["sub-repo"] = bundle_name
+                    bundle_opts["src_path"] = build_env.repos_dir / bundle_name
+                else:
+                    bundle_opts["src_path"] = build_env.default_repo_dir
+                bundle_opts["dst_path"] = build_env.bundles_dir / bundle_name
+
+                build_entity = BundleBuildEntity(build_env, bundle_name, bundle_opts)
+                entities.append(build_entity)
+
+    for entity in entities:
+        entity.echo("Starting")
+        try:
+            if "downstream" in entity.opts:
+                # clone bundle repo override
+                entity.setup()
+
+            entity.echo(f"Details: {entity}")
+            for channel in build_env.to_channels:
+                entity.bundle_build(channel)
+
+                # Bundles are built easily, but it's pointless to push the bundle
+                # if the crcs of each file in the bundle zips are the same
+                for artifact in entity.artifacts:
+                    if build_env.force or entity.has_changes(artifact):
+                        entity.echo(
+                            f"Pushing built bundle for channel={channel} (forced={build_env.force})."
+                        )
+                        entity.push(artifact)
+                        entity.promote(artifact, to_channels=[channel])
+                entity.reset_artifacts()
+        finally:
+            entity.echo("Stopping")
+
+    build_env.save()
+
+
+@cli.command()
+@click.option("--charm-list", required=True, help="path to charm list YAML")
+@click.option(
+    "--filter-by-tag",
+    required=True,
+    help="only build for charms matching a tag, comma separate list",
+)
+@click.option(
+    "--track", required=True, help="track to promote charm to", default="latest"
+)
+@click.option(
+    "--from-channel",
+    default="unpublished",
+    required=True,
+    help="Charm channel to publish from",
+)
+@click.option("--to-channel", required=True, help="Charm channel to publish to")
+def promote(charm_list, filter_by_tag, track, from_channel, to_channel):
+    """
+    Promote channel for a set of charms filtered by tag.
+    """
+    build_env = BuildEnv(build_type=BuildType.CHARM)
+    build_env.db["build_args"] = {
+        "job_list": charm_list,
+        "filter_by_tag": filter_by_tag.split(","),
+        "to_channel": to_channel,
+        "from_channel": from_channel,
+        "track": track,
+    }
+    build_env.clean()
+    return build_env.promote_all(
+        from_channel=from_channel, to_channels=build_env.to_channels
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -540,6 +540,7 @@
     channel-range:
       min: '999.0'
 - kubernetes-dashboard:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/kubernetes-dashboard-operator'
     docs: 'https://charmhub.io/kubernetes-dashboard/docs'
     downstream: charmed-kubernetes/kubernetes-dashboard-operator

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -41,7 +41,7 @@
     channel-range:
       min: '1.25'
 - cinder-csi:
-    bugs: 'https://launchpad.net/charm-cinder-csi'
+    bugs: 'https://bugs.launchpad.net/charm-cinder-csi'
     docs: 'https://charmhub.io/cinder-csi/docs'
     downstream: charmed-kubernetes/cinder-csi-operator.git
     store: 'https://charmhub.io/cinder-csi'
@@ -493,6 +493,7 @@
     upstream: >-
       https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin.git
 - coredns:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-coredns'
     docs: 'https://charmhub.io/coredns/docs'
     downstream: charmed-kubernetes/charm-coredns

--- a/tests/data/cli_response/charmcraft_upload-resource_k8s-ci-charm_test-file.txt
+++ b/tests/data/cli_response/charmcraft_upload-resource_k8s-ci-charm_test-file.txt
@@ -1,0 +1,1 @@
+Revision 3 of this resource

--- a/tests/data/cli_response/charmcraft_upload-resource_k8s-ci-charm_test-image.txt
+++ b/tests/data/cli_response/charmcraft_upload-resource_k8s-ci-charm_test-image.txt
@@ -1,0 +1,1 @@
+Revision 4 of this resource

--- a/tests/unit/build_charms/conftest.py
+++ b/tests/unit/build_charms/conftest.py
@@ -5,12 +5,24 @@ import pytest
 
 
 @pytest.fixture(scope="package")
-def charms():
+def builder_local():
     sys.path.append("jobs/build-charms")
-    charms = importlib.import_module("charms")
+    builder_local = importlib.import_module("builder_local")
 
-    yield charms
+    yield builder_local
 
     sys.path.remove("jobs/build-charms")
-    del sys.modules["charms"]
-    del charms
+    del sys.modules["builder_local"]
+    del builder_local
+
+
+@pytest.fixture(scope="package")
+def main():
+    sys.path.append("jobs/build-charms")
+    main = importlib.import_module("main")
+
+    yield main
+
+    sys.path.remove("jobs/build-charms")
+    del sys.modules["main"]
+    del main

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -30,18 +30,18 @@ CHARMCRAFT_LIB_SH = TEST_PATH.parent / "jobs" / "build-charms" / "charmcraft-lib
         ("candidate", None),
     ],
 )
-def test_matched_numerical_channel(charms, risk, expected):
+def test_matched_numerical_channel(builder_local, risk, expected):
     track_map = {
         "0.15": ["0.15/edge", "0.15/beta", "0.15/stable"],
         "2.14": ["2.14/edge", "2.14/beta"],
     }
-    assert charms.matched_numerical_channel(risk, track_map) == expected
+    assert builder_local.matched_numerical_channel(risk, track_map) == expected
 
 
-def test_build_env_missing_env(charms):
+def test_build_env_missing_env(builder_local):
     """Ensure missing environment variables raise Exception."""
-    with pytest.raises(charms.BuildException) as ie:
-        charms.BuildEnv()
+    with pytest.raises(builder_local.BuildException) as ie:
+        builder_local.BuildEnv()
     assert "build environment variables" in str(ie.value)
 
 
@@ -71,16 +71,16 @@ def test_environment(tmpdir):
 
 
 @pytest.fixture(autouse=True)
-def cilib_store(charms):
+def cilib_store(builder_local):
     """Create a fixture defining mock for cilib Store."""
-    with patch("charms.Store") as store:
+    with patch("builder_local.Store") as store:
         yield store
 
 
 @pytest.fixture(autouse=True)
-def github_repository(charms):
+def github_repository(builder_local):
     """Create a fixture defining mock for github api."""
-    with patch.object(charms, "Repository") as repo:
+    with patch.object(builder_local, "Repository") as repo:
         yield repo.with_session.return_value
 
 
@@ -112,7 +112,9 @@ def charmhub_info():
             return yaml.safe_load(fpath.read_text())
         return {}
 
-    with patch("charms._CharmHub.info", side_effect=command_response) as mock_info:
+    with patch(
+        "builder_local._CharmHub.info", side_effect=command_response
+    ) as mock_info:
         yield mock_info
 
 
@@ -136,10 +138,10 @@ def charmcraft_cmd():
 
 
 @pytest.fixture()
-def bundle_environment(test_environment, charms):
-    charm_env = charms.BuildEnv(build_type=charms.BuildType.BUNDLE)
+def bundle_environment(test_environment, builder_local):
+    charm_env = builder_local.BuildEnv(build_type=builder_local.BuildType.BUNDLE)
     charm_env.db["build_args"] = {
-        "artifact_list": str(CI_TESTING_BUNDLES),
+        "job_list": str(CI_TESTING_BUNDLES),
         "branch": "main",
         "filter_by_tag": ["k8s"],
         "to_channel": "edge",
@@ -149,10 +151,10 @@ def bundle_environment(test_environment, charms):
 
 
 @pytest.fixture()
-def charm_environment(test_environment, charms):
-    charm_env = charms.BuildEnv(build_type=charms.BuildType.CHARM)
+def charm_environment(test_environment, builder_local):
+    charm_env = builder_local.BuildEnv(build_type=builder_local.BuildType.CHARM)
     charm_env.db["build_args"] = {
-        "artifact_list": str(CI_TESTING_CHARMS),
+        "job_list": str(CI_TESTING_CHARMS),
         "filter_by_tag": ["k8s"],
         "to_channel": "edge",
         "from_channel": "beta",
@@ -176,13 +178,13 @@ def test_build_env_promote_all_charmhub(charm_environment, charmcraft_cmd):
     )
 
 
-@patch("charms.os.makedirs", Mock())
-@patch("charms.git")
-def test_build_entity_setup(git, charm_environment, tmpdir, charms):
+@patch("builder_local.os.makedirs", Mock())
+@patch("builder_local.git")
+def test_build_entity_setup(git, charm_environment, tmpdir, builder_local):
     """Tests build entity setup."""
-    artifacts = charm_environment.artifacts
+    artifacts = charm_environment.job_list
     charm_name, charm_opts = next(iter(artifacts[0].items()))
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
     assert charm_entity.reactive is False, "Initializes as false"
     charm_entity.setup()
     assert charm_entity.reactive is True, "test charm requires legacy builds"
@@ -196,34 +198,34 @@ def test_build_entity_setup(git, charm_environment, tmpdir, charms):
     )
 
 
-def test_build_entity_has_changed(charm_environment, charm_cmd, charms):
+def test_build_entity_charm_changes(charm_environment, charm_cmd, builder_local):
     """Tests has_changed property."""
-    artifacts = charm_environment.artifacts
+    artifacts = charm_environment.job_list
     charm_name, charm_opts = next(iter(artifacts[0].items()))
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
-    with patch("charms.BuildEntity.commit") as commit:
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
+    with patch("builder_local.BuildEntity.commit") as commit:
         # Test non-legacy charms with the commit rev checked in with charm matching
         commit.return_value = "51b893c"
-        assert charm_entity.has_changed is False
+        assert charm_entity.charm_changes is False
 
         # Test non-legacy charms with the commit rev checked in with charm not matching
         commit.return_value = "51b893d"
-        assert charm_entity.has_changed is True
+        assert charm_entity.charm_changes is True
 
         # Test legacy charms by comparing charmstore .build.manifest
         charm_entity.reactive = True
-        assert charm_entity.has_changed is True
+        assert charm_entity.charm_changes is True
 
 
-@patch("charms.script")
+@patch("builder_local.script")
 def test_build_entity_charm_build(
-    mock_script, charm_environment, charm_cmd, charmcraft_cmd, tmpdir, charms
+    mock_script, charm_environment, charm_cmd, charmcraft_cmd, tmpdir, builder_local
 ):
     """Test that BuildEntity runs charm_build."""
-    artifacts = charm_environment.artifacts
+    artifacts = charm_environment.job_list
     charm_name, charm_opts = next(iter(artifacts[0].items()))
 
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
 
     # Charms built with override
     charm_entity.opts["override-build"] = MagicMock()
@@ -241,13 +243,18 @@ def test_build_entity_charm_build(
 
     # Reactive charms built with charm tools
     charm_entity.reactive = True
+    charm_entity.artifacts = []
     charm_entity.charm_build()
 
     manifest_yaml = Path(charm_entity.src_path, "manifest.yaml")
     assert manifest_yaml.exists(), "Manifest not generated"
     manifest_yaml.unlink()
 
-    assert charm_entity.dst_path == str(K8S_CI_CHARM / "k8s-ci-charm.charm")
+    assert len(charm_entity.artifacts) == 1
+    artifact = charm_entity.artifacts[0]
+    assert artifact.arch.value == "all"
+    assert artifact.arch_docker == "amd64"
+    assert artifact.charm_or_bundle == str(K8S_CI_CHARM / "k8s-ci-charm.charm")
     charm_cmd.build.assert_called_once_with(
         "-r",
         "--force",
@@ -263,6 +270,7 @@ def test_build_entity_charm_build(
     # Operator Charms, build with charmcraft container
     charm_entity.reactive = False
     os.environ["charmcraft_lxc"] = "unnamed-job-0"
+    charm_entity.artifacts = []
     charm_entity.charm_build()
     charm_cmd.build.assert_not_called()
     mock_script.assert_called_once_with(
@@ -276,35 +284,37 @@ def test_build_entity_charm_build(
 
     # Operator Charms, fail build without charmcraft container
     del os.environ["charmcraft_lxc"]
-    with pytest.raises(charms.BuildException):
+    with pytest.raises(builder_local.BuildException):
+        charm_entity.artifacts = []
         charm_entity.charm_build()
 
 
-def test_build_entity_push(
-    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, charms
+def test_build_entity_upload(
+    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, builder_local
 ):
     """Test that BuildEntity pushes to appropriate store."""
-    artifacts = charm_environment.artifacts
-    charm_name, charm_opts = next(iter(artifacts[0].items()))
+    charms = charm_environment.job_list
+    charm_name, charm_opts = next(iter(charms[0].items()))
 
     charmcraft_cmd.upload.return_value = (
         CLI_RESPONSES / "charmcraft_upload_k8s-ci-charm.txt"
     ).read_text()
 
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
     charm_entity.tag = MagicMock()
-    charm_entity.push()
+    artifact = MagicMock()
+    charm_entity.push(artifact)
     charm_cmd.push.assert_not_called()
-    charmcraft_cmd.upload.assert_called_once_with(charm_entity.dst_path)
+    charmcraft_cmd.upload.assert_called_once_with(artifact.charm_or_bundle)
     charm_entity.tag.assert_called_once_with("k8s-ci-charm-845")
-    assert charm_entity.new_entity == "845"
+    assert artifact.rev == 845
 
 
 @pytest.fixture()
-def build_entity_tag(charm_environment, charms):
-    artifacts = charm_environment.artifacts
+def build_entity_tag(charm_environment, builder_local):
+    artifacts = charm_environment.job_list
     charm_name, charm_opts = next(iter(artifacts[0].items()))
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
     the_tag = f"{charm_entity.name}-369"
     the_sha = "0123456789abcdef0123456789abcdef01234567"
 
@@ -334,7 +344,7 @@ def test_build_entity_tag_duplicate(build_entity_tag, github_repository):
     github_repository.tag_commit.assert_not_called()
 
 
-def test_build_entity_tag_conflict(build_entity_tag, charms, github_repository):
+def test_build_entity_tag_conflict(build_entity_tag, builder_local, github_repository):
     the_sha, the_tag, charm_entity = build_entity_tag
 
     charm_entity.commit = MagicMock(return_value=the_sha)
@@ -342,22 +352,32 @@ def test_build_entity_tag_conflict(build_entity_tag, charms, github_repository):
         "object": dict(sha=the_sha.replace("0", "X"))
     }
 
-    with pytest.raises(charms.BuildException):
+    with pytest.raises(builder_local.BuildException):
         charm_entity.tag(the_tag)
 
 
-@patch("charms.os.makedirs", Mock())
-def test_build_entity_attach_resource(
-    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, charms
-):
-    artifacts = charm_environment.artifacts
-    charm_name, charm_opts = next(iter(artifacts[0].items()))
+@patch("builder_local.os.makedirs", Mock())
+def test_build_entity_resource_build(charm_environment, tmpdir, builder_local):
+    charms = charm_environment.job_list
+    charm_name, charm_opts = next(iter(charms[0].items()))
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
 
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
-    charm_entity.dst_path = charm_entity.src_path
-    with patch("charms.script") as mock_script:
-        charm_entity.attach_resources()
+    with patch("builder_local.script") as mock_script:
+        charm_entity.resource_build()
     mock_script.assert_called_once()
+
+
+@patch("builder_local.os.makedirs", Mock())
+def test_build_entity_assemble_resources(
+    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, builder_local
+):
+    charms = charm_environment.job_list
+    charm_name, charm_opts = next(iter(charms[0].items()))
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
+    artifact = MagicMock()
+    artifact.resources = []
+    charm_entity.assemble_resources(artifact)
+
     charmcraft_cmd.assert_has_calls(
         [
             call(
@@ -379,14 +399,24 @@ def test_build_entity_attach_resource(
 
 
 def test_build_entity_promote(
-    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, charms
+    charm_environment, charm_cmd, charmcraft_cmd, tmpdir, builder_local
 ):
     """Test that BuildEntity releases to appropriate store."""
-    artifacts = charm_environment.artifacts
-    charm_name, charm_opts = next(iter(artifacts[0].items()))
+    charms = charm_environment.job_list
+    charm_name, charm_opts = next(iter(charms[0].items()))
 
-    charm_entity = charms.BuildEntity(charm_environment, charm_name, charm_opts)
-    charm_entity.promote(to_channels=("edge", "0.15/edge"))
+    charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
+    artifact = MagicMock()
+    artifact.rev = 6
+    artifact.resources = [
+        builder_local.CharmResource(
+            "test-file", kind=builder_local.ResourceKind.FILEPATH, rev=3
+        ),
+        builder_local.CharmResource(
+            "test-image", kind=builder_local.ResourceKind.IMAGE, rev=4
+        ),
+    ]
+    charm_entity.release(artifact, to_channels=("edge", "0.15/edge"))
     charm_cmd.release.assert_not_called()
     charmcraft_cmd.release.assert_called_once_with(
         "k8s-ci-charm",
@@ -398,7 +428,7 @@ def test_build_entity_promote(
     )
     charmcraft_cmd.release.reset_mock()
 
-    charm_entity.promote(to_channels=("stable", "0.15/stable"))
+    charm_entity.release(artifact, to_channels=("stable", "0.15/stable"))
     charm_cmd.release.assert_not_called()
     charmcraft_cmd.release.assert_called_once_with(
         "k8s-ci-charm",
@@ -409,7 +439,7 @@ def test_build_entity_promote(
         "--resource=test-image:4",
     )
     charmcraft_cmd.release.reset_mock()
-    charm_entity.promote(to_channels=("0.14/stable",))
+    charm_entity.release(artifact, to_channels=("0.14/stable",))
     charm_cmd.release.assert_not_called()
     charmcraft_cmd.release.assert_called_once_with(
         "k8s-ci-charm",
@@ -422,59 +452,61 @@ def test_build_entity_promote(
 
 
 def test_bundle_build_entity_push(
-    bundle_environment, charm_cmd, charmcraft_cmd, tmpdir, charms
+    bundle_environment, charm_cmd, charmcraft_cmd, tmpdir, builder_local
 ):
     """Test that BundleBuildEntity pushes to appropriate store."""
-    artifacts = bundle_environment.artifacts
-    bundle_name, bundle_opts = next(iter(artifacts[0].items()))
+    bundles = bundle_environment.job_list
+    bundle_name, bundle_opts = next(iter(bundles[0].items()))
 
     bundle_opts["src_path"] = bundle_environment.default_repo_dir
     bundle_opts["dst_path"] = bundle_environment.bundles_dir / bundle_name
     charmcraft_cmd.upload.return_value = (
         CLI_RESPONSES / "charmcraft_upload_test-kubernetes.txt"
     ).read_text()
-    bundle_entity = charms.BundleBuildEntity(
+    bundle_entity = builder_local.BundleBuildEntity(
         bundle_environment, bundle_name, bundle_opts
     )
+    artifact = MagicMock()
     bundle_entity.tag = MagicMock()
-    bundle_entity.push()
+    bundle_entity.push(artifact)
     charm_cmd.push.assert_not_called()
-    charmcraft_cmd.upload.assert_called_once_with(bundle_entity.dst_path)
+    charmcraft_cmd.upload.assert_called_once_with(artifact.charm_or_bundle)
     bundle_entity.tag.assert_called_once_with("test-kubernetes-123")
-    assert bundle_entity.new_entity == "123"
+    assert artifact.rev == 123
 
 
-@patch("charms.sh.Command")
+@patch("builder_local.sh.Command")
 def test_bundle_build_entity_bundle_build(
-    sh_cmd, charmcraft_cmd, bundle_environment, charms
+    sh_cmd, charmcraft_cmd, bundle_environment, builder_local
 ):
     """Tests bundle_build method."""
-    artifacts = bundle_environment.artifacts
-    bundle_name, bundle_opts = next(iter(artifacts[0].items()))
+    bundles = bundle_environment.job_list
+    bundle_name, bundle_opts = next(iter(bundles[0].items()))
     bundle_opts["src_path"] = K8S_CI_BUNDLE
     bundle_opts["dst_path"] = dst_path = bundle_environment.bundles_dir / bundle_name
 
     # Test a bundle copy takes place
     # Test that a bundle pack occurs
     bundle_opts["skip-build"] = True
-    bundle_entity = charms.BundleBuildEntity(
+    bundle_entity = builder_local.BundleBuildEntity(
         bundle_environment, bundle_name, bundle_opts
     )
     bundle_entity.bundle_build("edge")
     charmcraft_cmd.pack.assert_called_once_with(_cwd=dst_path)
-    assert (
-        bundle_entity.dst_path
-        == "/not/real/path/to/scratch/tmp/bundles/test-kubernetes.zip"
+    assert len(bundle_entity.artifacts) == 1
+    artifact = bundle_entity.artifacts[0]
+    assert artifact.charm_or_bundle == Path(
+        "/not/real/path/to/scratch/tmp/bundles/test-kubernetes.zip"
     )
     assert (dst_path / "bundle.yaml").exists()
     assert (dst_path / "tests" / "test.yaml").exists()
     sh_cmd.assert_not_called()
-    bundle_entity.reset_dst_path()
+    bundle_entity.reset_artifacts()
     dst_path.mkdir()
 
     # Test a bundle build takes place
     del bundle_opts["skip-build"]
-    bundle_entity = charms.BundleBuildEntity(
+    bundle_entity = builder_local.BundleBuildEntity(
         bundle_environment, bundle_name, bundle_opts
     )
     bundle_entity.bundle_build("edge")
@@ -497,21 +529,22 @@ def test_bundle_build_entity_bundle_build(
     shutil.rmtree(dst_path)
 
 
-def test_bundle_build_entity_has_changed(bundle_environment, charm_cmd, charms):
+def test_bundle_build_entity_differs(bundle_environment, charm_cmd, builder_local):
     """Tests has_changed property."""
-    artifacts = bundle_environment.artifacts
-    bundle_name, bundle_opts = next(iter(artifacts[0].items()))
+    bundles = bundle_environment.job_list
+    bundle_name, bundle_opts = next(iter(bundles[0].items()))
     bundle_opts["src_path"] = bundle_environment.default_repo_dir
-    bundle_opts["dst_path"] = K8S_CI_BUNDLE.with_suffix(".bundle")
 
     # Test all charmhub charms comparing .build.manifest to revision
-    bundle_entity = charms.BundleBuildEntity(
+    bundle_entity = builder_local.BundleBuildEntity(
         bundle_environment, bundle_name, bundle_opts
     )
+    artifact = MagicMock()
+    artifact.charm_or_bundle = K8S_CI_BUNDLE.with_suffix(".bundle")
     with patch.object(
         bundle_entity, "download", return_value=MagicMock(autospec=ZipFile)
     ):
-        assert bundle_entity.has_changed is True
+        assert bundle_entity.bundle_differs(artifact) is True
 
 
 #   --------------------------------------------------
@@ -521,7 +554,7 @@ def test_bundle_build_entity_has_changed(bundle_environment, charm_cmd, charms):
 @pytest.fixture()
 def mock_build_env():
     """Create a fixture defining a mock BuildEnv object."""
-    with patch("charms.BuildEnv") as mock_env:
+    with patch("main.BuildEnv") as mock_env:
         mock_env_inst = mock_env.return_value
         mock_env_inst.db = {}
         yield mock_env_inst
@@ -530,19 +563,20 @@ def mock_build_env():
 @pytest.fixture()
 def mock_build_entity():
     """Create a fixture defining a mock BuildEntity object."""
-    with patch("charms.BuildEntity") as mock_ent:
+    with patch("main.BuildEntity") as mock_ent:
         yield mock_ent
 
 
 @pytest.fixture()
-def mock_bundle_build_entity(charms):
+def mock_bundle_build_entity(main):
     """Create a fixture defining a mock BundleBuildEntity object."""
-    spec = dir(charms.BundleBuildEntity)
-    with patch("charms.BundleBuildEntity") as mock_ent:
+    spec = dir(main.BundleBuildEntity)
+    with patch("main.BundleBuildEntity") as mock_ent:
 
         def create_mock_bundle(*args):
             mm = MagicMock(spec=spec)
             mm.build, mm.name, mm.opts = args
+            mm.artifacts = [MagicMock()]
             mock_ent.entities.append(mm)
             return mm
 
@@ -551,11 +585,11 @@ def mock_bundle_build_entity(charms):
         yield mock_ent
 
 
-def test_promote_command(mock_build_env, charms):
+def test_promote_command(mock_build_env, main):
     """Tests cli promote command which is run by jenkins job."""
     runner = CliRunner()
     result = runner.invoke(
-        charms.promote,
+        main.promote,
         [
             "--charm-list=test-charm",
             "--filter-by-tag=tag1,tag2",
@@ -566,7 +600,7 @@ def test_promote_command(mock_build_env, charms):
     if result.exception:
         raise result.exception
     assert mock_build_env.db["build_args"] == {
-        "artifact_list": "test-charm",
+        "job_list": "test-charm",
         "filter_by_tag": ["tag1", "tag2"],
         "from_channel": "latest/edge",
         "to_channel": "latest/beta",
@@ -578,11 +612,11 @@ def test_promote_command(mock_build_env, charms):
     )
 
 
-@patch("charms.sh", MagicMock())
-def test_build_command(mock_build_env, mock_build_entity, charms):
+@patch("builder_local.sh", MagicMock())
+def test_build_command(mock_build_env, mock_build_entity, main):
     """Tests cli build command which is run by jenkins job."""
     runner = CliRunner()
-    mock_build_env.artifacts = [
+    mock_build_env.job_list = [
         {
             "k8s-ci-charm": dict(
                 tags=["tag1", "k8s"],
@@ -593,9 +627,11 @@ def test_build_command(mock_build_env, mock_build_entity, charms):
         }
     ]
     mock_build_env.filter_by_tag = ["tag1", "tag2"]
+    artifact = MagicMock()
     entity = mock_build_entity.return_value
+    entity.artifacts = [artifact]
     result = runner.invoke(
-        charms.build,
+        main.build,
         [
             "--charm-list=tests/data/ci-testing-charms.inc",
             "--resource-spec=jobs/build-charms/resource-spec.yaml",
@@ -609,7 +645,7 @@ def test_build_command(mock_build_env, mock_build_entity, charms):
         raise result.exception
 
     assert mock_build_env.db["build_args"] == {
-        "artifact_list": "tests/data/ci-testing-charms.inc",
+        "job_list": "tests/data/ci-testing-charms.inc",
         "layer_list": "jobs/includes/charm-layer-list.inc",
         "branch": "",
         "layer_branch": "main",
@@ -634,18 +670,20 @@ def test_build_command(mock_build_env, mock_build_entity, charms):
     )
     entity.setup.assert_called_once_with()
     entity.charm_build.assert_called_once_with()
-    entity.push.assert_called_once_with()
-    entity.attach_resources.assert_called_once_with()
-    entity.promote.assert_called_once_with(to_channels=mock_build_env.to_channels)
+    entity.push.assert_called_once_with(artifact)
+    entity.assemble_resources.assert_called_once_with(artifact)
+    entity.release.assert_called_once_with(
+        artifact, to_channels=mock_build_env.to_channels
+    )
 
 
-@patch("charms.git")
+@patch("main.git")
 def test_bundle_build_command(
-    git, mock_build_env, mock_bundle_build_entity, tmpdir, charms
+    git, mock_build_env, mock_bundle_build_entity, tmpdir, main
 ):
     """Tests cli build command which is run by jenkins job."""
     runner = CliRunner()
-    mock_build_env.artifacts = [
+    mock_build_env.job_list = [
         {
             "test-kubernetes": dict(
                 tags=["k8s", "canonical-kubernetes"],
@@ -670,7 +708,7 @@ def test_bundle_build_command(
     mock_build_env.force = False
 
     result = runner.invoke(
-        charms.build_bundles,
+        main.build_bundles,
         [
             "--bundle-list=tests/data/ci-testing-bundles.inc",
             "--filter-by-tag=k8s",
@@ -680,7 +718,7 @@ def test_bundle_build_command(
         raise result.exception
 
     assert mock_build_env.db["build_args"] == {
-        "artifact_list": "tests/data/ci-testing-bundles.inc",
+        "job_list": "tests/data/ci-testing-bundles.inc",
         "branch": "main",
         "filter_by_tag": mock_build_env.filter_by_tag,
         "track": "latest",
@@ -697,6 +735,7 @@ def test_bundle_build_command(
     mock_build_env.save.assert_called_once_with()
 
     for entity in mock_bundle_build_entity.entities:
+        artifact = entity.artifacts[0]
         entity.echo.assert_has_calls(
             [
                 call("Starting"),
@@ -713,8 +752,9 @@ def test_bundle_build_command(
         assert entity.bundle_build.mock_calls == [
             call(channel) for channel in mock_build_env.to_channels
         ]
-        assert entity.push.mock_calls == [call(), call()]
-        assert entity.promote.mock_calls == [
-            call(to_channels=[channel]) for channel in mock_build_env.to_channels
+        assert entity.push.mock_calls == [call(artifact), call(artifact)]
+        assert entity.release.mock_calls == [
+            call(artifact, to_channels=[channel])
+            for channel in mock_build_env.to_channels
         ]
-        assert entity.reset_dst_path.mock_calls == [call(), call()]
+        assert entity.reset_artifacts.mock_calls == [call(), call()]

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -254,7 +254,7 @@ def test_build_entity_charm_build(
     artifact = charm_entity.artifacts[0]
     assert artifact.arch.value == "all"
     assert artifact.arch_docker == "amd64"
-    assert artifact.charm_or_bundle == str(K8S_CI_CHARM / "k8s-ci-charm.charm")
+    assert artifact.charm_or_bundle == K8S_CI_CHARM / "k8s-ci-charm.charm"
     charm_cmd.build.assert_called_once_with(
         "-r",
         "--force",
@@ -375,6 +375,7 @@ def test_build_entity_assemble_resources(
     charm_name, charm_opts = next(iter(charms[0].items()))
     charm_entity = builder_local.BuildEntity(charm_environment, charm_name, charm_opts)
     artifact = MagicMock()
+    artifact.charm_or_bundle = K8S_CI_CHARM
     artifact.resources = []
     charm_entity.assemble_resources(artifact)
 

--- a/tests/unit/sync_upstream/test_sync.py
+++ b/tests/unit/sync_upstream/test_sync.py
@@ -32,6 +32,7 @@ def test_sync_default_branch(mock_default_gh, mock_base, sync):
 @mock.patch("cilib.git.default_gh_branch", mock.MagicMock(return_value=None))
 def test_sync_no_default_branch(mock_base, sync):
     """Tests the repo default branch helper which runs when syncing forks."""
+    mock_base.git_user, mock_base.password = "git-user", "git-password"
     result = sync.CharmRepoModel.default_gh_branch(mock_base, remote="test/repo")
     assert result == "master"
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ temp_dir={toxworkdir}/.tmp
 
 [base]
 deps =
-     cffi
-     flake8
      pip-tools
      cython<3.0.0
 


### PR DESCRIPTION
In order to build charms targeting a certain architecture, the intent is to leverage a build farm of launchpad builders using  the `launchpadlib` library within the charm builder job

By changing only the `charm-support-matrix.inc` to include the `builder: 'launchpad'` option within a specific charm, the charm will be built on launchpad rather than on the jenkins runner.  

It is necessary only for the charm to be built using `charmcraft.yaml` (no reactive charms are supported there) and each `builds-on` entry in that `charmcraft yaml` will recieve a separate builder.

Incidentally, this allows for a single charm build invocation to also yield multiple charm build outputs -- one for each `builds-on` entry.  Much of the rearchitecture in this PR is around handling a single charm build invocation creating multiple charm files (eg. one charm file per architecture)

In that event -- these changes support each architecture being uploaded, associated with its resources, and released to the same charmhub channel -- for the various architectures|bases it supports.

These changes also facilitate having a different architecture's OCI image attached to a charm so that juju can download the appropriate binary arch and binary oci-image for that charm deployment. 

- [ ] update build-charms / promote charms job jjb completed
