### PR TITLE
Update node label validation for juju.io/cloud

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2079,7 +2079,7 @@ async def test_cloud_node_labels(cloud, model, tools):
         integrator = set(app for app in integrators if app in model.applications)
         assert (
             not integrator
-        ), f"Expect {expected_label} because {cloud} is integrated with {integrator}"
+        ), f"Expect {expected_label} because the model is integrated with {integrator}"
     else:
         # Otherwise expect the label to match the cloud
         assert f"Node label (juju.io/cloud={label})" == expected_label

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -2065,7 +2065,7 @@ async def test_cloud_node_labels(cloud, model, tools):
     raw_nodes = await run_until_success(unit, cmd)
     nodes = json.loads(raw_nodes)["items"]
     labels = [node["metadata"].get("labels", {}).get("juju.io/cloud") for node in nodes]
-    all_same_labels = all(l == labels[0] for l in labels)
+    all_same_labels = all(item == labels[0] for item in labels)
     assert (
         all_same_labels
     ), f"Unique label juju.io/cloud values found ({','.join(map(str,labels))})"


### PR DESCRIPTION
Partial reversion of test from [#1457](https://github.com/charmed-kubernetes/jenkins/commit/c0fc949215133b89701366623b500467899f0c29#diff-a3e9600e4339acd8390a865b32d04515eba72f1929856af1e778e36d7e550fb6L2074-L2093) where reactive charms (those in stable and edge channels) failed to identify the node labels for `juju.io/cloud`

ops charms populate this field by default
reactive charms populate this field only when the `*-integrator` charms were related

Let's test that if the nodes are labeled `None,` there are no `*-integrator` charms
But if the nodes are labelled, they match the cloud from juju's perspective