### PR TITLE
Revert pushing Charmed Kubernetes snaps and charms to 1.31 edge tracks

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -82,7 +82,6 @@ SNAP_K8S_TRACK_LIST = [
     ("1.28", ["1.28/stable", "1.28/candidate", "1.28/beta", "1.28/edge"]),
     ("1.29", ["1.29/stable", "1.29/candidate", "1.29/beta", "1.29/edge"]),
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
-    ("1.31", ["1.31/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 


### PR DESCRIPTION
* build charms wants to push to 1.31/edge tracks for [edge builds](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/build-charms/builder_local.py#L526-L529)
* [building snaps](https://github.com/charmed-kubernetes/jenkins/blob/main/cilib/service/snap.py#L122) will use that for finding new branches to build