### PR TITLE
[Validation test] Address timeouts after deployment

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -8,6 +8,7 @@ function compile::env
     : "${JUJU_DEPLOY_BUNDLE:?Must have a bundle defined}"
     : "${JUJU_DEPLOY_CHANNEL:?Must have a channel defined}"
     : "${JUJU_MODEL:?Must have a model defined}"
+    : "${JUJU_UPDATE_STATUS_INTERVAL:=150s}"
     : "${SERIES:?Must have a release series defined}"
     : "${SNAP_VERSION:?Must have a snap version defined}"
     : "${JOB_NAME_CUSTOM:?Must have a job name defined}"
@@ -223,6 +224,7 @@ function ci::run
         juju::bootstrap::before
         juju::bootstrap
         juju::bootstrap::after
+        juju::model::speed-up
         juju::deploy::before
         juju::deploy::overlay
         juju::deploy

--- a/juju.bash
+++ b/juju.bash
@@ -24,6 +24,13 @@ function juju::bootstrap::after
     echo "> skipping after tasks"
 }
 
+function juju::model::speed-up
+{
+    # Override the update-status hook rather than the default of 5m
+    echo "> Setting update-status-hook-interval=${JUJU_UPDATE_STATUS_INTERVAL}"
+    juju model-config -m "$JUJU_CONTROLLER:$JUJU_MODEL" update-status-hook-interval="${JUJU_UPDATE_STATUS_INTERVAL}"
+}
+
 function juju::version
 {
     # yields the short sem version of juju


### PR DESCRIPTION
Lately, the installed charmed-kubernetes installments aren't ready in 45 minutes but are SO close.  One more update-status hook on something like calico would have the model active-idle.  I believe that increasing the number of issued update-status hooks would prepare the environments quick enough without overburdening them

It's not worth setting the update-status hook interval to 5s because that would result in too much work the charms constantly trying to churn and determine the charm's status