### PR TITLE
Track repo differences with git status rather than git diff

### DIFF
--- a/cilib/git.py
+++ b/cilib/git.py
@@ -5,6 +5,7 @@ import logging
 import sh
 import re
 from subprocess import run
+from typing import Dict
 from .github_api import Repository
 import requests
 import requests.auth
@@ -69,11 +70,18 @@ def add(files, **subprocess_kwargs):
         run(["git", "add", fn], **subprocess_kwargs)
 
 
-def diff(**subprocess_kwargs):
-    """Diff git repo"""
-    cmd = ["git", "diff", "--name-only"]
+def status(**subprocess_kwargs) -> Dict[str, str]:
+    """Show any uncommitted files in a git repo.
+
+    Returns:
+        Dict[str, str]: A dictionary of uncommitted files and their status.
+
+        key values are the file names and the values are the status of the file.
+        https://git-scm.com/docs/git-status
+    """
+    cmd = ["git", "status", "--porcelain"]
     output = run(cmd, capture_output=True, text=True, **subprocess_kwargs)
-    return [line for line in output.stdout.splitlines()]
+    return dict(reversed(line.split(maxsplit=1)) for line in output.stdout.splitlines())
 
 
 def commit(message, **subprocess_kwargs):

--- a/cilib/models/repos/__init__.py
+++ b/cilib/models/repos/__init__.py
@@ -69,9 +69,9 @@ class BaseRepoModel(log.DebugMixin):
         """Add files to git repo"""
         git.add(files, **subprocess_kwargs)
 
-    def diff(self, **subprocess_kwargs):
+    def status(self, **subprocess_kwargs):
         """Diff git repo"""
-        return git.diff(**subprocess_kwargs)
+        return git.status(**subprocess_kwargs)
 
     @sham
     def push(self, origin="origin", ref="master", **subprocess_kwargs):

--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -66,7 +66,7 @@ class SnapService(DebugMixin):
         snapcraft_yml = self.render(snapcraft_fn_tpl, snapcraft_yml_context)
         snapcraft_fn.write_text(snapcraft_yml)
 
-        if self.snap_model.base.diff(cwd=str(src_path)):
+        if self.snap_model.base.status(cwd=str(src_path)):
             self.log(f"Committing {branch}")
             self.snap_model.base.add([str(snapcraft_fn)], cwd=str(src_path))
             self.snap_model.base.commit(f"{commit_msg} {branch}", cwd=str(src_path))


### PR DESCRIPTION
### Details
When new patch releases of upstream kubernetes are published as tags, we store new branches internally on launchpad, each with it's own `snapcraft.yaml` to build the various snaps. 

https://github.com/charmed-kubernetes/jenkins/pull/1580 introduced a change to only push these new branches when a difference was detected.  However using `git diff` on a branch where the only change is a new file results in an empty set of CHANGED files.  

Switching to git status shows the new files:

example)
```sh
⚡ git diff
⚡ git status
On branch v1.29.10
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	snapcraft.yaml

nothing added to commit but untracked files present (use "git add" to track)
⚡ git status --porcelain                                                                       
?? snapcraft.yaml
```

### Details
* adjust the check from git diff to git status which returns a list of changed files and how they were changed