### PR TITLE
Prevent o7k CCM from syncing from a repo we're closing

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -270,7 +270,7 @@
       - k8s
       - openstack
       - openstack-cloud-controller
-    upstream: 'https://github.com/canonical/openstack-cloud-controller-operator.git'
+    upstream: 'https://github.com/charmed-kubernetes/openstack-cloud-controller-operator.git'
     channel-range:
       min: '1.28'
 - tigera-secure-ee:


### PR DESCRIPTION
Stop syncing from the canonical org since it will be closed when [160639](https://portal.admin.canonical.com/C160639) is completed