### PR TITLE
Allow any tox env name to run positional argument commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,py38,p39,p310
+envlist = py,test
 skipsdist = True
 temp_dir={toxworkdir}/.tmp
 
@@ -17,6 +17,7 @@ setenv =
     PATH = {env:HOME}/.local/bin:{env:PATH}
 passenv = *
 install_command = python -I -m pip install --no-build-isolation {opts} {packages}
+commands = {posargs}
 
 [testenv:{format,test,docs,ansible}]
 commands =
@@ -24,9 +25,6 @@ commands =
      test: inv test
      docs: inv upload-docs
      ansible: ansible-playbook jobs/infra/playbook-jenkins.yml --limit localhost --tags 'jenkins' -i jobs/infra/hosts
-
-[testenv:{py, py38, py39, py310}]
-commands = {posargs}
 
 [testenv:juju29]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,test
+envlist = test
 skipsdist = True
 temp_dir={toxworkdir}/.tmp
 


### PR DESCRIPTION
It was discovered via solqa that previously the tox.ini allowed any created environment to run positional argument commands. 

example:
```shell
$ tox -e made-up -- python -c 'print("hello from made-up")'
made-up: install_deps> python -I -m pip install --no-build-isolation 'cython<3.0.0' pip-tools -r /home/addyess/git/charmed-kubernetes/jenkins/requirements.txt
hello from made-up
  made-up: OK (36.05=setup[36.02]+cmd[0.03] seconds)
  congratulations :) (36.08 seconds)
```

However, a previous change to `tox.ini` broken this allowing only well-defined env names to run arbitrary commands. 

This change returns the previous behavior so that arbitrary tox environment names can run arbitrary commands by moving the `commands = {posargs}` into the `[testenv]` section. 

* environment names such a: `format,test,docs,ansible` cannot run arbitrary commands
* the environment `juju29` can now run arbitrary commands -- just with the `requirements-2.9.txt`
* running without defining any environment will now only run `test`
