### PR TITLE
Update snapcraft go version based on changes to upstream's `.go-version`

### DIFF
--- a/cilib/git.py
+++ b/cilib/git.py
@@ -69,6 +69,13 @@ def add(files, **subprocess_kwargs):
         run(["git", "add", fn], **subprocess_kwargs)
 
 
+def diff(**subprocess_kwargs):
+    """Diff git repo"""
+    cmd = ["git", "diff", "--name-only"]
+    output = run(cmd, capture_output=True, text=True, **subprocess_kwargs)
+    return [line for line in output.stdout.splitlines()]
+
+
 def commit(message, **subprocess_kwargs):
     """Add commit to repo"""
     run(["git", "config", "user.email", "cdkbot@gmail.com"], **subprocess_kwargs)

--- a/cilib/models/repos/__init__.py
+++ b/cilib/models/repos/__init__.py
@@ -25,7 +25,7 @@ class BaseRepoModel:
         if "git.launchpad.net" in parsed.netloc:
             """
             Launchpad supports viewing files directly from the web interface
-            for example)
+            for example:
                 repo: git+ssh://k8s-team-ci@git.launchpad.net/snap-kube-apiserver
                 branch: v1.28.13
                 file: /snapcraft.yaml

--- a/cilib/models/repos/kubernetes.py
+++ b/cilib/models/repos/kubernetes.py
@@ -14,6 +14,7 @@ class InternalKubernetesRepoModel(BaseRepoModel):
         self.name = "k8s-internal-mirror"
         self.git_user = "k8s-team-ci"
         self.repo = f"git+ssh://{self.git_user}@git.launchpad.net/{self.name}"
+        self.source = UpstreamKubernetesRepoModel()
 
 
 class CriToolsUpstreamRepoModel(BaseRepoModel):

--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -41,6 +41,48 @@ class SnapService(DebugMixin):
         )
         return list(set(upstream_tags) - set(snap_branches))
 
+    def template_snapcraft_yml(
+        self,
+        src_path: Path,
+        branch: str,
+        k8s_version: semver.Version,
+        commit_msg: str = "Creating branch",
+    ):
+        snapcraft_fn = src_path / "snapcraft.yaml"
+        snapcraft_fn_tpl = src_path / "snapcraft.yaml.in"
+        snapcraft_yml_context = {
+            "snap_version": branch.lstrip("v"),
+            "patches": [],
+            "go_version": self.go_version(k8s_version),
+        }
+
+        if k8s_version.compare("1.27.0-alpha.0") >= 0:
+            snapcraft_yml_context["base"] = "core20"
+        elif k8s_version.compare("1.19.0") >= 0:
+            snapcraft_yml_context["base"] = "core18"
+
+        self.log(f"Writing template vars {snapcraft_yml_context}")
+        snapcraft_yml = snapcraft_fn_tpl.read_text()
+        snapcraft_yml = self.render(snapcraft_fn_tpl, snapcraft_yml_context)
+        snapcraft_fn.write_text(snapcraft_yml)
+
+        if self.snap_model.base.diff(cwd=str(src_path)):
+            self.log(f"Committing {branch}")
+            self.snap_model.base.add([str(snapcraft_fn)], cwd=str(src_path))
+            self.snap_model.base.commit(f"{commit_msg} {branch}", cwd=str(src_path))
+            self.snap_model.base.push(ref=branch, cwd=str(src_path))
+
+    def go_version(self, k8s_version: semver.Version):
+        """Determines the go version to use for a given k8s version"""
+        k8s_major_minor = f"{k8s_version.major}.{k8s_version.minor}"
+        default = enums.K8S_GO_MAP[k8s_major_minor]
+        try:
+            go_ver = self.upstream_model.source.cat(f"v{k8s_version}", "/.go-version")
+        except FileNotFoundError:
+            return default
+        go_parsed = semver.VersionInfo.parse(go_ver)
+        return f"go/{go_parsed.major}.{go_parsed.minor}/stable"
+
     def sync_from_upstream(self):
         """Syncs branches from upstream tags"""
         if not self.missing_branches:
@@ -49,47 +91,22 @@ class SnapService(DebugMixin):
 
         for branch in self.missing_branches:
             self.log(f"Processing branch {branch}")
+            k8s_version = semver.VersionInfo.parse(branch.lstrip("v"))
+            k8s_major_minor = f"{k8s_version.major}.{k8s_version.minor}"
+
+            if k8s_major_minor not in enums.K8S_GO_MAP:
+                self.log(
+                    f"Skipping {k8s_version} because {k8s_major_minor} isn't in K8S_GO_MAP"
+                )
+                continue
+
             with tempfile.TemporaryDirectory() as tmpdir:
                 src_path = Path(tmpdir) / self.snap_model.src
                 self.snap_model.base.clone(cwd=tmpdir)
                 self.snap_model.base.checkout(
                     branch, new_branch=True, cwd=str(src_path)
                 )
-
-                snapcraft_fn = src_path / "snapcraft.yaml"
-                snapcraft_fn_tpl = src_path / "snapcraft.yaml.in"
-
-                k8s_version = semver.VersionInfo.parse(branch.lstrip("v"))
-                k8s_major_minor = f"{k8s_version.major}.{k8s_version.minor}"
-
-                if k8s_major_minor not in enums.K8S_GO_MAP:
-                    self.log(
-                        f"Skipping {k8s_version} because {k8s_major_minor} isn't in K8S_GO_MAP"
-                    )
-                    continue
-
-                snapcraft_yml_context = {
-                    "snap_version": branch.lstrip("v"),
-                    "patches": [],
-                    "go_version": enums.K8S_GO_MAP[k8s_major_minor],
-                }
-
-                if k8s_version.compare("1.27.0-alpha.0") >= 0:
-                    snapcraft_yml_context["base"] = "core20"
-                elif k8s_version.compare("1.19.0") >= 0:
-                    snapcraft_yml_context["base"] = "core18"
-
-                self.log(f"Writing template vars {snapcraft_yml_context}")
-                snapcraft_yml = snapcraft_fn_tpl.read_text()
-                snapcraft_yml = self.render(snapcraft_fn_tpl, snapcraft_yml_context)
-                snapcraft_fn.write_text(snapcraft_yml)
-
-                self.log(f"Committing {branch}")
-                self.snap_model.base.add([str(snapcraft_fn)], cwd=str(src_path))
-                self.snap_model.base.commit(
-                    f"Creating branch {branch}", cwd=str(src_path)
-                )
-                self.snap_model.base.push(ref=branch, cwd=str(src_path))
+                self.template_snapcraft_yml(src_path, branch, k8s_version)
 
     def sync_stable_track_snaps(self):
         """Keeps current stable version snap builds in sync with latest track"""
@@ -155,6 +172,30 @@ class SnapService(DebugMixin):
                 )
                 if not latest_branch_version:
                     self.log(f"Found no stable branches ({_version}), skipping.")
+                    continue
+
+            # Go versions within a single track can update over time
+            # just because 1.28.0 builds with go/1.20, 1.28.13 may use go/1.22
+            # so we need to confirm this branch is using the correct go version
+            # and trigger new builds if it changes.
+            branch = f"v{latest_branch_version}"
+            branch_ver = semver.VersionInfo.parse(latest_branch_version)
+            if content := self.snap_model.base.cat(branch, "/snapcraft.yaml"):
+                go_version = self.go_version(branch_ver)
+                if go_version not in content:
+                    self.log(
+                        f"Go version mismatch for {branch}, updating snapcraft.yaml"
+                    )
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        branch = f"v{latest_branch_version}"
+                        src_path = Path(tmpdir) / self.snap_model.src
+                        self.snap_model.base.clone(cwd=tmpdir)
+                        self.snap_model.base.checkout(branch, cwd=str(src_path))
+                        self.template_snapcraft_yml(
+                            src_path, branch, branch_ver, commit_msg="Update Snapcraft"
+                        )
+                    self.log("Go version changed to {go_version}, building new snap")
+                    self._create_recipe(_version, branch)
                     continue
 
             for arch in enums.K8S_SUPPORT_ARCHES:


### PR DESCRIPTION
### Overview
Build snaps according to a rolling upstream go-version

### Details
Upstream https://github.com/kubernetes/kubernetes began to embed the required go-version for a specific branch or tag using the `.go-version` file.  It's recommended to use this version of go to build the snaps. 

Charmed Kubernetes has been keeping an internal map which can get stale -- rather than change it -- we can continue to use it if the supported branch doesn't contain the .go-version file.  

* the sync-snaps job will now confirm the correct go-version in the snapcraft yaml is used.  