### PR TITLE
Update validation tests for google cloud

### DIFF
--- a/jobs/integration/templates/integrator-charm-data/gce/out-of-tree.yaml
+++ b/jobs/integration/templates/integrator-charm-data/gce/out-of-tree.yaml
@@ -2,17 +2,24 @@ storage-class: csi-gce-pd-default
 storage:
   application: gcp-k8s-storage
   out-relations:
-    - - gcp-k8s-storage:certificates
-      - easyrsa:client
-    - - gcp-k8s-storage:kube-control
-      - kubernetes-control-plane:kube-control
-    - - gcp-k8s-storage:gcp-integration
-      - gcp-integrator:gcp
-  in-relations: []
+    - [gcp-k8s-storage:certificates, easyrsa:client]
+    - [gcp-k8s-storage:kube-control, kubernetes-control-plane:kube-control]
+    - [gcp-k8s-storage:gcp-integration, gcp-integrator:gcp]
+  in-relations:
+    - [gcp-integrator:gcp, kubernetes-control-plane:gcp]
+    - [gcp-integrator:gcp, kubernetes-worker:gcp]
   in-tree-until: '1.24'
   trust: true
   config:
     image-registry: k8s.gcr.io
 cloud-controller:
-  application: null
-  in-tree-until: '999.0'
+  application: gcp-cloud-provider
+  out-relations:
+    - [gcp-cloud-provider:certificates, easyrsa:client]
+    - [gcp-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+    - [gcp-cloud-provider:gcp-integration, gcp-integrator:gcp]
+    - [gcp-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+  in-relations:
+    - [gcp-integrator:gcp, kubernetes-control-plane:gcp]
+    - [gcp-integrator:gcp, kubernetes-worker:gcp]
+  in-tree-until: '1.28'

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -94,9 +94,11 @@ EOF
     channel: $JUJU_DEPLOY_CHANNEL
     num_units: 1
     trust: true
-relations:
-  - ['gcp-integrator', 'kubernetes-control-plane:gcp']
-  - ['gcp-integrator', 'kubernetes-worker:gcp']
+  gcp-cloud-provider:
+    charm: gcp-cloud-provider
+    channel: $JUJU_DEPLOY_CHANNEL
+    options:
+      enable-loadbalancers: true
 EOF
     elif [ "$JUJU_CLOUD" = "azure/centralus" ]; then
       # Deploy azure


### PR DESCRIPTION
Charmed-kubernetes starting with 1.29/edge supports `gcp-cloud-provider` integration. 

the `:gcp` relation with the worker and control-plane is available only for instance tagging, but isn't necessary for the operational storage or load-balancers