### PR TITLE
chore: Update k8s version to 1.32/stable

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -86,7 +86,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
     ("1.32", ["1.32/stable", "1.32/candidate", "1.32/beta", "1.32/edge"]),
-    ("1.33", ["1.33/edge"])
+    ("1.33", ["1.33/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -8,7 +8,7 @@ JOBS_PATH = Path("jobs")
 # Current supported STABLE K8s MAJOR.MINOR release. This determines what the
 # latest/stable channel is set to. It should be updated whenever a new CK
 # major.minor is GA.
-K8S_STABLE_VERSION = "1.31"
+K8S_STABLE_VERSION = "1.32"
 
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
@@ -20,7 +20,7 @@ K8S_STABLE_VERSION = "1.31"
 K8S_NEXT_VERSION = "1.33"
 
 # Lowest K8S SEMVER to process, this is usually K8S_STABLE_VERSION - 4
-K8S_STARTING_SEMVER = "1.27.0"
+K8S_STARTING_SEMVER = "1.28.0"
 
 # Supported arches
 K8S_SUPPORT_ARCHES = ["amd64", "ppc64el", "s390x", "arm64"]
@@ -86,6 +86,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
     ("1.32", ["1.32/stable", "1.32/candidate", "1.32/beta", "1.32/edge"]),
+    ("1.33", ["1.33/edge"])
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 
@@ -108,6 +109,7 @@ DEB_K8S_TRACK_MAP = {
     "1.30": "ppa:k8s-maintainers/1.30",
     "1.31": "ppa:k8s-maintainers/1.31",
     "1.32": "ppa:k8s-maintainers/1.32",
+    "1.33": "ppa:k8s-maintainers/1.33",
 }
 
 

--- a/cilib/models/repos/__init__.py
+++ b/cilib/models/repos/__init__.py
@@ -36,7 +36,7 @@ class BaseRepoModel(log.DebugMixin):
         elif "github.com" in parsed.netloc:
             """
             Github supports viewing files directly from the web interface
-            https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.31.0/.go-version
+            https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.0/.go-version
             """
             full_path = Path("/") / path
             url = f"https://raw.githubusercontent.com{parsed.path}/refs/tags/{branch}{full_path}"

--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -103,7 +103,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.29', '1.30', '1.31', '1.32']
+    version: ['1.30', '1.31', '1.32', '1.33']
     jobs:
       - 'build-release-cdk-addons-{version}'
 

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -117,7 +117,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.31/stable
+          default: 1.32/stable
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -133,7 +133,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.31/stable
+          default: 1.32/stable
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -66,7 +66,7 @@
       - string:
           name: charm_channel
           description: "The charm channel to validate"
-          default: "1.31/candidate"
+          default: "1.32/candidate"
           trim: true
       - string:
           name: cloud
@@ -138,8 +138,8 @@
           type: user-defined
           name: deploy_snap
           values:
+            - 1.32/stable
             - 1.31/stable
-            - 1.30/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -78,9 +78,9 @@
             - 1.30/edge
       - stable:
           snap_versions:
+            - 1.32/stable
             - 1.31/stable
             - 1.30/stable
-            - 1.29/stable
           dow: '0'      # Sunday
     jobs:
       - 'validate-ck-{charm-channel}-{series}'


### PR DESCRIPTION
### Overview
This PR bumps K8s version to 1.32, adds 1.33 and removes older versions where necessary according to the ["Confirm snap promotion"](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#confirm-snap-promotion-from-1xxrisk-to-latestrisk) step.