### PR TITLE
Update enums for 1.32 GA

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -85,7 +85,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.29", ["1.29/stable", "1.29/candidate", "1.29/beta", "1.29/edge"]),
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
-    ("1.32", ["1.32/beta", "1.32/edge"]),
+    ("1.32", ["1.32/stable", "1.32/candidate", "1.32/beta", "1.32/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 


### PR DESCRIPTION
Populate 1.32 stable snap pockets.

As described here: https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#stable-release-1