### PR TITLE
Setup 1.31 preparing for GA

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -12,12 +12,12 @@ K8S_STABLE_VERSION = "1.30"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
-# Typically, this is K8S_STABLE_VERSION +1. However, when prepping the next
-# stable release, this will be +2. For example, 1.29 is currently stable and
-# we're working on the 1.30 GA. Set this value to '1.31' sometime between the
-# final RC and GA so we don't get pre-release builds (e.g. 1.30.1-alpha.0) in
-# our 1.30 tracks.
-K8S_NEXT_VERSION = "1.31"
+# Typically, this is K8S_STABLE_VERSION+1. However, when preparing the next
+# stable release, this will be +2. For example, 1.30 is currently stable and
+# we're working on the 1.31 GA. Set this value to '1.32' sometime between the
+# final RC and GA so we don't get pre-release builds (e.g. 1.31.1-alpha.0) in
+# our 1.31 tracks.
+K8S_NEXT_VERSION = "1.32"
 
 # Lowest K8S SEMVER to process, this is usually K8S_STABLE_VERSION - 4
 K8S_STARTING_SEMVER = "1.26.0"
@@ -45,7 +45,8 @@ K8S_CRI_TOOLS_SEMVER = "1.19"
 
 # Kubernetes build source to go version map
 K8S_GO_MAP = {
-    "1.31": "go/latest/edge",
+    "1.32": "go/latest/edge",
+    "1.31": "go/1.22/stable",
     "1.30": "go/1.22/stable",
     "1.29": "go/1.21/stable",
     "1.28": "go/1.20/stable",
@@ -82,6 +83,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.28", ["1.28/stable", "1.28/candidate", "1.28/beta", "1.28/edge"]),
     ("1.29", ["1.29/stable", "1.29/candidate", "1.29/beta", "1.29/edge"]),
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
+    ("1.31", ["1.31/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -5,7 +5,7 @@ This document outlines the process for publishing a Charmed Kubernetes stable re
 
 ### Repository layout
 
-All charm repositories used by Charmed Kuberentes have a common branch scheme to provide a
+All charm repositories used by Charmed Kubernetes have a common branch scheme to provide a
 consistent experience across all code bases. Any external or shared repositories are forked
 into the `charmed-kubernetes` github organization and have the following branches:
 
@@ -45,7 +45,7 @@ For example, we requested 1.30 snap tracks while preparing for the 1.29 release:
 - https://forum.snapcraft.io/t/charmed-kubernetes-1-30-snap-tracks/38912
 
 Bundle/charm track requests are made by posting to the `charmhub requests` forum
-asking for new tracks to be opened for every neccessary
+asking for new tracks to be opened for every necessary
 [charm](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-support-matrix.inc)
 and
 [bundle](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-bundles-list.inc)

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -97,7 +97,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.27', '1.28', '1.29', '1.30']
+    version: ['1.28', '1.29', '1.30', '1.31']
     jobs:
       - 'build-release-cdk-addons-{version}'
 

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -117,7 +117,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.29/stable
+          default: 1.30/stable
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -125,7 +125,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.30/edge
+          default: 1.31/edge
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -133,7 +133,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.29/stable
+          default: 1.30/stable
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -141,7 +141,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.30/beta
+          default: 1.31/beta
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -149,7 +149,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.30/edge
+          default: 1.31/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -21,7 +21,7 @@
       - juju-lts
       - string:
           name: CK_VERSION
-          default: '1.29'
+          default: '1.31'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.

--- a/jobs/integration/test_integrator_charm.py
+++ b/jobs/integration/test_integrator_charm.py
@@ -85,7 +85,7 @@ def _prepare_relation(linkage, model, add=True):
     ]
     exists = any(right in str(_) for _ in right_endpoints)
     if add and not exists:
-        return app.relate(left_relation, right)
+        return app.integrate(left_relation, right)
     elif not add and exists:
         return app.destroy_relation(left_relation, right)
     return asyncio.sleep(0)

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -66,7 +66,7 @@
       - string:
           name: charm_channel
           description: "The charm channel to validate"
-          default: "1.29/candidate"
+          default: "1.30/candidate"
           trim: true
     axes:
       - axis:
@@ -78,8 +78,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.30/stable
             - 1.29/stable
-            - 1.28/stable
       - axis:
           type: user-defined
           name: series
@@ -128,8 +128,8 @@
           type: user-defined
           name: deploy_snap
           values:
+            - 1.30/stable
             - 1.29/stable
-            - 1.28/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.30'
+          default: '1.31'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.

--- a/jobs/sync-upstream.yaml
+++ b/jobs/sync-upstream.yaml
@@ -280,7 +280,7 @@
           name: STABLE_RELEASE
           description: |
             If blank, automatically determined based on last key of SNAP_K8S_TRACK_LIST
-            otherwise, this should be the major.minor release number (eg. 1.29)
+            otherwise, this should be the major.minor release number (eg. 1.30)
           default: ''
       - string:
           name: FILTER_BY_TAG

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,14 +73,14 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.31/edge
             - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
       - stable:
           snap_versions:
+            - 1.30/stable
             - 1.29/stable
             - 1.28/stable
-            - 1.27/stable
           dow: '0'      # Sunday
     jobs:
       - 'validate-ck-{charm-channel}-{series}'
@@ -117,9 +117,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
       - axis:
           type: user-defined
           name: series
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
       - axis:
           type: user-defined
           name: cloud
@@ -430,8 +430,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -477,8 +477,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -518,8 +518,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -559,8 +559,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -600,8 +600,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -641,8 +641,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -682,9 +682,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.31/edge
             - 1.30/edge
             - 1.29/edge
-            - 1.28/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -727,7 +727,6 @@
       - run-lxc:
           COMMAND: |
             bash jobs/validate/cilium-spec $snap_version $series $channel
-
 
 - job:
     name: 'validate-ck-autoscaler'


### PR DESCRIPTION
### Overview

Preparing for building 1.31 snaps and charms for GA testing of 1.31 Upstream release

### Details
* Update based on the [stable release docs](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md)
* Update CI jobs to reference new tracks for snaps and charms.
* [Link to created tag: `1.31.0-rc.0`](https://github.com/kubernetes/kubernetes/tree/v1.31.0-rc.0) does not 404
