### PR TITLE
Allow charms to set the version of charmcraft on lp builders

### DIFF
--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -28,7 +28,7 @@ class LPBuildEntity(BuildEntity):
     Builds charms on launchpad with charm recipes, then downloads locally
     """
 
-    SNAP_CHANNEL = {"charmcraft": "latest/stable"}
+    SNAP_CHANNEL = {"charmcraft": "2.x/stable"}
     BUILD_STATES_PENDING = {
         "Cancelling build",
         "Currently building",
@@ -129,7 +129,11 @@ class LPBuildEntity(BuildEntity):
 
     def _lp_request_builds(self) -> List[Resource]:
         """Request a charm build for this charm."""
-        req = self._lp_recipe.requestBuilds(channels=self.SNAP_CHANNEL)
+        channels = self.SNAP_CHANNEL
+        charmcraft_channel_file = Path(self.src_path) / ".charmcraft-channel"
+        if charmcraft_channel_file.exists():
+            channels["charmcraft"] = charmcraft_channel_file.read_text().strip()
+        req = self._lp_recipe.requestBuilds(channels=channels)
         self.echo("Waiting for charm recipe request")
         timeout = 5 * 60
         for _ in range(timeout):

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -117,7 +117,7 @@ class LPBuildEntity(BuildEntity):
                 name=self._lp_recipe_name,
                 auto_build=False,
                 auto_build_channels={},
-                build_path=self.opts.get("subdir", ""),
+                build_path=self.opts.get("subdir"),
                 description=f"Recipe for {self._lp_project} {self._lp_branch}",
                 git_ref=ref,
                 owner=self._lp_owner,

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -93,6 +93,9 @@ class LPBuildEntity(BuildEntity):
         charmcraft_channel_file = Path(self.src_path) / ".charmcraft-channel"
         if charmcraft_channel_file.exists():
             channels["charmcraft"] = charmcraft_channel_file.read_text().strip()
+            self.echo(
+                f"Using channel from {charmcraft_channel_file}: {channels['charmcraft']}"
+            )
         return channels
 
     @cached_property

--- a/jobs/build-charms/charmcraft-lib.sh
+++ b/jobs/build-charms/charmcraft-lib.sh
@@ -13,7 +13,7 @@ ci_charmcraft_launch()
   # Launch local LXD container to publish to charmcraft
   local charmcraft_lxc=$1
   ci_lxc_launch ubuntu:20.04 $charmcraft_lxc
-  until sudo lxc shell $charmcraft_lxc -- bash -c 'snap install charmcraft --classic'; do
+  until sudo lxc shell $charmcraft_lxc -- bash -c "snap install charmcraft --classic --channel=2.x/stable"; do
     echo 'retrying charmcraft install in 3s...'
     sleep 3
   done
@@ -38,6 +38,7 @@ ci_charmcraft_pack()
   local repository=$2
   local branch=$3
   local subdir=${4:-.}
+
   sudo lxc shell $charmcraft_lxc -- bash -c "rm -rf /root/*"
   sudo lxc shell $charmcraft_lxc -- bash -c "git clone ${repository} -b ${branch} charm"
   sudo lxc shell $charmcraft_lxc -- bash -c "cd charm/$subdir; cat version || git rev-parse --short HEAD | tee version"

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -128,7 +128,7 @@
         - jenkins
         - adhoc
     - name: upgrade charmcraft
-      command: "snap refresh charmcraft --channel latest/stable"
+      command: "snap refresh charmcraft --channel 2.x/stable"
       ignore_errors: yes
       tags:
         - jenkins
@@ -156,7 +156,7 @@
       ignore_errors: yes
       loop:
         - "charm --classic --channel 3.x/stable"
-        - "charmcraft --classic --edge"
+        - "charmcraft --classic --channel 2.x/stable"
         - "go --classic --stable"
         - "google-cloud-cli --classic --channel latest/stable"
         - "juju --channel=3.1/stable"

--- a/jobs/infra/playbook-jenkins.yml
+++ b/jobs/infra/playbook-jenkins.yml
@@ -127,12 +127,6 @@
       tags:
         - jenkins
         - adhoc
-    - name: upgrade charmcraft
-      command: "snap refresh charmcraft --channel 2.x/stable"
-      ignore_errors: yes
-      tags:
-        - jenkins
-        - adhoc
     - name: upgrade juju
       command: "snap refresh juju --channel 3.1/stable"
       ignore_errors: yes
@@ -156,7 +150,6 @@
       ignore_errors: yes
       loop:
         - "charm --classic --channel 3.x/stable"
-        - "charmcraft --classic --channel 2.x/stable"
         - "go --classic --stable"
         - "google-cloud-cli --classic --channel latest/stable"
         - "juju --channel=3.1/stable"
@@ -178,6 +171,7 @@
         - "microk8s"
         - "bundletester"
         - "surl"
+        - "charmcraft"
       tags:
         - jenkins
     - name: copy bashrc


### PR DESCRIPTION
## Overview
Updates the jenkins builder to use 2.x/stable by default for building charms, but let's the charms decide if they wish to build using a different charmcraft builder by setting in a file in the top-level of the repo. 

## Details

* reads from a file in a charm branch to determine the `.charmcraft-channel`
* adjusts LP builders to use this channel
* all other charm builds (non-lp built) will use 2.x/stable