### PR TITLE
Ensure go version 1.21 in microk8s capi release

### DIFF
--- a/jobs/microk8s/clusterapi/release.sh
+++ b/jobs/microk8s/clusterapi/release.sh
@@ -56,7 +56,15 @@ then
 
     echo "Run unit tests"
 
-    sudo snap install go --channel 1.19 || sudo snap refresh go --channel 1.19
+    # Check if Go is installed
+    if ! command -v go &> /dev/null; then
+        echo "Go is not installed. Installing Go..."
+        sudo snap install go --classic --channel 1.21
+    else
+        echo "Go is already installed. Refreshing Go..."
+        sudo snap refresh go --channel 1.21
+    fi
+
     (
         cd bootstrap
         make vet


### PR DESCRIPTION
---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
