### PR TITLE
Run coredns charm validation with image from charmhub

### DIFF
--- a/ci.bash
+++ b/ci.bash
@@ -9,6 +9,7 @@ function compile::env
     : "${JUJU_DEPLOY_CHANNEL:?Must have a channel defined}"
     : "${JUJU_MODEL:?Must have a model defined}"
     : "${JUJU_UPDATE_STATUS_INTERVAL:=150s}"
+    : "${JUJU_OWNER:=k8sci}"
     : "${JOB_STAGE:-}"
     : "${JOB_REPORTING:-yes}"
     : "${SERIES:?Must have a release series defined}"

--- a/jobs/arc-conformance/conformance-spec
+++ b/jobs/arc-conformance/conformance-spec
@@ -23,7 +23,7 @@ function juju::bootstrap
          --force \
          --bootstrap-constraints arch="$ARCH" \
          --model-default test-mode=true \
-         --model-default resource-tags="owner=k8sci" \
+         --model-default resource-tags="owner=$JUJU_OWNER" \
          --model-default image-stream=released \
          --model-default automatically-retry-hooks=true \
          --model-default logging-config="<root>=DEBUG"

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -12,9 +12,9 @@ from subprocess import check_output, CalledProcessError
 
 VPC_CIDR = "172.30.0.0/16"
 SUBNET_CIDRS = ["172.30.0.0/24", "172.30.1.0/24"]
-REGION = "us-east-2"
-AVAILABILITY_ZONE = "us-east-2a"
-OWNER = "k8sci"
+REGION = os.environ.get("JUJU_CLOUD", "us-east-2")
+AVAILABILITY_ZONE = f"{REGION}a"
+OWNER = os.environ.get("JUJU_OWNER", "k8sci")
 
 BIRD_CONFIG_BASE = """
 log syslog all;

--- a/jobs/spec-helpers/bootstrap.yml
+++ b/jobs/spec-helpers/bootstrap.yml
@@ -8,7 +8,7 @@ juju:
     replace-controller: yes
     model-default:
       - test-mode=true
-      - resource-tags=owner=k8sci
+      - resource-tags=owner=$JUJU_OWNER
   deploy:
     reuse: no
     bundle: $JUJU_DEPLOY_BUNDLE

--- a/jobs/validate-offline/spec.yml
+++ b/jobs/validate-offline/spec.yml
@@ -15,7 +15,7 @@ plan:
         set -x
 
         juju kill-controller -y $JUJU_CONTROLLER || true
-        juju bootstrap $JUJU_CLOUD $JUJU_CONTROLLER --model-default resource-tags=owner=k8sci --model-default test-mode=true
+        juju bootstrap $JUJU_CLOUD $JUJU_CONTROLLER --model-default resource-tags=owner=$JUJU_OWNER --model-default test-mode=true
         juju deploy ubuntu --constraints "mem=16G root-disk=500G cores=16"
         juju-wait -e $JUJU_CONTROLLER:$JUJU_MODEL -w
 

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -31,7 +31,7 @@ function juju::bootstrap
       --force \
       --bootstrap-constraints arch="$ARCH" \
       --model-default test-mode=true \
-      --model-default resource-tags=owner=k8sci \
+      --model-default resource-tags=owner=$JUJU_OWNER \
       --model-default image-stream=daily \
       --model-default automatically-retry-hooks=true \
       --model-default logging-config="<root>=DEBUG" \

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -25,7 +25,7 @@ function juju::bootstrap
       --force --bootstrap-series "$SERIES" \
       --bootstrap-constraints arch="amd64" \
       --model-default test-mode=true \
-      --model-default resource-tags=owner=k8sci \
+      --model-default resource-tags=owner=$JUJU_OWNER \
       --model-default image-stream=daily \
       --model-default automatically-retry-hooks=true \
       --model-default logging-config="<root>=DEBUG" \

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -22,7 +22,7 @@ set -x
 #          --force --bootstrap-series "$SERIES" \
 #          --bootstrap-constraints arch="amd64" \
 #          --model-default test-mode=true \
-#          --model-default resource-tags=owner=k8sci \
+#          --model-default resource-tags=owner=$JUJU_OWNER \
 #          --model-default image-stream=daily \
 #          --model-default vpc-id=vpc-0e4f11d0d4e9ba35f \
 #          --model-default automatically-retry-hooks=true \

--- a/juju.bash
+++ b/juju.bash
@@ -89,7 +89,7 @@ function juju::bootstrap
     fi
 
     juju::destroy
-    TAGS="owner=k8sci job=${JOB_NAME_CUSTOM}"
+    TAGS="owner=${JUJU_OWNER} job=${JOB_NAME_CUSTOM}"
     if [ "${JOB_STAGE}" ]; then TAGS+=" stage=${STAGE}"; fi
     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
          ${add_model[@]} \


### PR DESCRIPTION
Summary
------

Remove the hack that installed a multi-arch image from rocks when testing the coredns charm and use the oci image associated with the charm from charmhub


Details
----------------
In order to test on AWS with arm64 cores, I needed to override the `owner` tag used on instances in AWS so they wouldn't be reaped by infra jenkins runs while i'm testing.  I went ahead an parameterized this everywhere


