### PR TITLE
Prepare for building ops charmed-k8s from launchpad

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -31,13 +31,39 @@
   cni-arm64: '{out_path}/cni-arm64.tgz'
   cni-s390x: '{out_path}/cni-s390x.tgz'
 'kubernetes-control-plane':
-  cni-amd64: '{out_path}/cni-amd64.tgz'
-  cni-arm64: '{out_path}/cni-arm64.tgz'
-  cni-s390x: '{out_path}/cni-s390x.tgz'
+  cni-amd64:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-arm64:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-s390x:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-plugins:
+    format: '{out_path}/cni-plugins-{arch}.tar.gz'
+    channel-range:
+      min: '1.29'
 'kubernetes-worker':
-  cni-amd64: '{out_path}/cni-amd64.tgz'
-  cni-arm64: '{out_path}/cni-arm64.tgz'
-  cni-s390x: '{out_path}/cni-s390x.tgz'
+  cni-amd64:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-arm64:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-s390x:
+    format: '{out_path}/cni-amd64.tgz'
+    channel-range:
+      max: '1.29'
+  cni-plugins:
+    format: '{out_path}/cni-plugins-{arch}.tar.gz'
+    channel-range:
+      min: '1.29'
 'kube-ovn':
   kubectl-ko: '{src_path}/plugins/kubectl-ko'
 'metallb-controller':

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -209,6 +209,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-e2e.git'
 - kubernetes-control-plane:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-control-plane'
     build-resources: 'cd {out_path}; bash {src_path}/build-cni-resources.sh'
     docs: 'https://charmhub.io/kubernetes-control-plane/docs'
@@ -234,6 +235,7 @@
     upstream: >-
       https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator.git
 - kubernetes-worker:
+    builder: 'launchpad'
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-worker'
     build-resources: 'cd {out_path}; bash {src_path}/build-cni-resources.sh'
     docs: 'https://charmhub.io/kubernetes-worker/docs'


### PR DESCRIPTION
Ops versions of `kubernetes-control-plane` and `kubernetes-worker` should build from launchpad with a charm recipe starting with 1.29.

These CI changes are necessary to instruct the charm builder to use launchpad and to build the appropriate charm resources.