### PR TITLE
Update validation jobs to 3.1/stable (and some to 3.3/stable)

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -254,8 +254,8 @@ function ci::cleanup::before
 
 function ci::cleanup::model::addons
 {
-    if ! timeout 10m juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons"; then
-      timeout 10m juju destroy-model -y --destroy-storage "$JUJU_CONTROLLER:addons" --force
+    if ! timeout 10m juju destroy-model --no-prompt --destroy-storage "$JUJU_CONTROLLER:addons"; then
+      timeout 10m juju destroy-model --no-prompt --destroy-storage "$JUJU_CONTROLLER:addons" --force
     fi
 }
 

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -89,7 +89,7 @@
           name: juju_channel
           description: |-
             specify the juju channel to use
-          default: 2.9/stable
+          default: 3.1/stable
 
 - parameter:
     name: series-stable

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -128,7 +128,7 @@
         - jenkins
         - adhoc
     - name: upgrade juju
-      command: "snap refresh juju --channel 2.9/stable --classic"
+      command: "snap refresh juju --channel 3.1/stable --classic"
       ignore_errors: yes
       tags:
         - jenkins
@@ -153,7 +153,7 @@
         - "charmcraft --classic --edge"
         - "go --classic --stable"
         - "google-cloud-cli --classic --channel latest/stable"
-        - "juju --classic --channel=2.9/stable"
+        - "juju --classic --channel=3.1/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
         - "kubectl --classic"

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -128,7 +128,7 @@
         - jenkins
         - adhoc
     - name: upgrade juju
-      command: "snap refresh juju --channel 3.1/stable --classic"
+      command: "snap refresh juju --channel 3.1/stable"
       ignore_errors: yes
       tags:
         - jenkins
@@ -153,7 +153,7 @@
         - "charmcraft --classic --edge"
         - "go --classic --stable"
         - "google-cloud-cli --classic --channel latest/stable"
-        - "juju --classic --channel=3.1/stable"
+        - "juju --channel=3.1/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
         - "kubectl --classic"

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -403,7 +403,7 @@ async def k8s_model(k8s_cloud, tools):
                 "--destroy-storage",
                 "--force",
                 "--no-wait",
-                "-y",
+                "--no-prompt",
                 tools.k8s_connection,
             )
 
@@ -541,7 +541,7 @@ async def deploy(request, tools):
     await _model_obj.connect(f"{tools.controller_name}:{nonce_model}")
     yield (tools.controller_name, _model_obj)
     await _model_obj.disconnect()
-    await tools.run("juju", "destroy-model", "-y", nonce_model)
+    await tools.run("juju", "destroy-model", "--no-prompt", nonce_model)
 
 
 @pytest.fixture(scope="module")

--- a/jobs/validate-offline/playbook.yml
+++ b/jobs/validate-offline/playbook.yml
@@ -27,7 +27,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel=2.9/stable"
+        - "juju --classic --channel=3.1/stable"
         - "juju-wait --classic"
         - "lxd"
       tags:

--- a/jobs/validate-offline/playbook.yml
+++ b/jobs/validate-offline/playbook.yml
@@ -27,7 +27,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel=3.1/stable"
+        - "juju --channel=3.1/stable"
         - "juju-wait --classic"
         - "lxd"
       tags:

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -33,8 +33,8 @@
           description: |-
             specify the juju channel to use
           values:
-            - 2.9/stable
             - 3.1/stable
+            - 3.3/stable
       - axis:
           type: user-defined
           name: snap_version

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -751,7 +751,11 @@
       - snap-edge
       - series-stable
       - lxc-runner-params
-      - juju-lts
+      - string:
+          name: juju_channel
+          description: |-
+            specify the juju channel to use
+          default: 2.9/stable
       - string:
           name: LXC_SNAP_LIST
           description: |-

--- a/jobs/validate/playbooks/single-system.yml
+++ b/jobs/validate/playbooks/single-system.yml
@@ -34,7 +34,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel=2.9/stable"
+        - "juju --classic --channel=3.1/stable"
         - "juju-wait --classic"
         - "juju-crashdump --classic --edge"
         - "lxd"

--- a/jobs/validate/playbooks/single-system.yml
+++ b/jobs/validate/playbooks/single-system.yml
@@ -34,7 +34,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --classic --channel=3.1/stable"
+        - "juju --channel=3.1/stable"
         - "juju-wait --classic"
         - "juju-crashdump --classic --edge"
         - "lxd"

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-juju==3.2.3.0
+juju==3.3.0.0
     # via -r requirements.in
 kubernetes==26.1.0
     # via juju


### PR DESCRIPTION
End testing charmed-kubernetes against juju 2.9, Start testing with 3.3

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

