### PR TITLE
stop remapping `TMPDIR` inside lxc containers

### DIFF
--- a/lxc_runner.sh
+++ b/lxc_runner.sh
@@ -31,7 +31,6 @@ ci_lxc_init_runner()
     echo "declare -x HUDSON_HOME=${LXC_HOME}" >> ${WORKSPACE}/.env
     echo "declare -x JENKINS_HOME=${LXC_HOME}" >> ${WORKSPACE}/.env
     echo "declare -x PWD=${LXC_WORKSPACE}" >> ${WORKSPACE}/.env
-    echo "declare -x TMPDIR=${LXC_WORKSPACE}/tmp" >> ${WORKSPACE}/.env
     echo "declare -x WORKSPACE=${LXC_WORKSPACE}" >> ${WORKSPACE}/.env
     echo "declare -x WORKSPACE_TMP=${LXC_WORKSPACE}@tmp" >> ${WORKSPACE}/.env
     echo "declare -x PYTHONPATH=${LXC_WORKSPACE}:\"${PYTHONPATH:-}\"" >> ${WORKSPACE}/.env


### PR DESCRIPTION
There's really no need to remap `TMPDIR` inside the worker containers because they are ephemeral anyway.  Let them put tmp wherever they please.