### PR TITLE
Updated color options of the ci report, include bootstrap failed 

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -148,11 +148,14 @@ def _gen_metadata(numdays=None):
         if not job_name:
             continue
 
+        obj.update(**_job_metadata(prefix_id) or {})
         obj["test_result"], _, obj["build_endtime"] = get_file_prefix("result-", files)
         if not obj["build_endtime"]:
             continue
 
-        obj["deploy_result"], _, _ = get_file_prefix("deployresult-", files)
+        for key, value in obj.items():
+            if isinstance(value, str) and any(key.endswith(_) for _ in ["starttime", "endtime"]):
+                obj[key] = datetime.fromisoformat(value)
 
         # Validate jobs are now cloud-specific; drop old jobs from the report
         if "validate-ck-amd64" in job_name:
@@ -168,28 +171,40 @@ def _gen_metadata(numdays=None):
         if job_name not in db:
             db[job_name] = {}
 
-        if obj["deploy_result"] == "False":
-            hover_text = "Deploy Failed"  # juju deploy failed
-            result_bg_color = "#ff0000!important;"
-        elif obj["deploy_result"] == "Timeout":
-            hover_text = "Deploy Timeout"  # juju deployment timedout
-            result_bg_color = "#ff5500!important;"
-        elif obj["deploy_result"] == "True" and obj["test_result"] == "Timeout":
-            hover_text = "Test Timeout"  # juju deploys, tests timeout
-            result_bg_color = "#ffaa00!important;"
-        elif obj["deploy_result"] == "True" and obj["test_result"] == "False":
-            hover_text = "Test Failures"  # juju deploys, tests failed
-            result_bg_color = "#ffff00!important;"
-        elif obj["deploy_result"] == "True" and obj["test_result"] == "True":
-            hover_text = "Test Pass"  # juju deploys, tests pass
-            result_bg_color = "#00ff00!important;"
+        result = obj["test_result"]
+        deploy = obj["deploy_result"]
+        stage = obj.get("deploy_stage") or "Unknown"
+
+        if deploy != "True" and stage == "bootstrap":
+            # juju bootstrap failed
+            hover_text = "Bootstrap Failed"
+            result_style = "test-bootstrap-fail"
+        elif deploy == "False":
+            # juju deploy failed
+            hover_text = f"Deploy Failed ({stage})"
+            result_style = "test-deploy-fail"
+        elif deploy == "Timeout":
+             # juju deployment timeout
+            hover_text = f"Deploy Timeout ({stage})"
+            result_style = "test-deploy-timeout"
+        elif deploy == "True" and result == "Timeout":
+            # juju deploys, tests timeout
+            hover_text = "Test Timeout"
+            result_style = "test-test-timeout"
+        elif deploy == "True" and result == "False":
+            # juju deploys, tests failed
+            hover_text = "Test Failures"
+            result_style = "test-test-failure"
+        elif deploy == "True" and result == "True":
+            # juju deploys, tests pass
+            hover_text = "Test Pass"
+            result_style = "test-test-passing"
             obj["font_awesome_icon"] = "fa-laugh-squint"
         else:
-            result, deploy = obj["test_result"], obj["deploy_result"]
             hover_text = f"Unknown status deploy={deploy} result={result}"
-            result_bg_color = "#00ffff!important;"  # dunno what happened?
+            result_style = "test-unknown-status"
 
-        obj["bg_color"] = result_bg_color
+        obj["result_style"] = result_style
         obj["hover_text"] = hover_text
 
         day = obj["build_endtime"].strftime("%Y-%m-%d")
@@ -260,19 +275,25 @@ def job_result(job_id, metadata_db, columbo_json):
     run.cmd_ok(f"rm -rf {html_p}")
 
 
+def _job_metadata(job_id):
+    url = f"{REPORT_HOST}/{job_id}/metadata.json"
+    log.info(f"{job_id} :: Fetching {url}")
+    metadata = requests.get(url)
+    if metadata.ok:
+        try:
+            return metadata.json()
+        except json.decoder.JSONDecodeError:
+            log.error(f"{job_id} :: Invalid JSON {url}")
+            return None
+    log.error(f"{job_id} :: Missing Metadata {url}")
+    return None
+
+
 @cli.command()
 @click.option("--job-id", help="ID of Job to parse")
 def job_info(job_id):
     """Get metadata info for job"""
