### PR TITLE
docs: Improve release instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ site/
 /*.json
 /*.log
 jobs/reports/_build
+jobs/jjb-config.ini
 reports/_build
 *.db
 report.*

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ site/
 /*.json
 /*.log
 jobs/reports/_build
-jobs/jjb-config.ini
 reports/_build
 *.db
 report.*

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -54,6 +54,7 @@ This file should be located in `jobs/jjb-conf.ini` and **not** checked into the 
 Then, execute:
 
 ```sh
+# wokeignore:rule=master
 tox -e py -- jenkins-jobs --conf jobs/jjb-conf.ini update jobs/ci-master.yaml:jobs/*.yaml
 ```
 
@@ -80,6 +81,11 @@ for the charms/snaps as defined in the [charm-support-matrix](https://github.com
 ### Bump cdk-addons version
 
 In [cdk-addons](https://github.com/charmed-kubernetes/cdk-addons) create a new release branch 1.xx and update the make file similar to [this PR](https://github.com/charmed-kubernetes/cdk-addons/commit/9352559d5e1822b897745b6c254c31ac0e616e33)
+
+
+### Bump cdk-addons build jobs
+
+In [build-snaps.yaml](../../../jobs/build-snaps.yaml) update the `build-release-snaps` job definition to add `1.xx` and remove `1.xx-4`. 
 
 ### Add release images to containers-image sync list
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -34,25 +34,6 @@ Solutions QA period, fixes which need to be applied to address CI or QA failures
 
 ## Prepare CI
 
-### $stable++ release
-
-It may feel early, but part of releasing the next stable version requires
-preparing for the release that will follow. This requires opening tracks and
-building relevant snaps and charms that will be used in the new `edge` channel.
-
-For example, we requested 1.31 snap tracks while preparing for the 1.30 release:
-
-- https://forum.snapcraft.io/t/charmed-kubernetes-1-31-snap-tracks/39824
-
-Bundle/charm track requests are made by posting to the `charmhub requests` forum
-asking for new tracks to be opened for every necessary
-[charm](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-support-matrix.inc)
-and
-[bundle](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-bundles-list.inc)
-owned by `Canonical Kubernetes`. For example:
-
-- https://discourse.charmhub.io/t/request-new-1-30-track-for-all-charmed-k8s-charms-and-bundles/13394
-
 ### $stable release
 
 Once upstream has an RC for the upcoming release, our CI should stop
@@ -68,6 +49,14 @@ tests for our 1.29 release:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/1463
 
+You now need to tell Jenkins that the jobs changed. First, get the `jjb-config.ini` from the Kubernetes BitWarden.
+This file should be located in `jobs/jjb-conf.ini` and **not** checked into the repo.
+Then, execute:
+
+```sh
+tox -e py -- jenkins-jobs --conf jobs/jjb-conf.ini update jobs/ci-master.yaml:jobs/*.yaml
+```
+
 ## Preparing the release
 
 ### Create release branches for all repos
@@ -77,6 +66,24 @@ tests for our 1.29 release:
 We need to create `release_1.xx` branches from `main` for all
 Charmed Kubernetes repositories. This will be our snapshot
 from which we test, fix, and subsequently promote to the new release.
+
+### Create tracks for charms/snaps
+
+We do have guard-rails defined for the charms and snaps, so we don't need to request tracks anymore.
+However, we still need to manually create the tracks.
+For that, execute
+
+https://github.com/charmed-kubernetes/jenkins/blob/main/bin/ensure_track --kind <charm|snap> --name <entity-name> --track <track to create, e.g. 1.32>
+
+for the charms/snaps as defined in the [charm-support-matrix](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-support-matrix.inc)
+
+### Bump cdk-addons version
+
+In [cdk-addons](https://github.com/charmed-kubernetes/cdk-addons) create a new release branch 1.xx and update the make file similar to [this PR](https://github.com/charmed-kubernetes/cdk-addons/commit/9352559d5e1822b897745b6c254c31ac0e616e33)
+
+### Add release images to containers-image sync list
+
+In the [bundle](https://github.com/charmed-kubernetes/bundle) repository, add a new line for the static container list similar to [this PR](https://github.com/charmed-kubernetes/bundle/commit/fcdcc54177f2514216d5aa8fb6fa3cb1ef13ebfe)
 
 ### Pin snap channel for charms in the release branches
 
@@ -120,7 +127,7 @@ published to the `1.xx/beta` channel in Charmhub based on the job options.
 
 **Job**: https://jenkins.canonical.com/k8s-ps5/job/promote-charms/
 
-In preparation for running the **validate-charm-release-upgrade** job, 
+In preparation for running the **validate-charm-release-upgrade** job,
 the charms must be promoted from `1.xx/beta` to `latest/beta` channels.
 
 > **Note**: This job must be run again if any charm needed by this release
@@ -156,6 +163,9 @@ run on multiple series and with multiple snap channels.
 
 Before running this job, confirm that the `snap_version` job parameter is set to the
 appropriate channel for this release (e.g. 1.29/beta).
+
+A successful Jenkins job run only confirms that the tests were started, **not** that they passed.
+Check [Jenkaas](http://jenkaas.s3-website-us-east-1.amazonaws.com/) to ensure all tests completed successfully.
 
 ### Notify Solutions QA
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -74,7 +74,7 @@ We do have guard-rails defined for the charms and snaps, so we don't need to req
 However, we still need to manually create the tracks.
 For that, execute
 
-https://github.com/charmed-kubernetes/jenkins/blob/main/bin/ensure_track --kind <charm|snap> --name <entity-name> --track <track to create, e.g. 1.32>
+https://github.com/charmed-kubernetes/jenkins/blob/main/bin/ensure_track --kind <charm|snap> --name <charm/snap-name> --track <track to create, e.g. 1.32>
 
 for the charms/snaps as defined in the [charm-support-matrix](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/includes/charm-support-matrix.inc)
 
@@ -82,14 +82,15 @@ for the charms/snaps as defined in the [charm-support-matrix](https://github.com
 
 In [cdk-addons](https://github.com/charmed-kubernetes/cdk-addons) create a new release branch named after your release, e.g. `release-1.XX` and update the make file similar to [this PR](https://github.com/charmed-kubernetes/cdk-addons/commit/9352559d5e1822b897745b6c254c31ac0e616e33)
 
-
 ### Bump cdk-addons build jobs
 
 In [build-snaps.yaml](../../../jobs/build-snaps.yaml) update the `build-release-snaps` job definition to add `1.xx` and remove `1.xx-4`. See e.g. [this PR](https://github.com/charmed-kubernetes/jenkins/pull/1610)
 
 ### Add release images to containers-image sync list
 
-In the [bundle](https://github.com/charmed-kubernetes/bundle) repository, add a new line for the static container list similar to [this PR](https://github.com/charmed-kubernetes/bundle/commit/fcdcc54177f2514216d5aa8fb6fa3cb1ef13ebfe)
+In the [bundle](https://github.com/charmed-kubernetes/bundle) repository, add a new line for the static container list similar to [this PR](https://github.com/charmed-kubernetes/bundle/commit/fcdcc54177f2514216d5aa8fb6fa3cb1ef13ebfe).
+This is required for [this job](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/build-snaps/build-release-cdk-addons.groovy#L158) to build the cdk-addons and [this job](https://github.com/charmed-kubernetes/jenkins/blob/main/jobs/sync-oci-images/sync-oci-images.groovy#L266) to copy images from upstream to rocks.cc.
+This `-static` field gives these to jobs an indication of some base set of static images we wish to copy from upstream to rocks.cc and to reference when building cdk-addons.
 
 ### Pin snap channel for charms in the release branches
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -80,12 +80,12 @@ for the charms/snaps as defined in the [charm-support-matrix](https://github.com
 
 ### Bump cdk-addons version
 
-In [cdk-addons](https://github.com/charmed-kubernetes/cdk-addons) create a new release branch 1.xx and update the make file similar to [this PR](https://github.com/charmed-kubernetes/cdk-addons/commit/9352559d5e1822b897745b6c254c31ac0e616e33)
+In [cdk-addons](https://github.com/charmed-kubernetes/cdk-addons) create a new release branch named after your release, e.g. `release-1.XX` and update the make file similar to [this PR](https://github.com/charmed-kubernetes/cdk-addons/commit/9352559d5e1822b897745b6c254c31ac0e616e33)
 
 
 ### Bump cdk-addons build jobs
 
-In [build-snaps.yaml](../../../jobs/build-snaps.yaml) update the `build-release-snaps` job definition to add `1.xx` and remove `1.xx-4`. 
+In [build-snaps.yaml](../../../jobs/build-snaps.yaml) update the `build-release-snaps` job definition to add `1.xx` and remove `1.xx-4`. See e.g. [this PR](https://github.com/charmed-kubernetes/jenkins/pull/1610)
 
 ### Add release images to containers-image sync list
 
@@ -172,6 +172,7 @@ appropriate channel for this release (e.g. 1.29/beta).
 
 A successful Jenkins job run only confirms that the tests were started, **not** that they passed.
 Check [Jenkaas](http://jenkaas.s3-website-us-east-1.amazonaws.com/) to ensure all tests completed successfully.
+Each column represents a day. Look for the day you triggered the release tests and check if all validation tests passed in that column.
 
 ### Notify Solutions QA
 

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -103,7 +103,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.28', '1.29', '1.30', '1.31']
+    version: ['1.29', '1.30', '1.31', '1.32']
     jobs:
       - 'build-release-cdk-addons-{version}'
 

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -138,8 +138,8 @@
           type: user-defined
           name: deploy_snap
           values:
+            - 1.31/stable
             - 1.30/stable
-            - 1.29/stable
       - axis:
           type: user-defined
           name: series


### PR DESCRIPTION
Filling gaps in the manual as identified in the 1.32 release.

