### PR TITLE
Ensure that lp builders are insync with upstream sources

### DIFF
--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -214,7 +214,7 @@ class LPBuildEntity(BuildEntity):
 
     def _lp_request_sync(self):
         """Ensure that the upstream github repo is in sync with the launchpad repo."""
-        self.echo(f"Creating recipe for branch :{self._lp_branch}")
+        self.echo(f"Syncing lp branch from upstream :{self._lp_branch}")
         git_sha = self.commit()
         repo = self._lp.git_repositories.getDefaultRepository(target=self._lp_project)
 


### PR DESCRIPTION
Ensure the commit hash from the launchpad git sources are insync with the upstream sources before building the charm on a launchpad builder. 