-    url = f"{REPORT_HOST}/{job_id}/metadata.json"
-    log.info(f"{job_id} :: Downloading {url}")
-    has_metadata = requests.get(url)
-    if has_metadata.ok:
-        try:
-            obj = has_metadata.json()
-        except json.decoder.JSONDecodeError:
-            return
-
+    obj = _job_metadata(job_id)
     click.echo(pformat(obj))
 
 

--- a/jobs/templates/_base.html
+++ b/jobs/templates/_base.html
@@ -45,8 +45,35 @@
           background-color: #d4dee8!important;
           color: #000000;
       }
-      .download-link {
+      .test-global a {
+          color: #FFFFFF;
+      }
+      .test-bootstrap-fail {
+          background-color: #CC79A7!important;
+      }
+      .test-deploy-fail {
+          background-color: #D55E00!important;
+      }
+      .test-deploy-timeout {
+          background-color: #F0E442!important;
+      }
+      .test-deploy-timeout th {
+          color: #FFFFFF!important;
+      }
+      .test-deploy-timeout a {
           color: #000000;
+      }
+      .test-test-timeout {
+          background-color: #0072B2!important;
+      }
+      .test-test-failure {
+          background-color: #56B4E9!important;
+      }
+      .test-test-passing {
+          background-color: #009E73!important;
+      }
+      .test-unknown-status {
+          background-color: #000000!important;
       }
 
     </style>

--- a/jobs/templates/index.html
+++ b/jobs/templates/index.html
@@ -8,6 +8,26 @@
         <table class="table table-hover table-bordered">
           <thead class="thead-dark">
             <tr>
+              <th class="align-middle">Color Key</th>
+              <th class="test-bootstrap-fail" style="min-width:175px">Bootstrap Fail</th>
+              <th class="test-deploy-fail" style="min-width:175px">   Model Deploy Fail</th>
+              <th class="test-deploy-timeout" style="min-width:175px; color:black">Model Deploy Timedout</th>
+              <th class="test-test-timeout" style="min-width:175px">  PyTest Timedout</th>
+              <th class="test-test-failure" style="min-width:175px">  PyTest Failure</th>
+              <th class="test-test-passing" style="min-width:175px">  PyTest Success</th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+    </div>
+    <div class="col"></div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <div class="table">
+        <table class="table table-hover table-bordered">
+          <thead class="thead-dark">
+            <tr>
               <th class="align-middle">Job Name <small>Last modified: {{ modified.strftime('%Y-%m-%d %H:%M:%S') }}</small></th>
               {% for day in headers %}
               <th class="align-middle text-center" style="min-width: 70px;">{{ day }}</th>
@@ -18,9 +38,9 @@
           <tr>
             <td class="align-middle">{{ row[0] }}</td>
             {% for day in row[1:] %}
-            <td class="text-center align-middle" {%- if day.bg_color %}style="background-color: {{day.bg_color}}"{% endif %}>
+            <td class="text-center align-middle test-global {% if day.result_style %}{{day.result_style}}{% endif %}">
               {% if day.index %}
-              <a class="download-link" href="{{day.index}}" job_id="{{day.job_id}}" onmouseover="load_report_hover(this, '{{day.hover_text}}')">
+              <a href="{{day.index}}" job_id="{{day.job_id}}" onmouseover="load_report_hover(this, '{{day.hover_text}}')">
                 <i class="fas {{day.font_awesome_icon or 'fa-file-alt'}}"></i>
               </a>
               {% elif day.artifacts %}

--- a/jobs/validate/autoscaler-spec
+++ b/jobs/validate/autoscaler-spec
@@ -86,7 +86,7 @@ EOF
 
     juju deploy -m "${JUJU_CONTROLLER}:addons" ./k8s_overlay.yaml --trust
     timeout 45m juju-wait -e "${JUJU_CONTROLLER}:addons" -w
-    juju::deploy-report $?
+    juju::deploy-report $? "model-wait"
 
     # Retaint control-plane nodes
     for node in $(kubectl get nodes | grep control-plane | cut -d' ' -f1); do

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -37,6 +37,8 @@ function juju::bootstrap
       --model-default logging-config="<root>=DEBUG" \
       --model-default vpc-id=$vpc_id
 
+    juju::deploy-report $? "bootstrap"
+
     if [ "$ROUTING_MODE" = "bgp-router" ]; then
       echo "Deploying bgp router"
       python3 $WORKSPACE/jobs/integration/tigera_aws.py deploy-bgp-router
@@ -44,7 +46,7 @@ function juju::bootstrap
       ret=$?
       if (( ret > 0 )); then
           # Fail Deploy Early
-          juju::deploy-report $ret
+          juju::deploy-report $ret "bgp-setup"
       fi
     fi
 }
