### PR TITLE
Update validation testing to use juju 3.1/stable and 3/stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         python:
           - "3.8"
-          - "3.9"
           - "3.10"
+          - "3.12"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -134,7 +134,7 @@
         - jenkins
         - adhoc
     - name: upgrade juju
-      command: "snap refresh juju --channel 3.1/stable"
+      command: "snap refresh juju --channel 3/stable"
       ignore_errors: yes
       tags:
         - jenkins
@@ -159,7 +159,7 @@
         - "charmcraft --classic --edge"
         - "go --classic --stable"
         - "google-cloud-cli --classic --channel latest/stable"
-        - "juju --channel=3.1/stable"
+        - "juju --channel=3/stable"
         - "juju-crashdump --classic --edge"
         - "juju-wait --classic"
         - "kubectl --classic"

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -180,13 +180,14 @@ class Tools:
         )
 
     def juju_base(self, series):
-        """Retrieve juju 3.1 base from series."""
+        """Retrieve juju 3.x base from series."""
         if self.juju_version < (3, 1):
             return f"--series={series}"
         mapping = {
             "bionic": "ubuntu@18.04",
             "focal": "ubuntu@20.04",
             "jammy": "ubuntu@22.04",
+            "noble": "ubuntu@24.04",
         }
         return f"--base={mapping[series]}"
 

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -96,13 +96,14 @@ def juju_version():
 
 
 def juju_base(series):
-    """Retrieve juju 3.1 base from series."""
+    """Retrieve juju 3.x base from series."""
     if juju_version() < (3, 1):
         return f"--series={series}"
     mapping = {
         "bionic": "ubuntu@18.04",
         "focal": "ubuntu@20.04",
         "jammy": "ubuntu@22.04",
+        "noble": "ubuntu@24.04",
     }
     return f"--base={mapping[series]}"
 

--- a/jobs/validate-offline/playbook.yml
+++ b/jobs/validate-offline/playbook.yml
@@ -27,7 +27,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --channel=3.1/stable"
+        - "juju --channel=3/stable"
         - "juju-wait --classic"
         - "lxd"
       tags:

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -33,8 +33,8 @@
           description: |-
             specify the juju channel to use
           values:
-            - 3.1/stable
             - 3.3/stable
+            - 3/stable
       - axis:
           type: user-defined
           name: snap_version
@@ -414,11 +414,7 @@
       - charms-edge
       - series-stable
       - lxc-runner-params
-      - string:
-          name: juju_channel
-          description: |-
-            specify the juju channel to use
-          default: 3.1/stable
+      - juju-lts
 
     axes:
       - axis:
@@ -467,11 +463,7 @@
       - charms-edge
       - series-stable
       - lxc-runner-params
-      - string:
-          name: juju_channel
-          description: |-
-            specify the juju channel to use
-          default: 3.1/stable
+      - juju-lts
     axes:
       - axis:
           type: user-defined

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -33,7 +33,7 @@
           description: |-
             specify the juju channel to use
           values:
-            - 3.3/stable
+            - 3.1/stable
             - 3/stable
       - axis:
           type: user-defined

--- a/jobs/validate/playbooks/single-system.yml
+++ b/jobs/validate/playbooks/single-system.yml
@@ -34,7 +34,7 @@
       command: "snap install {{item}}"
       ignore_errors: yes
       loop:
-        - "juju --channel=3.1/stable"
+        - "juju --channel=3/stable"
         - "juju-wait --classic"
         - "juju-crashdump --classic --edge"
         - "lxd"


### PR DESCRIPTION
### Overview

Update most of the charmed-kubernetes CI to use juju `3/stable` when in need of an LTS juju, and continue testing with juju 3.3 for the time being. 


### Details

* removes references to juju 3.1/stable
* replaces juju lts with just `3/stable`
* prepares a small amount to use noble bases mapping
*  [ ] Needs `jjb` after merge
