### PR TITLE
Add lightkube to the list of forks kept in sync by cdkbot

### DIFF
--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -540,7 +540,8 @@ class BuildEnv:
         layers_to_pull = [
             layer_name
             for layer in self.layers
-            if (layer_name := next(iter(layer))) != "layer:index"
+            for layer_name, layer_ops in layer.items()
+            if layer_ops.get("build_cache") != False
         ]
         pool = ThreadPool()
         results = pool.map(self.download, layers_to_pull)

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -541,7 +541,7 @@ class BuildEnv:
             layer_name
             for layer in self.layers
             for layer_name, layer_ops in layer.items()
-            if layer_ops.get("build_cache") != False
+            if layer_ops.get("build_cache") is not False
         ]
         pool = ThreadPool()
         results = pool.map(self.download, layers_to_pull)

--- a/jobs/includes/charm-layer-list.inc
+++ b/jobs/includes/charm-layer-list.inc
@@ -391,3 +391,11 @@
     needs_stable: no
     needs_tagging: no
     supports_rename: no
+    build_cache: no
+- lightkube:
+    downstream: "canonical/lightkube.git"
+    upstream: "https://github.com/gtsystem/lightkube"
+    needs_stable: no
+    needs_tagging: no
+    supports_rename: no
+    build_cache: no


### PR DESCRIPTION
The sync job synchronizes a number of "Layers and Charms" from their upstream source, to their downstream source.  By adding lightkube to the list of "layer" -- then this repo will be kept in sync with its upstream source. 

It doesn't need stable branches, tagging, or to support renaming -- and it isn't necessary to pull locally for the reactive build cache.  