### PR TITLE
restore ceph testing using ceph-csi charm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1860,7 +1860,6 @@ async def test_dns_provider(model, k8s_model, tools):
     control_plane_app = model.applications["kubernetes-control-plane"]
     machine = control_plane_app.units[0].machine
     machine_arch = machine.safe_data["hardware-characteristics"]["arch"]
-    machine_base = machine.safe_data["base"]
 
     async def deploy_validation_pod():
         async def _check_ready():


### PR DESCRIPTION
I've tested this on vsphere and the tests pass as expected.  There's not much difference from before -- just now we're using the ceph-csi charm