### PR TITLE
[KU-1044] cdk-addons follows the charm track

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -157,9 +157,9 @@ class Tools:
         self.k8s_connection = f"{self.controller_name}:{self.k8s_model_name_full}"
         self.is_series_upgrade = request.config.getoption("--is-series-upgrade")
         self.charm_channel = (
-            request.config.getoption("--charm-channel")    # use specified channel
+            request.config.getoption("--charm-channel")  # use specified channel
             or os.environ.get("CHARM_CHANNEL_UPGRADE_TO")  # fallback to upgrade env var
-            or os.environ.get("JUJU_DEPLOY_CHANNEL")       # fallback to env var
+            or os.environ.get("JUJU_DEPLOY_CHANNEL")  # fallback to env var
             or "edge"  # default to edge
         )
         self.snap_channel = request.config.getoption("--snap-channel")

--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -320,10 +320,10 @@ async def test_snap_versions(model, tools):
             for snap in snaps:
                 snap_version = snap_versions[snap]
                 if snap == "cdk-addons" and addons_track:
-                    msg=f"Snap {snap} is version {snap_version} and not {addons_track}.*"
+                    msg = f"Snap {snap} is version {snap_version} and not {addons_track}.*"
                     assert snap_version.startswith(addons_track + "."), msg
                 else:
-                    msg=f"Snap {snap} is version {snap_version} and not {track}.*"
+                    msg = f"Snap {snap} is version {snap_version} and not {track}.*"
                     assert snap_version.startswith(track + "."), msg
 
 


### PR DESCRIPTION
## Overview
Start testing that cdk-addons follows the charm channel and not the configured snap channel

## Details
With recent changes to support k8s upgrades for keystone and ceph, we realized that cdk-addons apply script can still overwrite cluster resources. A change was made so that cdk-addons `apply` does not touch deployments / resources after upgrading to 1.29.  We had to ensure that starting in charms 1.29 and beyond the cdk-addons snap follows the charm. 

These changes validate the cdk-addons snap version.