### PR TITLE
Bump go-version to 1.22 for kubernetes 1.30

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -44,7 +44,7 @@ K8S_CRI_TOOLS_SEMVER = "1.19"
 
 # Kubernetes build source to go version map
 K8S_GO_MAP = {
-    "1.30": "go/1.21/stable",
+    "1.30": "go/1.22/stable",
     "1.29": "go/1.21/stable",
     "1.28": "go/1.20/stable",
     "1.27": "go/1.20/stable",


### PR DESCRIPTION
Address Failing snap builds
https://launchpad.net/~k8s-jenkaas-admins/+snap/kubelet-1.30

```
Kubernetes requires go1.22 or greater.
Please install go1.22 or later.
```