### PR TITLE
Provide an override on the go version for eks snaps

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -77,6 +77,12 @@
           description: |
             Snap base to use as an override while building snaps
       - string:
+          name: eks_go_override
+          default: ''
+          description: |
+            Snap go version to use as an override while building snaps
+            MUST be in format 'go/\d+\.\d+/stable'
+      - string:
           name: k8s_tag
           default: 'v{version}'
           description: |

--- a/jobs/build-snaps/build-release-eks-snaps.groovy
+++ b/jobs/build-snaps/build-release-eks-snaps.groovy
@@ -14,6 +14,7 @@ def _find_eks_base(version, override){
 }
 def eks_base_override = params.eks_base_override
 def EKS_BASE = _find_eks_base(kube_version, eks_base_override)
+def GO_VERSION = params.eks_go_override
 
 pipeline {
     agent {
@@ -67,6 +68,11 @@ pipeline {
                         sed -i -e "s/^name: \${snap}/name: \${EKS_SNAP}/" \
                                -e "s/^base: .*/base: ${EKS_BASE}/" \
                                -e "s/install-mode: .*/install-mode: disable/" snapcraft.yaml
+
+                        # update the go version if overriden
+                        if [ -n "${GO_VERSION}" ]; then
+                            sed -i -e "s#go/.*#${GO_VERSION}#g" snapcraft.yaml
+                        fi
 
                         # if we don't have any base defined at this point, add one
                         grep -q "^base: " snapcraft.yaml || echo "base: ${EKS_BASE}" >> snapcraft.yaml


### PR DESCRIPTION
### Overview
* Supply the go-version to override the definition in the snapcraft.yaml

### Details
#1580 identified situations where the correct go version wasn't present when building the k8s snaps
This presents itself as a failed build of the eks snaps in certain cases. 

Rather than change many branches, providing an override when building seemed like a saner option.