### PR TITLE
Improve exception tracing when setting up a k8s-cloud

### DIFF
--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -112,15 +112,11 @@ async def upgrade_charms(model, channel, tools):
     model_name = model.info.name
     for app_name, app in model.applications.items():
         log.info(f"Upgrading {app_name} from {app.charm_url} to --channel={channel}")
+        juju_2 = model.connection().info["server-version"].startswith("2.")
+        command = "upgrade-charm" if juju_2 else "refresh"
         await tools.run(
-            "juju", "upgrade-charm", "-m", model_name, app.name, "--channel", channel
+            "juju", command, "-m", model_name, app.name, "--channel", channel
         )
-        # Blocked on https://github.com/juju/python-libjuju/issues/728
-        # try:
-        #    await app.refresh(channel=channel)
-        # except JujuError as e:
-        #     if "already running charm" not in str(e):
-        #         raise
     await tools.juju_wait()
 
 


### PR DESCRIPTION
We continue to see errors in the validation tests where `k8s_cloud` fixture is involved, but the only error coming back has to do with a failed async.  This is because the fixture is trying too hard to catch exceptions -- when it should really bubble those out

There's also a bit of flakiness in many tests to get the `kubeconfig` from the control-plane unit.  lets setup one fixture that can do that for every test.  If we don't like it being module scoped -- that's fine we can remove that. 