### PR TITLE
Add timeouts to cleanup of the addon juju model

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -250,6 +250,13 @@ function ci::cleanup::before
     echo "> skipping before tasks"
 }
 
+function ci::cleanup::model::addons
+{
+    if ! timeout 10m juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons"; then
+      timeout 10m juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons" --force
+    fi
+}
+
 function ci::cleanup::after
 {
     echo "> skipping after tasks"

--- a/jobs/validate/autoscaler-spec
+++ b/jobs/validate/autoscaler-spec
@@ -121,7 +121,7 @@ function test::execute
 
 function ci::cleanup::before
 {
-    juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons" || true
+    ci::cleanup::model::addons
 }
 
 

--- a/jobs/validate/ovn-multus-spec
+++ b/jobs/validate/ovn-multus-spec
@@ -109,7 +109,7 @@ function test::execute
 
 function ci::cleanup::before
 {
-    juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons" || true
+    ci::cleanup::model::addons
 }
 
 

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -112,7 +112,7 @@ function test::execute
 
 function ci::cleanup::before
 {
-    juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons" || true
+    ci::cleanup::model::addons
 }
 
 ###############################################################################


### PR DESCRIPTION
Some CI jobs (sriov in particular) is not cleaning up the `addon` juju model in a timely manner.  It's likely the k8s cloud models cannot successfully cleanup because the underlying charmed-kubernetes machine models have been reaped already.  But because the ci runs do not finish -- there is no way to collect the results from the juju-crashdumps.

This proposal simply runs a force clean up if the addons model doesn't complete within 10 minutes.  It also unifies this logic into one place `ci:cleanup:model:addons` rather than copy the same solution to multiple job specifications