### PR TITLE
remove kubernetes-autoscaler operator

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -203,7 +203,6 @@
     store: 'https://charmhub.io/kubernetes-autoscaler'
     summary: automatically scales up and down a kubernetes cluster
     tags:
-      - k8s-operator
       - kubernetes-autoscaler
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-autoscaler.git'


### PR DESCRIPTION
## Overview

Remove the Kubernetes-Autoscaler from nightly builds

## Details
KU-1168 ends support for the kubernetes-autoscaler. 
https://launchpad.net/charm-kubernetes-autoscaler/+announcement/54120
