### PR TITLE
Check channel boundaries before checking out charm code

### DIFF
--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -906,6 +906,10 @@ class BuildEntity:
 
         self.reactive = self.layer_path.exists()
 
+    def within_channel_bounds(self, to_channels):
+        """Check if there's a valid channel to publish to."""
+        return apply_channel_bounds(self.opts, to_channels)
+
     def charm_build(self):
         """Perform a build against charm/bundle."""
         lxc = os.environ.get("charmcraft_lxc")

--- a/jobs/build-charms/main.py
+++ b/jobs/build-charms/main.py
@@ -100,6 +100,9 @@ def build(
     for entity in entities:
         entity.echo("Starting")
         try:
+            if not entity.within_channel_bounds(to_channels=to_channels):
+                entity.echo("Skipped due to channel boundaries")
+                continue
             entity.setup()
             entity.echo(f"Details: {entity}")
 


### PR DESCRIPTION
`tigera-secure-ee` charm should not be built beyond the [1.28 release branch](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-support-matrix.inc#L278-L291), and if queued for building during 1.29/beta, it should be skipped over due to its channel boundaries settings.  

This code will check the channel-boundaries and only build if there is a channel for a charm to be published to based on the channel boundaries