### PR TITLE
Skip community addons tests for microk8s

### DIFF
--- a/jobs/microk8s/executors/juju.py
+++ b/jobs/microk8s/executors/juju.py
@@ -69,7 +69,7 @@ class JujuExecutor(ExecutorInterface):
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None
     ):
-        cmd = "sudo tests/test-distro.sh {} {} {}".format(
+        cmd = "sudo SKIP_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
             distro, track_channel_to_upgrade, testing_track_channel
         )
         if proxy:

--- a/jobs/microk8s/executors/juju.py
+++ b/jobs/microk8s/executors/juju.py
@@ -69,7 +69,7 @@ class JujuExecutor(ExecutorInterface):
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None
     ):
-        cmd = "sudo SKIP_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
+        cmd = "sudo DISABLE_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
             distro, track_channel_to_upgrade, testing_track_channel
         )
         if proxy:

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -55,7 +55,7 @@ class LocalExecutor(ExecutorInterface):
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None
     ):
-        cmd = "SKIP_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
+        cmd = "DISABLE_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
             distro, track_channel_to_upgrade, testing_track_channel
         )
         if proxy:

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -55,7 +55,7 @@ class LocalExecutor(ExecutorInterface):
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None
     ):
-        cmd = "tests/test-distro.sh {} {} {}".format(
+        cmd = "SKIP_COMMUNITY_TESTS=1 tests/test-distro.sh {} {} {}".format(
             distro, track_channel_to_upgrade, testing_track_channel
         )
         if proxy:


### PR DESCRIPTION
Add flag to skip community addons tests for Jenkins jobs

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
