### PR TITLE
Clear the homedir setting

### DIFF
--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -25,9 +25,9 @@
       tags:
         - adhoc
         - jenkins
-    - name: set homedir
+    - name: clear homedir
       shell: |
-        snap set system homedirs=/var/lib/
+        snap set system homedirs!
       tags:
         - adhoc
         - jenkins


### PR DESCRIPTION
Since homedir is seems to be causing some problems with the snapd in our CI we are disabling it. 