### PR TITLE
Update to testing with 1.30/edge channels

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -117,7 +117,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.28/stable
+          default: 1.29/stable
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -125,7 +125,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.29/edge
+          default: 1.30/edge
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -133,7 +133,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.28/stable
+          default: 1.29/stable
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -149,7 +149,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.29/edge
+          default: 1.30/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/infra/fixtures/docker.daemon.json
+++ b/jobs/infra/fixtures/docker.daemon.json
@@ -1,3 +1,4 @@
 {
-    "mtu": 1458
+    "mtu": 1458,
+    "iptables": false
 }

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -68,8 +68,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.29/stable
             - 1.28/stable
-            - 1.27/stable
       - axis:
           type: user-defined
           name: series
@@ -118,8 +118,8 @@
           type: user-defined
           name: deploy_snap
           values:
+            - 1.29/stable
             - 1.28/stable
-            - 1.27/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,14 +73,14 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.30/edge
             - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
       - stable:
           snap_versions:
+            - 1.29/stable
             - 1.28/stable
             - 1.27/stable
-            - 1.26/stable
           dow: '0'      # Sunday
     jobs:
       - 'validate-ck-{charm-channel}-{series}'
@@ -117,9 +117,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
       - axis:
           type: user-defined
           name: series
@@ -178,8 +178,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.28/stable
             - 1.27/stable
-            - 1.26/stable
       - axis:
           type: user-defined
           name: arch
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
       - axis:
           type: user-defined
           name: cloud
@@ -430,8 +430,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -477,8 +477,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -518,8 +518,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -559,8 +559,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -600,8 +600,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -641,8 +641,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -682,9 +682,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/edge
             - 1.29/edge
             - 1.28/edge
-            - 1.27/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"


### PR DESCRIPTION
Charms are available from 1.30/edge
Snaps are available from 1.30/edge
It's time to update the CI to test 1.30/edge

* [x] needs jjb