### PR TITLE
Ensure tests are run from 1.32/edge charms and snaps

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -141,7 +141,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.31/beta
+          default: 1.32/beta
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -149,7 +149,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.31/edge
+          default: 1.32/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -21,7 +21,7 @@
       - juju-lts
       - string:
           name: CK_VERSION
-          default: '1.31'
+          default: '1.32'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.31'
+          default: '1.32'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,9 +73,9 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.32/edge
             - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
       - stable:
           snap_versions:
             - 1.30/stable
@@ -117,9 +117,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
       - axis:
           type: user-defined
           name: series
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
       - axis:
           type: user-defined
           name: cloud
@@ -426,8 +426,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -469,8 +469,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -510,8 +510,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -551,8 +551,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -592,8 +592,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -633,8 +633,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
-            - 1.30/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -674,9 +674,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.32/edge
             - 1.31/edge
             - 1.30/edge
-            - 1.29/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"


### PR DESCRIPTION
Ensure tests run with 1.32/edge for charms and snaps where appropriate. Updates validate jobs and sync-oci-image to sync 1.32 images

As described in: https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#stable-release-1

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge
