### PR TITLE
switch charm support matrix to build charmcraft charms with launchpad

### DIFF
--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -97,6 +97,7 @@ class LPBuildEntity(BuildEntity):
                 name=self._lp_recipe_name,
                 auto_build=False,
                 auto_build_channels=self.SNAP_CHANNEL,
+                build_path=self.opts.get("subdir", ""),
                 git_ref=ref,
                 owner=self._lp_owner,
                 project=self._lp_project,

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -114,8 +114,8 @@ class LPBuildEntity(BuildEntity):
 
         with urllib.request.urlopen(build.build_log_url) as f:
             contents = zlib.decompress(f.read(), 16 + zlib.MAX_WBITS)
-        self._lp_build_log_cache[build.self_link] = contents
-        return contents
+        self._lp_build_log_cache[build.self_link] = c_str = contents.decode()
+        return c_str
 
     def _lp_request_builds(self) -> List[Resource]:
         """Request a charm build for this charm."""

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -159,7 +159,7 @@ class LPBuildEntity(BuildEntity):
                 raise BuildException(err_msg)
         return builds
 
-    def _lp_charm_filename_from_build(self, build):
+    def _lp_charm_filename_from_build(self, build) -> str:
         """Determine the charm file name of a particular build.
 
         Currently, this is accomplished by reading the buildlog
@@ -169,7 +169,7 @@ class LPBuildEntity(BuildEntity):
         """
 
         def find_packed_charm(lines):
-            found, keyword = False, b"Charms packed:"
+            found, keyword = False, "Charms packed:"
             for line in lines:
                 if line.startswith(keyword):
                     found |= True

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -128,6 +128,7 @@ class LPBuildEntity(BuildEntity):
                 err_msg = f"Failed requesting lauchpad build {self.entity}, aborting"
                 raise BuildException(err_msg)
             if status == "Completed":
+                self.echo(f"Build recipe started @ {self._lp_recipe.self_link}")
                 break
             time.sleep(1.0)
             req.lp_refresh()

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -38,11 +38,10 @@ class LPBuildEntity(BuildEntity):
         "Successfully built",
     }
 
-    @staticmethod
-    def _lp_recipe_from_branch(branch: str):
+    def _lp_recipe_from_branch(self, branch: str):
         """Recipe names must be lowercase alphanumerics with allowed +, -, and ."""
         subbed = re.sub(r"[^0-9a-zA-Z\+\-\.]+", "-", branch)
-        return subbed.lower()
+        return f"{self.name}-{subbed.lower()}"
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -128,7 +128,7 @@ class LPBuildEntity(BuildEntity):
                 err_msg = f"Failed requesting lauchpad build {self.entity}, aborting"
                 raise BuildException(err_msg)
             if status == "Completed":
-                self.echo(f"Build recipe started @ {self._lp_recipe.self_link}")
+                self.echo(f"Build recipe started @ {self._lp_recipe.web_link}")
                 break
             time.sleep(1.0)
             req.lp_refresh()

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -219,7 +219,6 @@ class LPBuildEntity(BuildEntity):
         builds = self._lp_complete_builds(request)
         download_path = Path(self.src_path)
         self.artifacts = [
-            self._lp_build_download(build, download_path)
-            for build in builds
+            self._lp_build_download(build, download_path) for build in builds
         ]
         self._lp_amend_git_version()

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -174,7 +174,7 @@ class LPBuildEntity(BuildEntity):
                 if line.startswith(keyword):
                     found |= True
                 elif found:
-                    yield line.decode().strip()
+                    yield line.strip()
                     found = False
 
         fp = find_packed_charm(self._lp_build_log(build).splitlines())

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -810,7 +810,10 @@ class BuildEntity:
             except sh.ErrorReturnCode as e:
                 self.echo(e.stderr)
         elif lxc:
-            self.echo(f"Building in container {lxc}")
+            msg = f"Consider moving {self.name} to launchpad builder"
+            border = "-".join("=" * (len(msg) // 2 + 1))
+            self.echo("\n".join((border, msg, border)))
+            self.echo(f"Building in container {lxc}.")
             repository = f"https://github.com/{self.downstream}"
             charmcraft_script = (
                 "#!/bin/bash -eux\n"

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -571,7 +571,7 @@ class Arch(Enum):
 @unique
 class Series(Enum):
     ALL = "all"
-    UNKNONWN = "unknown"
+    UNKNOWN = "unknown"
     XENIAL = "16.04"
     BIONIC = "18.04"
     FOCAL = "20.04"

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -582,7 +582,7 @@ class Series(Enum):
         for series in cls:
             if series.value == value:
                 return series
-        return Series.UNKNONWN
+        return Series.UNKNOWN
 
 
 @unique

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -623,7 +623,7 @@ class Artifact:
             yield Arch.from_value(arch), Series.from_value(base)
 
     @classmethod
-    def from_charm(cls, charm_file: Path) -> List["Artifact"]:
+    def from_charm(cls, charm_file: Path) -> ["Artifact"]:
         """
         Parsed according to charmcraft file output.
         https://discourse.charmhub.io/t/charmcraft-bases-provider-support/4713
@@ -632,17 +632,17 @@ class Artifact:
         base_arches = list(
             pair for each in run_on_bases for pair in Artifact._from_run_on_base(each)
         )
+        arch, series = base_arches[0]
         if len(base_arches) == 1:
-            # single series, single arch     --> Series._specific_, Arch._specific_    (list of 1)
-            return [cls(charm_file, arch, series) for arch, series in base_arches]
+            # single series, single arch     --> Series._specific_, Arch._specific_
+            return cls(charm_file, arch, series)
         if len(set(arch for arch, _ in base_arches)) == 1:
-            # multiple series, single arch   --> Series.ALL       , Arch._specific_    (list of 1)
-            arch, _ = base_arches[0]
-            return [cls(charm_file, arch, Series.ALL)]
+            # multiple series, single arch   --> Series.ALL       , Arch._specific_
+            return cls(charm_file, arch, Series.ALL)
         if len(set(series for _, series in base_arches)) == 1:
-            # single series, multiple arch   --> Series._specific_, Artifact per arch  (list of N arches)
-            return [cls(charm_file, arch, series) for arch, series in base_arches]
-        return [cls(charm_file, Arch.ALL, Series.ALL)]
+            # single series, multiple arch   --> Series._specific_, Arch.ALL
+            return cls(charm_file, Arch.ALL, series)
+        return cls(charm_file, Arch.ALL, Series.ALL)
 
     @property
     def arch_docker(self) -> str:

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -145,6 +145,7 @@ class _WrappedCmd:
         self._command = getattr(sh, command).bake(
             _tee=True,
             _out=partial(entity.echo, nl=False),
+            _truncate_exc=False,
         )
         setattr(self, command, self._command)
 

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -352,7 +352,6 @@
     channel-range:
       min: '1.25'
 - github-runner:
-    builder: 'launchpad'
     downstream: charmed-kubernetes/github-runner-operator
     tags:
       - github-runner

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -1,5 +1,6 @@
 # -*- mode:yaml; -*-
 - calico:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-calico'
     build-resources: 'cd {out_path}; bash {src_path}/build-calico-resource.sh'
     docs: 'https://charmhub.io/calico/docs'
@@ -26,6 +27,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/layer-canal.git'
 - ceph-csi:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-ceph-csi'
     docs: 'https://charmhub.io/ceph-csi/README.md'
     downstream: charmed-kubernetes/ceph-csi-operator.git
@@ -55,6 +57,7 @@
     channel-range:
       min: '1.28'
 - cilium:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-cilium'
     build-resources: 'cd {out_path}; bash {src_path}/fetch-resources.sh'
     docs: 'https://charmhub.io/cilium/docs'
@@ -128,6 +131,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kata.git'
 - kube-ovn:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kube-ovn'
     docs: 'https://charmhub.io/kube-ovn/docs'
     downstream: charmed-kubernetes/charm-kube-ovn.git
@@ -152,6 +156,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer.git'
 - kube-state-metrics:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/kube-state-metrics-operator'
     docs: 'https://charmhub.io/kube-state-metrics/docs'
     downstream: charmed-kubernetes/kube-state-metrics-operator.git
@@ -163,6 +168,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/kube-state-metrics-operator.git'
 - kubernetes-autoscaler:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-autoscaler'
     docs: 'https://charmhub.io/kubernetes-autoscaler/docs'
     downstream: charmed-kubernetes/charm-kubernetes-autoscaler.git
@@ -197,6 +203,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git'
 - kubernetes-metrics-server:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charmed-kubernetes'
     docs: 'https://charmhub.io/kubernetes-metrics-server/docs'
     downstream: charmed-kubernetes/kubernetes-metrics-server-operator.git
@@ -221,6 +228,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-worker.git'
 - kubevirt:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kubevirt'
     docs: 'https://charmhub.io/kubevirt/docs'
     downstream: charmed-kubernetes/charm-kube-virt.git
@@ -234,6 +242,7 @@
     channel-range:
       min: '1.27'
 - openstack-cloud-controller:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-openstack-cloud-controller-operator'
     docs: 'https://charmhub.io/openstack-cloud-controller/docs'
     downstream: charmed-kubernetes/openstack-cloud-controller-operator.git
@@ -304,6 +313,7 @@
       - integrator
     upstream: 'https://github.com/juju-solutions/charm-azure-integrator.git'
 - azure-cloud-provider:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-azure-cloud-provider'
     docs: 'https://charmhub.io/azure-cloud-provider/docs'
     downstream: charmed-kubernetes/charm-azure-cloud-provider
@@ -328,6 +338,7 @@
       - integrator
     upstream: 'https://github.com/juju-solutions/charm-gcp-integrator.git'
 - gcp-k8s-storage:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-gcp-k8s-storage'
     docs: 'https://charmhub.io/gcp-k8s-storage/docs'
     downstream: charmed-kubernetes/gcp-k8s-storage
@@ -341,6 +352,7 @@
     channel-range:
       min: '1.25'
 - github-runner:
+    builder: 'launchpad'
     downstream: charmed-kubernetes/github-runner-operator
     tags:
       - github-runner
@@ -357,6 +369,7 @@
       - integrator
     upstream: 'https://github.com/juju-solutions/charm-aws-integrator.git'
 - aws-k8s-storage:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-aws-k8s-storage'
     docs: 'https://charmhub.io/aws-k8s-storage/docs'
     downstream: charmed-kubernetes/aws-k8s-storage
@@ -370,6 +383,7 @@
     channel-range:
       min: '1.25'
 - aws-cloud-provider:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-aws-cloud-provider'
     docs: 'https://charmhub.io/aws-cloud-provider/docs'
     downstream: charmed-kubernetes/charm-aws-cloud-provider
@@ -405,6 +419,7 @@
       - integrator
     upstream: 'https://github.com/juju-solutions/charm-vsphere-integrator.git'
 - vsphere-cloud-provider:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-vsphere-cloud-provider'
     docs: 'https://charmhub.io/vsphere-cloud-provider/docs'
     downstream: charmed-kubernetes/vsphere-cloud-provider
@@ -418,6 +433,7 @@
     channel-range:
       min: '1.25'
 - metallb:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb/docs'
     downstream: charmed-kubernetes/metallb-operator
@@ -457,6 +473,7 @@
     channel-range:
       max: '1.27'
 - multus:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-multus'
     docs: 'https://charmhub.io/multus/docs'
     downstream: charmed-kubernetes/charm-multus
@@ -468,6 +485,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-multus.git'
 - sriov-cni:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-sriov-cni'
     docs: 'https://charmhub.io/sriov-cni/docs'
     downstream: charmed-kubernetes/charm-sriov-cni
@@ -480,6 +498,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-sriov-cni.git'
 - sriov-network-device-plugin:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-sriov-network-device-plugin'
     docs: 'https://charmhub.io/sriov-network-device-plugin/docs'
     downstream: charmed-kubernetes/charm-sriov-network-device-plugin
@@ -505,6 +524,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-coredns.git'
 - gatekeeper-controller-manager:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
     docs: 'https://charmhub.io/gatekeeper-controller-manager/docs'
     downstream: charmed-kubernetes/opa-gatekeeper-operators
@@ -517,6 +537,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - gatekeeper-audit:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
     docs: 'https://charmhub.io/gatekeeper-audit/docs'
     downstream: charmed-kubernetes/opa-gatekeeper-operators
@@ -529,6 +550,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - bird:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-bird'
     docs: 'https://charmhub.io/bird/docs'
     downstream: charmed-kubernetes/bird-operator
@@ -554,6 +576,7 @@
     channel-range:
       min: '1.28'
 - volcano-admission:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
     downstream: charmed-kubernetes/charm-volcano
@@ -569,6 +592,7 @@
     channel-range:
       min: '1.27'
 - volcano-controllers:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
     downstream: charmed-kubernetes/charm-volcano
@@ -584,6 +608,7 @@
     channel-range:
       min: '1.27'
 - volcano-scheduler:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
     downstream: charmed-kubernetes/charm-volcano

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -204,7 +204,7 @@
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git'
 - kubernetes-metrics-server:
     builder: 'launchpad'
-    bugs: 'https://bugs.launchpad.net/charmed-kubernetes'
+    bugs: 'https://bugs.launchpad.net/charm-kubernetes-metrics-server'
     docs: 'https://charmhub.io/kubernetes-metrics-server/docs'
     downstream: charmed-kubernetes/kubernetes-metrics-server-operator.git
     store: 'https://charmhub.io/kubernetes-metrics-server'
@@ -243,7 +243,7 @@
       min: '1.27'
 - openstack-cloud-controller:
     builder: 'launchpad'
-    bugs: 'https://bugs.launchpad.net/charm-openstack-cloud-controller-operator'
+    bugs: 'https://bugs.launchpad.net/charm-openstack-cloud-controller'
     docs: 'https://charmhub.io/openstack-cloud-controller/docs'
     downstream: charmed-kubernetes/openstack-cloud-controller-operator.git
     store: 'https://charmhub.io/openstack-cloud-controller'

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -22,6 +22,25 @@ CLI_RESPONSES = STATIC_TEST_PATH / "cli_response"
 CHARMCRAFT_LIB_SH = TEST_PATH.parent / "jobs" / "build-charms" / "charmcraft-lib.sh"
 
 
+architecure_test_data = [
+    # a single base and single arch -- a single artifact for this arch
+    ("charm_ubuntu-20.04-arm64.charm", [("20.04", "arm64")]),
+    # a single base and N arches -- an artifact per N arches
+    ("charm_ubuntu-20.04-arm64-amd64.charm", [("20.04", "arm64"), ("20.04", "amd64")]),
+    # N bases and one arch -- a single artifact for this arch
+    ("charm_ubuntu-20.04-arm64_ubuntu-22.04-arm64.charm", [("all", "arm64")]),
+    # N bases and M arches -- a single artifact for all series and archs
+    ("charm_ubuntu-20.04-arm64-amd64_ubuntu-22.04-arm64-amd64.charm", [("all", "all")]),
+]
+
+
+@pytest.mark.parametrize("filename, expected", architecure_test_data)
+def test_artifacts_from_charm_file(builder_local, filename, expected):
+    artifacts = builder_local.Artifact.from_charm(Path(filename))
+    as_strs = [(_.series.value, _.arch.value) for _ in artifacts]
+    assert as_strs == expected
+
+
 @pytest.mark.parametrize(
     "risk, expected",
     [

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -23,22 +23,22 @@ CHARMCRAFT_LIB_SH = TEST_PATH.parent / "jobs" / "build-charms" / "charmcraft-lib
 
 
 architecure_test_data = [
-    # a single base and single arch -- a single artifact for this arch
-    ("charm_ubuntu-20.04-arm64.charm", [("20.04", "arm64")]),
-    # a single base and N arches -- an artifact per N arches
-    ("charm_ubuntu-20.04-arm64-amd64.charm", [("20.04", "arm64"), ("20.04", "amd64")]),
+    # a single base and single arch -- a single specific artifact
+    ("charm_ubuntu-20.04-arm64.charm", "20.04", "arm64"),
+    # a single base and N arches -- a single artifact for this series
+    ("charm_ubuntu-20.04-arm64-amd64.charm", "20.04", "all"),
     # N bases and one arch -- a single artifact for this arch
-    ("charm_ubuntu-20.04-arm64_ubuntu-22.04-arm64.charm", [("all", "arm64")]),
+    ("charm_ubuntu-20.04-arm64_ubuntu-22.04-arm64.charm", "all", "arm64"),
     # N bases and M arches -- a single artifact for all series and archs
-    ("charm_ubuntu-20.04-arm64-amd64_ubuntu-22.04-arm64-amd64.charm", [("all", "all")]),
+    ("charm_ubuntu-20.04-arm64-amd64_ubuntu-22.04-arm64-amd64.charm", "all", "all"),
 ]
 
 
-@pytest.mark.parametrize("filename, expected", architecure_test_data)
-def test_artifacts_from_charm_file(builder_local, filename, expected):
-    artifacts = builder_local.Artifact.from_charm(Path(filename))
-    as_strs = [(_.series.value, _.arch.value) for _ in artifacts]
-    assert as_strs == expected
+@pytest.mark.parametrize("filename, series, arch", architecure_test_data)
+def test_artifacts_from_charm_file(builder_local, filename, series, arch):
+    artifact = builder_local.Artifact.from_charm(Path(filename))
+    series_str, arch_str = map(str, (artifact.series, artifact.arch))
+    assert series_str, arch_str == (series, arch)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updating the remaining `ops` based charms to build on launchpad

* aws-cloud-provider
* aws-k8s-storage
* azure-cloud-provider
* bird-operator
* ceph-csi-operator
* charm-cilium
* charm-kube-ovn
* charm-kube-virt
* charm-multus
* charm-sriov-cni
* charm-sriov-network-device-plugin
* gcp-k8s-storage
* kubernetes-autoscaler
* kubernetes-dashboard-operator
* kubernetes-metrics-server-operator
* kube-state-metrics-operator
* layer-calico
* metallb-operator
* opa-audit-operator
* opa-manager-operator
* openstack-cloud-controller-operator
* volcano-admission 
* volcano-controllers
* volcano-scheduler
* vsphere-cloud-provider

