### PR TITLE
Ensure tests are run from 1.29/edge charms and snaps

### DIFF
--- a/cilib/models/repos/__init__.py
+++ b/cilib/models/repos/__init__.py
@@ -101,6 +101,8 @@ class BaseRepoModel:
                     _semvers.append(str(semver_version))
             except:
                 continue
+        if not _semvers:
+            return None
         max_ver = max(map(version.parse, _semvers))
 
         # Grab the branches for max_ver to determine if there are any patches that need to be applied

--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -129,6 +129,10 @@ class SnapService(DebugMixin):
                     )
                 )
 
+                if not latest_branch_version:
+                    self.log(f"Found no pre-release branches ({_version}), skipping.")
+                    continue
+
                 # S-a-n-i-t-y check; there is a period of time where K8S_NEXT_VERSION
                 # is stable (1.xx.0) *and* has a pre-release branch (1.xx.1-alpha.1).
                 # If our latest branch version is not a pre-release, bail out.
@@ -141,11 +145,17 @@ class SnapService(DebugMixin):
                     continue
             else:
                 # We don't want pre-releases when syncing our stable versions
+                self.log(
+                    f"Ignore pre-releases when syncing our stable versions: ({_version})."
+                )
                 latest_branch_version = (
                     self.snap_model.base.latest_branch_from_major_minor(
                         _version, exclude_pre=True
                     )
                 )
+                if not latest_branch_version:
+                    self.log(f"Found no stable branches ({_version}), skipping.")
+                    continue
 
             for arch in enums.K8S_SUPPORT_ARCHES:
                 self.log(f"> Checking snaps in version {_version} for arch {arch}")

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -141,7 +141,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.28/beta
+          default: 1.29/beta
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -149,7 +149,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.28/edge
+          default: 1.29/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -21,7 +21,7 @@
       - juju-lts
       - string:
           name: CK_VERSION
-          default: '1.28'
+          default: '1.29'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.28'
+          default: '1.29'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,9 +73,9 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.29/edge
             - 1.28/edge
             - 1.27/edge
-            - 1.26/edge
       - stable:
           snap_versions:
             - 1.28/stable
@@ -117,9 +117,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
             - 1.27/edge
-            - 1.26/edge
       - axis:
           type: user-defined
           name: series
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
       - axis:
           type: user-defined
           name: cloud
@@ -430,8 +430,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -477,8 +477,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -518,8 +518,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -559,8 +559,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -600,8 +600,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -641,8 +641,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -682,9 +682,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/edge
             - 1.28/edge
             - 1.27/edge
-            - 1.26/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"


### PR DESCRIPTION
Ensure tests run with 1.29/edge for charms and snaps where appropriate.
Updates validate jobs and `sync-oci-image` to sync 1.29 images
resolves issue in `sync-snaps` when internal branches don't match any branches to build

- [ ] Needs `jjb` after merge