### PR TITLE
1.31 stable work: adjust enums, start building 1.32

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -8,7 +8,7 @@ JOBS_PATH = Path("jobs")
 # Current supported STABLE K8s MAJOR.MINOR release. This determines what the
 # latest/stable channel is set to. It should be updated whenever a new CK
 # major.minor is GA.
-K8S_STABLE_VERSION = "1.30"
+K8S_STABLE_VERSION = "1.31"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
@@ -84,6 +84,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.29", ["1.29/stable", "1.29/candidate", "1.29/beta", "1.29/edge"]),
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
+    ("1.32", ["1.32/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 
@@ -105,6 +106,7 @@ DEB_K8S_TRACK_MAP = {
     "1.29": "ppa:k8s-maintainers/1.29",
     "1.30": "ppa:k8s-maintainers/1.30",
     "1.31": "ppa:k8s-maintainers/1.31",
+    "1.32": "ppa:k8s-maintainers/1.32",
 }
 
 


### PR DESCRIPTION
Set enums for 1.31 being the new stable release and enable 1.32/edge.

charms will automatically create 1.32 tracks

-----------
According to Release step from:
https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#confirm-snap-promotion-from-1xxrisk-to-latestrisk