### PR TITLE
provide support for arch specific file resources

### DIFF
--- a/cilib/version.py
+++ b/cilib/version.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Mapping, Union
 import semver
 from cilib import log
 
@@ -98,8 +98,15 @@ class ChannelRange:
         assert "1.24/edge" in ChannelRange(None, None)              # No bounds
     """
 
-    _min: Optional[str]
-    _max: Optional[str]
+    _min: Optional[str] = None
+    _max: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Optional[str]]) -> "ChannelRange":
+        range_def = d.get("channel-range", {})
+        definitions = range_def.get("min"), range_def.get("max")
+        assert all(isinstance(_, (str, type(None))) for _ in definitions)
+        return cls(*definitions)
 
     @property
     def min(self) -> Optional[Release]:

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -214,7 +214,7 @@ class LPBuildEntity(BuildEntity):
 
     def _lp_request_sync(self):
         """Ensure that the upstream github repo is in sync with the launchpad repo."""
-        self.echo(f"Syncing lp branch from upstream :{self._lp_branch}")
+        self.echo(f"Syncing lp branch from upstream: {self._lp_branch}")
         git_sha = self.commit()
         repo = self._lp.git_repositories.getDefaultRepository(target=self._lp_project)
 

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -1040,7 +1040,7 @@ class BuildEntity:
         context = dict(
             src_path=self.src_path,
             out_path=self._resource_path,
-            arch=artifact.arch,
+            arch=artifact.arch.value,
         )
         ch_channels = apply_channel_bounds(self.opts, to_channels)
 

--- a/jobs/build-charms/main.py
+++ b/jobs/build-charms/main.py
@@ -4,6 +4,7 @@ from sh.contrib import git
 
 from builder_local import BundleBuildEntity, BuildEnv, BuildEntity, BuildType
 from builder_launchpad import LPBuildEntity
+from cilib.version import RISKS
 
 
 @click.group()
@@ -91,6 +92,10 @@ def build(
                 build_env.echo(f"Queued {charm_entity.entity} for building")
 
     failed_entities = []
+    to_channels = [
+        f"{build_env.track}/{chan.lower()}" if (chan.lower() in RISKS) else chan
+        for chan in build_env.to_channels
+    ]
 
     for entity in entities:
         entity.echo("Starting")
@@ -108,8 +113,8 @@ def build(
             entity.resource_build()
             for each in entity.artifacts:
                 entity.push(each)
-                entity.assemble_resources(each)
-                entity.release(each, to_channels=build_env.to_channels)
+                entity.assemble_resources(each, to_channels=to_channels)
+                entity.release(each, to_channels=to_channels)
         except Exception:
             entity.echo(traceback.format_exc())
             failed_entities.append(entity)

--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -16,6 +16,11 @@
   flannel-amd64: '{out_path}/flannel-amd64.tar.gz'
   flannel-arm64: '{out_path}/flannel-arm64.tar.gz'
   flannel-s390x: '{out_path}/flannel-s390x.tar.gz'
+'kubeapi-load-balancer':
+  nginx-prometheus-exporter: 
+    format: '{out_path}/nginx-prometheus-exporter_linux_{arch}.tar.gz'
+    channel-range:
+      min: '1.29'
 'kubernetes-autoscaler':
   juju-autoscaler-image: 'localhost/placeholder'  # value replaced by metadata.yaml upstream-source
 'kubernetes-dashboard':

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -145,9 +145,11 @@
     channel-range:
       min: '1.25'
 - kubeapi-load-balancer:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kubeapi-load-balancer'
     docs: 'https://charmhub.io/kubeapi-load-balancer/docs'
     downstream: charmed-kubernetes/charm-kubeapi-load-balancer.git
+    build-resources: 'cd {out_path}; bash {src_path}/build-resources.sh'
     store: 'https://charmhub.io/kubeapi-load-balancer'
     summary: Nginx Load Balancer
     tags:

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -442,7 +442,7 @@ def test_build_entity_promote(
             "test-image", kind=builder_local.ResourceKind.IMAGE, rev=4
         ),
     ]
-    charm_entity.release(artifact, to_channels=("edge", "0.15/edge"))
+    charm_entity.release(artifact, to_channels=("latest/edge", "0.15/edge"))
     charm_cmd.release.assert_not_called()
     charmcraft_cmd.release.assert_called_once_with(
         "k8s-ci-charm",
@@ -454,7 +454,7 @@ def test_build_entity_promote(
     )
     charmcraft_cmd.release.reset_mock()
 
-    charm_entity.release(artifact, to_channels=("stable", "0.15/stable"))
+    charm_entity.release(artifact, to_channels=("latest/stable", "0.15/stable"))
     charm_cmd.release.assert_not_called()
     charmcraft_cmd.release.assert_called_once_with(
         "k8s-ci-charm",
@@ -653,7 +653,9 @@ def test_build_command(mock_build_env, mock_build_entity, main):
             "ignored": dict(tags=["ignore-me"]),
         }
     ]
+    mock_build_env.track = "latest"
     mock_build_env.filter_by_tag = ["tag1", "tag2"]
+    mock_build_env.to_channels = ["edge", "1.18/edge"]
     artifact = MagicMock()
     entity = mock_build_entity.return_value
     entity.artifacts = [artifact]
@@ -698,9 +700,11 @@ def test_build_command(mock_build_env, mock_build_entity, main):
     entity.setup.assert_called_once_with()
     entity.charm_build.assert_called_once_with()
     entity.push.assert_called_once_with(artifact)
-    entity.assemble_resources.assert_called_once_with(artifact)
+    entity.assemble_resources.assert_called_once_with(
+        artifact, to_channels=["latest/edge", "1.18/edge"]
+    )
     entity.release.assert_called_once_with(
-        artifact, to_channels=mock_build_env.to_channels
+        artifact, to_channels=["latest/edge", "1.18/edge"]
     )
 
 


### PR DESCRIPTION
If a multi-arch charm has a file resource which must be different based on the charm's arch (for instance, it contains a binary image) then the build tool chain needs to be able to release the correct arch based resource along with that arch specific charm artifact.

* This allows charms to assemble an arch specific file resource
* This allows a channel-range to be applied for a specific charm resource 
    * ex) in the 1.28 track this charm grew a need for a foo resource
    * This lets bug fix releases continue to release the charm without that resource