### PR TITLE
Simplify the EKS job so you don't have type in the version information 5 times

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -83,7 +83,7 @@
             Source tag from https://github.com/kubernetes/kubernetes.
       - string:
           name: channels
-          default: '{version}/edge,{version}/beta,{version}/candidate'
+          default: 'edge,beta,candidate,stable'
           description: |
             Comma separated snap store channels to release the built snaps to.
       - bool:

--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -2,6 +2,7 @@
 
 def kube_version = params.k8s_tag
 def kube_ersion = kube_version.substring(1)
+def channels = params.channels.tokenize(',').collect { kube_ersion + '/' + it }.join(',')
 def lxc_name = env.JOB_NAME+"-"+env.BUILD_NUMBER
 def _find_eks_base(version, override){
     if (override.length())
@@ -127,7 +128,7 @@ pipeline {
             steps {
                 script {
                     if(params.dry_run) {
-                        echo "Dry run; would have uploaded snaps to ${params.channels}"
+                        echo "Dry run; would have uploaded snaps to ${channels}"
                     } else {
                         sh """
                             BUILD_ARCH=\$(dpkg --print-architecture)
@@ -140,7 +141,7 @@ pipeline {
 
                                 echo "Uploading \${BUILT_SNAP}."
                                 sudo lxc shell ${lxc_name} -- bash -c \
-                                    "snapcraft -v upload /\${EKS_SNAP}/\${BUILT_SNAP} --release ${params.channels}"
+                                    "snapcraft -v upload /\${EKS_SNAP}/\${BUILT_SNAP} --release ${channels}"
                             done
                             sudo lxc shell ${lxc_name} -- bash -c "snapcraft logout"
                         """


### PR DESCRIPTION
### Overview

Simplifies running the eks snap builds

### Details
rather than running the job where you set the parameters
* k8s_tag=v1.31.1
* channels=1.31.1/edge,1.31.1/candidate,1.31.1/beta,1.31.1/stable

Now running the job where you set the parameters
* k8s_tag=v1.31.1
* channels=edge,candidate,beta,stable
---

* include all snap risks rather than just edge,beta,candidate
* build the snap channel list using some groovy split, amend, join magic 🪄 