### PR TITLE
Update build versions of MicroK8s

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -18,9 +18,6 @@ def get_tracks(all=False):
     """
     return [
         "latest",
-        "1.24",
-        "1.25",
-        "1.25-strict",
         "1.26",
         "1.26-strict",
         "1.27",
@@ -31,6 +28,8 @@ def get_tracks(all=False):
         "1.29-strict",
         "1.30",
         "1.30-strict",
+        "1.31",
+        "1.31-strict",
     ]
 
 

--- a/jobs/microk8s/release.sh
+++ b/jobs/microk8s/release.sh
@@ -89,6 +89,9 @@ function test::execute
     if [ "${CHANNEL}" == "pre-release" ]; then
         juju ssh -m "${juju_full_model}" --pty=true $JUJU_UNIT -- 'sudo snap install snapcraft --classic'
     fi
+    if [ "${ARCH}" == "amd64" ] && [ "${CHANNEL}" == "stable" ]; then
+        juju ssh -m "${juju_full_model}" --pty=true $JUJU_UNIT -- 'sudo apt install nvidia-headless-535-server nvidia-utils-535-server -y'
+    fi
 
     case $CHANNEL in
         beta)


### PR DESCRIPTION
We update the microk8s builds to include 1.31.

We also install the nvidia gpu drivers because the operator is not able to build and load them on the specific AWS instance we get from juju.