### PR TITLE
Move `TMPDIR` on each job out of the jenkins git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ __pycache__/
 logs/
 pytest.log
 site/
-*.json
-*.log
+/*.json
+/*.log
 jobs/reports/_build
 reports/_build
 *.db

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -323,7 +323,7 @@
 
           export PATH=/snap/bin:$HOME/bin/:$PATH
           export NODE_LABELS="$NODE_LABELS"
-          export TMPDIR="$WORKSPACE/tmp"
+          export TMPDIR="/tmp/$BUILD_TAG"
           export PATH=venv/bin:$PATH
           export PYTHONPATH=$WORKSPACE:"${{PYTHONPATH:-}}"
 


### PR DESCRIPTION
Reactive Charm Builds:

when the `charm` snap runs, it will `pip download` source tgz and build source wheels to install into the charms
charm dependencies such as `hvac` use `poetry-core` rather than `setup.py` to specify collected dependencies.
thus, `poetry-core` is downloaded and installed into a temporary environment (also from source tgz) and installed as a source wheel.  

This change prevents the `TMPDIR` environment variable from being set within the jenkins repo directory during a jenkins run of charm build so that the installed `poetry-core` completely sidesteps reading `.gitignore` from the jenkins repo.  

Secondarily -- it further constrains this project's `.gitignore` to ignore and `json` files in the top-level directory which may be build artifacts

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge
