### PR TITLE
Swap out juju series for base specification

### DIFF
--- a/jobs/arc-conformance/conformance-spec
+++ b/jobs/arc-conformance/conformance-spec
@@ -19,7 +19,7 @@ function juju::bootstrap
     # override because azure needs image-stream=released
     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
          --add-model "$JUJU_MODEL" \
-         --bootstrap-series "$SERIES" \
+         --bootstrap-base "$(juju::base::from_series $SERIES)" \
          --force \
          --bootstrap-constraints arch="$ARCH" \
          --model-default test-mode=true \
@@ -38,7 +38,8 @@ function juju::deploy::overlay
 {
     # override to set cidr and allow-privileged for sonobuoy
     cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   calico:
     options:

--- a/jobs/cncf-conformance/conformance-spec
+++ b/jobs/cncf-conformance/conformance-spec
@@ -27,7 +27,7 @@ function juju::bootstrap::before
 function juju::deploy::overlay
 {
     cat <<EOF > overlay.yaml
-series: $SERIES
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:

--- a/jobs/microk8s/release.sh
+++ b/jobs/microk8s/release.sh
@@ -63,7 +63,8 @@ function juju::deploy::overlay
     fi
 
     cat << EOF > $JUJU_DEPLOY_BUNDLE
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   ubuntu:
     charm: ubuntu

--- a/jobs/validate/autoscaler-spec
+++ b/jobs/validate/autoscaler-spec
@@ -17,7 +17,8 @@ set -x
 function juju::deploy::overlay
 {
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:
@@ -61,7 +62,8 @@ function juju::deploy::after
 
     tee k8s_overlay.yaml <<EOF > /dev/null
 bundle: kubernetes
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-autoscaler:
     charm: kubernetes-autoscaler

--- a/jobs/validate/calico-spec
+++ b/jobs/validate/calico-spec
@@ -27,7 +27,7 @@ function juju::bootstrap
 
     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
       --add-model "$JUJU_MODEL" \
-      --bootstrap-series "$SERIES" \
+      --bootstrap-base "$(juju::base::from_series $SERIES)" \
       --force \
       --bootstrap-constraints arch="$ARCH" \
       --model-default test-mode=true \
@@ -56,7 +56,8 @@ function juju::deploy::overlay
     if [ "$ROUTING_MODE" = "vxlan" ]; then
       # Calico does not support VXLAN + IPv6, so we need to skip the IPv6 CIDRs
       cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:
@@ -72,7 +73,8 @@ EOF
     else
       # No VXLAN, so we'll test IPv6
       cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:

--- a/jobs/validate/cilium-spec
+++ b/jobs/validate/cilium-spec
@@ -20,7 +20,8 @@ function juju::deploy::overlay
     constraints="arch=$ARCH cores=2 mem=8G root-disk=16G"
 
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     constraints: $constraints

--- a/jobs/validate/ck-s390-spec
+++ b/jobs/validate/ck-s390-spec
@@ -27,7 +27,8 @@ function juju::wait
 function juju::deploy
 {
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:
@@ -53,7 +54,7 @@ export LANG=C.UTF-8
 juju bootstrap localhost/localhost \
     $JUJU_CONTROLLER \
     --add-model $JUJU_MODEL \
-    --bootstrap-series $SERIES \
+    --bootstrap-base $(juju::base::from_series $SERIES) \
     --force \
     --config juju-http-proxy=http://squid.internal:3128 \
     --config juju-https-proxy=http://squid.internal:3128 \

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -34,7 +34,8 @@ function juju::deploy::overlay
     constraints="arch=$ARCH cores=2 mem=8G root-disk=16G"
 
     cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   easyrsa:
     constraints: $constraints

--- a/jobs/validate/localhost-spec
+++ b/jobs/validate/localhost-spec
@@ -17,7 +17,7 @@ function juju::deploy
     (
         set -e
         juju deploy -m "$JUJU_CONTROLLER:$JUJU_MODEL" \
-        --series "$SERIES" \
+        --base "$(juju::base::from_series $SERIES)" \
         --force \
         --constraints "mem=32G root-disk=100G cores=8" \
         ubuntu
@@ -32,7 +32,8 @@ function juju::deploy
 function juju::deploy::after
 {
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:
@@ -62,7 +63,7 @@ export SNAP_VERSION=$SNAP_VERSION
 juju bootstrap localhost/localhost \
     \$JUJU_CONTROLLER \
     --add-model \$JUJU_MODEL \
-    --bootstrap-series \$SERIES \
+    --bootstrap-base $(juju::base::from_series $SERIES) \
     --force \
     --model-default image-stream=daily
 

--- a/jobs/validate/nvidia-spec
+++ b/jobs/validate/nvidia-spec
@@ -19,7 +19,8 @@ set -x
 function juju::deploy
 {
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   containerd:
     options:

--- a/jobs/validate/ovn-multus-spec
+++ b/jobs/validate/ovn-multus-spec
@@ -20,7 +20,8 @@ function juju::deploy::overlay
     constraints="arch=$ARCH cores=2 mem=8G root-disk=16G"
 
     tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     constraints: $constraints

--- a/jobs/validate/sriov-spec
+++ b/jobs/validate/sriov-spec
@@ -20,7 +20,8 @@ function juju::deploy::overlay
    constraints="arch=$ARCH instance-type=c4.xlarge root-disk=16G"
 
    tee overlay.yaml <<EOF > /dev/null
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     constraints: $constraints
@@ -61,7 +62,8 @@ function juju::deploy::after
 
     tee k8s-bundle.yaml <<EOF > /dev/null
 bundle: kubernetes
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   sriov-cni:
     charm: sriov-cni

--- a/jobs/validate/tigera-ee-spec
+++ b/jobs/validate/tigera-ee-spec
@@ -22,7 +22,8 @@ function juju::bootstrap
 
     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
       --add-model "$JUJU_MODEL" \
-      --force --bootstrap-series "$SERIES" \
+      --force \
+      --bootstrap-base "$(juju::base::from_series $SERIES)" \
       --bootstrap-constraints arch="amd64" \
       --model-default test-mode=true \
       --model-default resource-tags=owner=$JUJU_OWNER \
@@ -35,7 +36,8 @@ function juju::bootstrap
 function juju::deploy::overlay
 {
     cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     channel: $JUJU_DEPLOY_CHANNEL

--- a/jobs/validate/vault-spec
+++ b/jobs/validate/vault-spec
@@ -19,7 +19,7 @@ set -x
 # {
 #     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
 #          --add-model "$JUJU_MODEL" \
-#          --force --bootstrap-series "$SERIES" \
+#          --force --bootstrap-base "$(juju::base::from_series $SERIES)" \
 #          --bootstrap-constraints arch="amd64" \
 #          --model-default test-mode=true \
 #          --model-default resource-tags=owner=$JUJU_OWNER \
@@ -32,7 +32,8 @@ set -x
 function juju::deploy::overlay
 {
     cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     options:

--- a/juju.bash
+++ b/juju.bash
@@ -14,6 +14,20 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
+function juju::base::from_series
+{
+    case "$1" in
+        "noble")  echo "ubuntu@24.04";;
+        "jammy")  echo "ubuntu@22.04";;
+        "focal")  echo "ubuntu@20.04";;
+        "bionic") echo "ubuntu@18.04";;
+        *) 
+          test::report "unknown series=$1"
+          exit 1
+        ;;
+    esac
+}
+
 function juju::bootstrap::before
 {
     echo "> skipping before tasks"
@@ -94,7 +108,8 @@ function juju::bootstrap
     juju bootstrap "$JUJU_CLOUD" "$JUJU_CONTROLLER" \
          ${add_model[@]} \
          --debug \
-         --force --bootstrap-series "$SERIES" \
+         --force \
+         --bootstrap-base "$(juju::base::from_series $SERIES)" \
          --bootstrap-constraints arch="${ARCH:-amd64}" \
          --model-default test-mode=true \
          --model-default resource-tags="${TAGS}" \
@@ -121,7 +136,8 @@ function juju::deploy::overlay
     constraints="arch=${ARCH:-amd64} cores=2 mem=8G root-disk=16G"
 
     cat <<EOF > overlay.yaml
-series: $SERIES
+series: null
+default-base: $(juju::base::from_series $SERIES)
 applications:
   kubernetes-control-plane:
     constraints: $constraints

--- a/requirements-2.9.txt
+++ b/requirements-2.9.txt
@@ -152,7 +152,7 @@ paramiko==2.12.0
 pbr==5.11.1
     # via
     #   stevedore
-pluggy==1.2.0
+pluggy==1.5.0
     # via pytest
 prettytable==3.7.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,7 @@ platformdirs==4.2.0
     # via
     #   black
     #   mkdocs
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prettytable==3.9.0
     # via -r requirements.in


### PR DESCRIPTION
### Overview

Swap out mentions of juju SERIES for juju base

### Details

* in `juju.bash`, create a method called `juju::base::from_series`
* use that method to translate series -> base
* replace calls to bundles to use 
    ```yaml
    series: null
    default-base: $(juju::base::from_series $SERIES)
    ```
* replace `boostrap-series` with `bootstrap-base`