@@ -105,7 +107,7 @@ function juju::deploy
         python $WORKSPACE/jobs/integration/tigera_aws.py configure-bgp
       fi
     )
-    juju::deploy-report $?
+    juju::deploy-report $? "bgp-setup"
 }
 
 ###############################################################################

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -142,7 +142,7 @@ function juju::wait
     echo "Waiting for deployment to settle..."
     timeout 45m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w -x kubernetes-control-plane
 
-    juju::deploy-report $?
+    juju::deploy-report $? "model-wait"
 }
 
 function test::execute

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -26,7 +26,7 @@ function juju::deploy
         juju relate ubuntu ci-setup
     )
 
-    juju::deploy-report $?
+    juju::deploy-report $? "model-deploy"
 }
 
 function juju::deploy::after

--- a/jobs/validate/ovn-multus-spec
+++ b/jobs/validate/ovn-multus-spec
@@ -65,7 +65,7 @@ function juju::wait
     echo "Waiting for deployment to settle..."
     timeout 60m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w
 
-    juju::deploy-report $?
+    juju::deploy-report $? "model-wait"
 }
 
 

--- a/juju.bash
+++ b/juju.bash
@@ -85,7 +85,7 @@ function juju::bootstrap
          --model-default logging-config="<root>=DEBUG" \
          $extra_args
 
-    juju::deploy-report $?
+    juju::deploy-report $? "bootstrap"
 }
 
 function juju::deploy::before
@@ -124,7 +124,7 @@ function juju::deploy
          --force \
          --channel "$JUJU_DEPLOY_CHANNEL" "$JUJU_DEPLOY_BUNDLE"
 
-    juju::deploy-report $?
+    juju::deploy-report $? "model-deploy"
 }
 
 function juju::wait
@@ -132,7 +132,7 @@ function juju::wait
     echo "Waiting for deployment to settle..."
     timeout 45m juju-wait -e "$JUJU_CONTROLLER:$JUJU_MODEL" -w
 
-    juju::deploy-report $?
+    juju::deploy-report $? "model-wait"
 }
 
 function juju::unitAddress
@@ -153,6 +153,7 @@ function juju::deploy-report
 {
     # report deployment failure
     local ret=$1
+    local stage=${2:unspecified}
 
     local is_pass="True"
     if (( ret == 124 )); then
@@ -162,6 +163,7 @@ function juju::deploy-report
     fi
     kv::set "deploy_result" "${is_pass}"
     kv::set "deploy_endtime" "$(timestamp)"
+    kv::set "deploy_stage" "$(stage)"
     touch "meta/deployresult-${is_pass}"
     python bin/s3 cp "meta/deployresult-${is_pass}" "meta/deployresult-${is_pass}"
 


### PR DESCRIPTION
* the color palette now is a more inclusive for Color Blindness
* Rather than use specific CSS styles for each icon, use a well defined css type
* Provides a color key at the page header
* Hover text now specifies which stage the test failed in
* distinguishes between deploy failed from juju bootstrap failure
*  fixes bug where we relied on the alphabetical order of the words "False", "Timedout" and "True" to indicate whether a test or deployment failed, timedout or passed  (by pulling the metadata.json for each job rather than using the presence of a file named `deploy-result-*`)