### PR TITLE
Parameterize cloud to run validation-upgrade job

### DIFF
--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -117,6 +117,11 @@
       - snap-beta  # this value represents the snap channel after the upgrade
       - lxc-runner-params
       - juju-lts
+      - string:
+          name: cloud
+          description: "The cloud to use in validation"
+          default: "vsphere/Boston"
+          trim: true
     axes:
       - axis:
           type: slave  # wokeignore:rule=slave
@@ -146,4 +151,4 @@
           JOB_SPEC_DIR: "jobs/release"
       - run-lxc:
           COMMAND: |
-            bash jobs/release/release-upgrade-spec $snap_version $deploy_snap $series
+            bash jobs/release/release-upgrade-spec $snap_version $deploy_snap $series $cloud

--- a/jobs/release/release-upgrade-spec
+++ b/jobs/release/release-upgrade-spec
@@ -46,9 +46,9 @@ export SNAP_CHANNEL_UPGRADE_TO=${1:-1.27/beta}
 
 SNAP_VERSION=${2:-1.26/stable}
 SERIES=${3:-focal}
+JUJU_CLOUD=${4:-vsphere/Boston}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=stable
-JUJU_CLOUD=vsphere/Boston
 JUJU_CONTROLLER=validate-$(identifier::short)
 JUJU_MODEL=validate-release-upgrade
 ARCH=amd64


### PR DESCRIPTION
### Overview

Jenkins job `validate-charm-release-upgrade` updated to accept a parameter detailing which cloud to tests with

### Details
* jenkins job gets a new string parameter defaulted to vsphere/Boston
* Use of this `cloud` parameter when calling the spec
* updates the spec script to use a 4th parameter -- which cloud to use