### PR TITLE
clean up the deployment before destroying the namespace

### DIFF
--- a/jobs/integration/templates/nginx_deployment.yaml
+++ b/jobs/integration/templates/nginx_deployment.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: rocks.canonical.com/cdk/nginx:1.18
         ports:
         - containerPort: 80

--- a/jobs/integration/test_autoscaler.py
+++ b/jobs/integration/test_autoscaler.py
@@ -29,6 +29,7 @@ async def deployment(kubectl, namespace):
     kubectl.create.namespace(namespace)
     kubectl.create(f=path_to_deployment, namespace=namespace)
     yield path_to_deployment
+    kubectl.delete(f=path_to_deployment, namespace=namespace, grace_period=5*60)
     kubectl.delete.namespace(namespace)
 
 

--- a/jobs/integration/test_autoscaler.py
+++ b/jobs/integration/test_autoscaler.py
@@ -29,7 +29,7 @@ async def deployment(kubectl, namespace):
     kubectl.create.namespace(namespace)
     kubectl.create(f=path_to_deployment, namespace=namespace)
     yield path_to_deployment
-    kubectl.delete(f=path_to_deployment, namespace=namespace, grace_period=5*60)
+    kubectl.delete(f=path_to_deployment, namespace=namespace, grace_period=5 * 60)
     kubectl.delete.namespace(namespace)
 
 


### PR DESCRIPTION
Addressing test timeouts during the teardown of the autoscaler tests.  

[LP#2033414](https://bugs.launchpad.net/charm-kubernetes-autoscaler/+bug/2033414)