### PR TITLE
Build bundles with track/risk channels

### DIFF
--- a/jobs/build-charms/main.py
+++ b/jobs/build-charms/main.py
@@ -190,6 +190,11 @@ def build_bundles(
                 build_entity = BundleBuildEntity(build_env, bundle_name, bundle_opts)
                 entities.append(build_entity)
 
+    to_channels = [
+        f"{build_env.track}/{chan.lower()}" if (chan.lower() in RISKS) else chan
+        for chan in build_env.to_channels
+    ]
+
     for entity in entities:
         entity.echo("Starting")
         try:
@@ -198,7 +203,7 @@ def build_bundles(
                 entity.setup()
 
             entity.echo(f"Details: {entity}")
-            for channel in build_env.to_channels:
+            for channel in to_channels:
                 entity.bundle_build(channel)
 
                 # Bundles are built easily, but it's pointless to push the bundle

--- a/tests/unit/build_charms/test_charms.py
+++ b/tests/unit/build_charms/test_charms.py
@@ -735,6 +735,7 @@ def test_bundle_build_command(
     mock_build_env.bundles_dir = mock_build_env.tmp_dir / "bundles"
     mock_build_env.default_repo_dir = mock_build_env.repos_dir / "bundles-kubernetes"
     mock_build_env.to_channels = ("edge", "0.15/edge")
+    mock_build_env.track = "latest"
     mock_build_env.filter_by_tag = ["k8s"]
     mock_build_env.force = False
 
@@ -771,7 +772,7 @@ def test_bundle_build_command(
             [
                 call("Starting"),
                 call(f"Details: {entity}"),
-                call("Pushing built bundle for channel=edge (forced=False)."),
+                call("Pushing built bundle for channel=latest/edge (forced=False)."),
                 call("Pushing built bundle for channel=0.15/edge (forced=False)."),
                 call("Stopping"),
             ],
@@ -781,11 +782,11 @@ def test_bundle_build_command(
             entity.setup.assert_called_once_with()
 
         assert entity.bundle_build.mock_calls == [
-            call(channel) for channel in mock_build_env.to_channels
+            call(channel) for channel in ["latest/edge", "0.15/edge"]
         ]
         assert entity.push.mock_calls == [call(artifact), call(artifact)]
         assert entity.release.mock_calls == [
             call(artifact, to_channels=[channel])
-            for channel in mock_build_env.to_channels
+            for channel in ["latest/edge", "0.15/edge"]
         ]
         assert entity.reset_artifacts.mock_calls == [call(), call()]


### PR DESCRIPTION
Similar to https://github.com/charmed-kubernetes/jenkins/pull/1416, we need to build the bundles passing `<track>/<risk>` to the build job.  The [build script](https://github.com/charmed-kubernetes/bundle/blob/b9128af4886feeca000827258c97b51b13fcac1e/bundle) in the bundles repo still handles the channel correctly.