### PR TITLE
Removed tee -a usage from microk8s release pipeline

### DIFF
--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -133,11 +133,11 @@ pipeline {
                                 AWS_ACCESS_KEY_ID=\$(aws configure get aws_access_key_id)
                                 AWS_SECRET_ACCESS_KEY=\$(aws configure get aws_secret_access_key)
 
-                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo echo INSTANCE_TYPE=${eksd_instance_type} | sudo tee -a /etc/environment"
-                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo echo STACK_NAME=${juju_controller} | sudo tee -a /etc/environment"
-                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo echo AWS_REGION=\$AWS_REGION | sudo tee -a /etc/environment"
-                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo echo AWS_ACCESS_KEY_ID=\$AWS_ACCESS_KEY_ID | sudo tee -a /etc/environment"
-                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo echo AWS_SECRET_ACCESS_KEY=\$AWS_SECRET_ACCESS_KEY | sudo tee -a /etc/environment"
+                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo sh -c 'echo INSTANCE_TYPE=${eksd_instance_type} >> /etc/environment'"
+                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo sh -c 'echo STACK_NAME=${juju_controller} >> /etc/environment'"
+                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo sh -c 'echo AWS_REGION=\$AWS_REGION >> /etc/environment'"
+                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo sh -c 'echo AWS_ACCESS_KEY_ID=\$AWS_ACCESS_KEY_ID >> /etc/environment'"
+                                juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- "sudo sh -c 'echo AWS_SECRET_ACCESS_KEY=\$AWS_SECRET_ACCESS_KEY >> /etc/environment'"
                                 set -x
 
                                 juju ssh -m "${juju_full_model}" --pty=true ubuntu/0 -- 'sudo snap install lxd'


### PR DESCRIPTION
Replaced `sudo tee -a` usage with pipes to append environment variables to `/etc/environment`.