### PR TITLE
Charm build job should upload resources for `kubernetes-dashboard`

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -18,6 +18,9 @@
   flannel-s390x: '{out_path}/flannel-s390x.tar.gz'
 'kubernetes-autoscaler':
   juju-autoscaler-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
+'kubernetes-dashboard':
+  dashboard-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
+  scraper-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
 'kubernetes-master':
   cni-amd64: '{out_path}/cni-amd64.tgz'
   cni-arm64: '{out_path}/cni-arm64.tgz'


### PR DESCRIPTION
In order to provide multiarch support for the kubernetes-dashboard, have the build infra pull and release the arch specific oci images and release them to charmhub

Will require a forced rebuild of the `kubernetes-dashboard` charm in the CI