### PR TITLE
Include nvidia-operator charms to builds, excluding the nightly builds

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -658,6 +658,32 @@
     subdir: charms/volcano-scheduler
     channel-range:
       min: '1.27'
+- nvidia-gpu-operator:
+    builder: 'launchpad'
+    bugs: 'https://bugs.launchpad.net/nvidia-operators'
+    downstream: charmed-kubernetes/nvidia
+    store: 'https://charmhub.io/nvidia-gpu-operator'
+    summary: Simplifies the management of NVIDIA GPU resources in a Kubernetes cluster.
+    tags:
+      - nvidia
+      - nvidia-gpu
+    upstream: 'https://github.com/charmed-kubernetes/nvidia'
+    subdir: charms/gpu-operator
+    channel-range:
+      min: '1.29'
+- nvidia-network-operator:
+    builder: 'launchpad'
+    bugs: 'https://bugs.launchpad.net/nvidia-operators'
+    downstream: charmed-kubernetes/nvidia
+    store: 'https://charmhub.io/nvidia-network-operator'
+    summary: Simplifies the management of NVIDIA networking resources in a Kubernetes cluster
+    tags:
+      - nvidia
+      - nvidia-network
+    upstream: 'https://github.com/charmed-kubernetes/nvidia'
+    subdir: charms/network-operator
+    channel-range:
+      min: '1.27'
 
 
 # EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard


### PR DESCRIPTION
by not including the `k8s-operator` tag, these charms won't build nightly

But we can run a parameterized build to craft these charms one off. 

I've also requested tracks to be opened for these charms at 1.29.