### PR TITLE
kubernetes-control-plane/worker no longer supports vsphere relation in 1.29 and beyond

### DIFF
--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -63,9 +63,9 @@ EOF
       folder: k8s-crew-root
     num_units: 1
     trust: true
-relations:
-  - ['vsphere-integrator', 'kubernetes-control-plane:vsphere']
-  - ['vsphere-integrator', 'kubernetes-worker:vsphere']
+  vsphere-cloud-provider:
+    charm: vsphere-cloud-provider
+    channel: $JUJU_DEPLOY_CHANNEL
 EOF
     elif [ "$JUJU_CLOUD" = "aws/us-east-1" ]; then
       # Deploy aws


### PR DESCRIPTION
the core vsphere bundle no longer needs vsphere relations against kubernetes-worker/control-plane.  They haven't needed them for some time and provide no extra features other than supplied cloud credentials. 