### PR TITLE
Ensure charmcraft logs directory exists

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -199,6 +199,15 @@
         state: directory
       tags:
         - jenkins
+    - name: Ensure charmcraft log directory exists
+      file:
+        path: /var/lib/jenkins/.local/state/charmcraft/log
+        state: directory
+        owner: jenkins
+        group: jenkins
+        mode: 0755
+      tags:
+        - jenkins
     - name: ssh config
       template:
         src: "fixtures/ssh_config"


### PR DESCRIPTION
* infra job needs to create charmcraft logs directory `/var/lib/jenkins/.local/state/charmcraft/log`
  * this directory is used by charm-builds job to copy charmcraft logs out from failed charm builds