### PR TITLE
Rather than use -y, use --no-prompt when destroying or killing juju controllers

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -272,8 +272,8 @@ function ci::cleanup
         ci::cleanup::before || true
         test::capture || true
 
-        if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
-            timeout 10m juju kill-controller -t 2m0s -y "$JUJU_CONTROLLER" || true
+        if ! timeout 2m juju destroy-controller --no-prompt --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"; then
+            timeout 10m juju kill-controller -t 2m0s --no-prompt "$JUJU_CONTROLLER" || true
         fi
         ci::cleanup::after || true
     } 2>&1 | sed -u -e "s/^/[$log_name_custom] /" | tee -a "ci.log"

--- a/jobs/infra/fixtures/cleanup-env.sh
+++ b/jobs/infra/fixtures/cleanup-env.sh
@@ -23,8 +23,8 @@ juju controllers --format json | jq -r '.controllers | keys[]' | parallel --ungr
 # for i in $(juju controllers --format json | jq -r '.controllers | keys[]'); do
 #     if [ "$i" != "jaas" ]; then
 #         echo "$i"
-#         if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$i"; then
-#             timeout 2m juju kill-controller -y "$i" 2>&1
+#         if ! timeout 2m juju destroy-controller --no-prompt --destroy-all-models --destroy-storage "$i"; then
+#             timeout 2m juju kill-controller --no-prompt "$i" 2>&1
 #         fi
 #     fi
 # done

--- a/jobs/infra/fixtures/cleanup-s390x-env.sh
+++ b/jobs/infra/fixtures/cleanup-s390x-env.sh
@@ -2,8 +2,8 @@
 for i in $(juju controllers --format json | jq -r '.controllers | keys[]'); do
     if [[ "$i" != "jaas" ]]; then
         echo "$i"
-        if ! timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$i"; then
-            timeout 5m juju kill-controller -t 2m0s -y "$i" 2>&1
+        if ! timeout 2m juju destroy-controller --no-prompt --destroy-all-models --destroy-storage "$i"; then
+            timeout 5m juju kill-controller -t 2m0s --no-prompt "$i" 2>&1
         fi
     fi
 done

--- a/jobs/release-microk8s/release-microk8s.groovy
+++ b/jobs/release-microk8s/release-microk8s.groovy
@@ -1,7 +1,7 @@
 
 def destroy_controller(controller) {
     return """#!/bin/bash
-    if ! timeout 4m juju destroy-controller -y --destroy-all-models --destroy-storage "${controller}"; then
+    if ! timeout 4m juju destroy-controller --no-prompt --destroy-all-models --destroy-storage "${controller}"; then
         timeout 4m juju kill-controller --no-prompt "${controller}" || true
     fi
     """

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -106,8 +106,8 @@ function ci::cleanup::before
     scp -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -r ubuntu@10.13.6.3:jenkins/*.html . || true
 
     ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -tt ubuntu@10.13.6.3 -- rm -rf juju-crashdump* || true
-    ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -tt ubuntu@10.13.6.3 -- timeout 2m juju destroy-controller -y --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"
-    ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -tt ubuntu@10.13.6.3 -- timeout 10m juju kill-controller -y "$JUJU_CONTROLLER"
+    ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -tt ubuntu@10.13.6.3 -- timeout 2m juju destroy-controller --no-prompt --destroy-all-models --destroy-storage "$JUJU_CONTROLLER"
+    ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -i /var/lib/jenkins/.ssh/cdkbot_rsa -tt ubuntu@10.13.6.3 -- timeout 10m juju kill-controller --no-prompt "$JUJU_CONTROLLER"
 }
 
 ###############################################################################


### PR DESCRIPTION
Since juju 3.2, `-y` option has been removed.  This leaves models sitting around in our CI un-destroyed after a test completes.  