### PR TITLE
Facilitate writing bird.conf with juju > 3.1

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -587,7 +587,8 @@ def configure_bgp():
     bird_conf: str = BIRD_CONFIG_BASE % list(router_ips)[0]
     for ip in calico_ips:
         bird_conf += BIRD_CONFIG_PEER % ip
-    juju("ssh", "router/0", "cat > /etc/bird/bird.conf", input=bird_conf.encode())
+    juju("ssh", "router/0", "cat > bird.conf", input=bird_conf.encode())
+    juju("ssh", "router/0", "sudo", "cp", "bird.conf", "/etc/bird/bird.conf")
     juju("ssh", "router/0", "sudo", "service", "bird", "restart")
 
 

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -603,7 +603,7 @@ async def test_ipv6(model, tools):
     control_plane = control_plane_app.units[0]
     await kubectl(
         model,
-        "create -f - << EOF{}EOF".format(
+        "apply -f - << EOF{}EOF".format(
             f"""
 apiVersion: apps/v1
 kind: Deployment
@@ -686,7 +686,7 @@ spec:
         # pods might not be up by this point, retry until it works
         with timeout_for_current_task(60):
             while True:
-                cmd = "curl '{}'".format(url)
+                cmd = "curl '{}' --max-time 1".format(url)
                 output = await juju_run(control_plane, cmd, check=False)
                 if (
                     output.status == "completed"


### PR DESCRIPTION
An analysis of failures of the `validate-ck-calico-bgp-router-jammy-1.27-edge` and `validate-ck-calico-bgp-router-jammy-1.28-edge` jobs demonstrated a few issues:

Addressed issues:
* juju 3.1 snap confinement prevents it from reading from `/tmp`.  Rather than generate `bird.conf` and scp'ing from the temp directory, just write it directly over the ssh stdin
* ensure that the series of the router unit is selected via the `SERIES` environment variable
* remove extraneous unused arguments to the `juju` method

Unaddressed failure:
* Usually EC2 instances will start up with interface names `ens5` and `ens6` as expected, but occasionally ens2 and ens3 which causes the setup to fail.