### PR TITLE
Stop testing Charmed Kubernetes against focal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.10"
           - "3.12"
     steps:

--- a/bin/report
+++ b/bin/report
@@ -27,7 +27,7 @@ bucket = s3.Bucket("jenkaas")
 
 OBJECTS = bucket.objects.all()
 
-SERIES = ["focal", "bionic", "xenial"]
+SERIES = ["noble", "jammy"]
 
 REPORT_HOST = "https://jenkaas.s3.amazonaws.com"
 

--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -641,6 +641,7 @@ class Series(Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
+    NOBLE = "24.04"
 
     @classmethod
     def from_value(cls, value: str) -> "Series":

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -116,7 +116,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-easyrsa.git'
 - etcd:
-    builder: launchpad
+    builder: local
     bugs: 'https://bugs.launchpad.net/charm-etcd'
     docs: 'https://charmhub.io/etcd/docs'
     downstream: charmed-kubernetes/layer-etcd.git
@@ -455,7 +455,7 @@
     channel-range:
       min: '1.27'
 - openstack-integrator:
-    builder: launchpad
+    builder: local
     bugs: 'https://bugs.launchpad.net/charm-openstack-integrator'
     docs: 'https://charmhub.io/openstack-integrator/docs'
     downstream: charmed-kubernetes/charm-openstack-integrator

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -116,7 +116,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-easyrsa.git'
 - etcd:
-    builder: local
+    builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-etcd'
     docs: 'https://charmhub.io/etcd/docs'
     downstream: charmed-kubernetes/layer-etcd.git
@@ -455,7 +455,7 @@
     channel-range:
       min: '1.27'
 - openstack-integrator:
-    builder: local
+    builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-openstack-integrator'
     docs: 'https://charmhub.io/openstack-integrator/docs'
     downstream: charmed-kubernetes/charm-openstack-integrator

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -51,7 +51,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--series",
         action="store",
-        default=os.environ.get("SERIES", "focal"),
+        default=os.environ.get("SERIES", "jammy"),
         help="Base series",
     )
     parser.addoption("--cloud", action="store", help="Juju cloud to use")

--- a/jobs/integration/templates/validate-dns-spec.yaml
+++ b/jobs/integration/templates/validate-dns-spec.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: rocks.canonical.com/cdk/ubuntu:focal
+      image: rocks.canonical.com/cdk/ubuntu:jammy
       imagePullPolicy: IfNotPresent
       command: ['sh', '-c', 'apt update -qqy && apt install -qqfy bind9-host && echo "validate-dns: Ready" && sleep 3600 || echo "validate-dns: Failed"']
   restartPolicy: Never

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -28,11 +28,7 @@ import click
 
 
 # note: we can't upgrade to focal until after it's released
-SERIES_ORDER = [
-    "bionic",
-    "focal",
-    "jammy",
-]
+SERIES_ORDER = ["bionic", "focal", "jammy", "noble"]
 
 
 def tracefunc(frame, event, arg):

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -37,7 +37,6 @@
           type: user-defined
           name: series
           values:
-            - focal
             - jammy
     builders:
       - set-env:
@@ -89,7 +88,6 @@
           type: user-defined
           name: series
           values:
-            - focal
             - jammy
       - axis:
           type: user-defined
@@ -144,7 +142,6 @@
           type: user-defined
           name: series
           values:
-            - focal
             - jammy
       - axis:
           type: user-defined

--- a/jobs/release/bugfix-spec
+++ b/jobs/release/bugfix-spec
@@ -16,7 +16,7 @@ set -x
 # ENV
 ###############################################################################
 SNAP_VERSION=${1:-1.25/stable}
-SERIES=${2:-focal}
+SERIES=${2:-jammy}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=${3:-candidate}
 JUJU_CLOUD=aws/us-east-2

--- a/jobs/release/release-upgrade-spec
+++ b/jobs/release/release-upgrade-spec
@@ -45,7 +45,7 @@ export CHARM_CHANNEL_UPGRADE_TO=beta
 export SNAP_CHANNEL_UPGRADE_TO=${1:-1.27/beta}
 
 SNAP_VERSION=${2:-1.26/stable}
-SERIES=${3:-focal}
+SERIES=${3:-jammy}
 JUJU_CLOUD=${4:-vsphere/Boston}
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
 JUJU_DEPLOY_CHANNEL=stable

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -67,9 +67,6 @@
       - jammy:
           hour: '0' # Midnight
           dow: '1,3,5'  # MWF
-      - focal:
-          hour: '12' # Noon
-          dow: '2,4,6'  # TuThSa
     charm-channel:
       - edge:
           snap_versions:
@@ -124,7 +121,6 @@
           type: user-defined
           name: series
           values:
-            - focal
             - jammy
       - axis:
           type: user-defined

--- a/jobs/validate/integrator-spec
+++ b/jobs/validate/integrator-spec
@@ -46,7 +46,6 @@ applications:
     constraints: $constraints
     options:
       channel: $SNAP_VERSION
-      allow-privileged: 'true'
   kubernetes-worker:
     constraints: $constraints
     options:
@@ -67,6 +66,11 @@ EOF
   vsphere-cloud-provider:
     charm: vsphere-cloud-provider
     channel: $JUJU_DEPLOY_CHANNEL
+relations:
+- [vsphere-cloud-provider:certificates, easyrsa:client]
+- [vsphere-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+- [vsphere-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+- [vsphere-cloud-provider:vsphere-integration, vsphere-integrator:clients]
 EOF
     elif [ "$JUJU_CLOUD" = "aws/us-east-1" ]; then
       # Deploy aws
@@ -80,12 +84,12 @@ EOF
     charm: aws-cloud-provider
     channel: $JUJU_DEPLOY_CHANNEL
 relations:
-  - ['aws-integrator', 'kubernetes-control-plane:aws']
-  - ['aws-integrator', 'kubernetes-worker:aws']
-  - ['aws-cloud-provider:certificates', 'easyrsa:client']
-  - ['aws-cloud-provider:kube-control', 'kubernetes-control-plane:kube-control']
-  - ['aws-cloud-provider:aws-integration', 'aws-integrator:aws']
-  - ['aws-cloud-provider:external-cloud-provider', 'kubernetes-control-plane:external-cloud-provider']
+- [aws-integrator, kubernetes-control-plane:aws]
+- [aws-integrator, kubernetes-worker:aws]
+- [aws-integrator, aws-cloud-provider:aws-integration]
+- [aws-cloud-provider:certificates, easyrsa:client]
+- [aws-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+- [aws-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
 EOF
     elif [ "$JUJU_CLOUD" = "google/us-east1" ]; then
       # Deploy google
@@ -100,6 +104,13 @@ EOF
     channel: $JUJU_DEPLOY_CHANNEL
     options:
       enable-loadbalancers: true
+relations:
+- [gcp-integrator, kubernetes-control-plane:gcp]
+- [gcp-integrator, kubernetes-worker:gcp]
+- [gcp-integrator, gcp-cloud-provider:gcp-integration]
+- [gcp-cloud-provider:certificates, easyrsa:client]
+- [gcp-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+- [gcp-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
 EOF
     elif [ "$JUJU_CLOUD" = "azure/centralus" ]; then
       # Deploy azure
@@ -112,9 +123,16 @@ EOF
     channel: $JUJU_DEPLOY_CHANNEL
     num_units: 1
     trust: true
+  azure-cloud-provider
+    charm: azure-cloud-provider
+    channel: $JUJU_DEPLOY_CHANNEL
 relations:
-  - ['azure-integrator', 'kubernetes-control-plane:azure']
-  - ['azure-integrator', 'kubernetes-worker:azure']
+- [azure-integrator, kubernetes-control-plane:azure]
+- [azure-integrator, kubernetes-worker:azure]
+- [azure-integrator, azure-cloud-provider:azure-integration]
+- [azure-cloud-provider:certificates, easyrsa:client]
+- [azure-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+- [azure-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
 EOF
     else
       >&2 echo "Unspecified cloud"

--- a/tests/data/bundles/test-kubernetes/bundle.yaml
+++ b/tests/data/bundles/test-kubernetes/bundle.yaml
@@ -1,13 +1,13 @@
 name: test-kubernetes
 description: A minimal two-machine Kubernetes cluster, appropriate for development.
-series: focal
+series: jammy
 machines:
   '0':
     constraints: cores=2 mem=4G root-disk=16G
-    series: focal
+    series: jammy
   '1':
     constraints: cores=4 mem=4G root-disk=16G
-    series: focal
+    series: jammy
 applications:
   containerd:
     annotations:

--- a/tests/data/charms/k8s-ci-charm/metadata.yaml
+++ b/tests/data/charms/k8s-ci-charm/metadata.yaml
@@ -15,5 +15,5 @@ resources:
 tags:
 - k8s
 series:
-- focal
-- bionic
+- noble
+- jammy

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
 [testenv]
 deps =
      {[base]deps}
+     pip
      -r {toxinidir}/requirements.txt
 setenv =
     PYTHONPATH = PYTHONPATH:{toxinidir}


### PR DESCRIPTION
### Overview
No longer test charmed kubernetes against focal

### Details
* Ends testing on python38
* migrates default series from focal to jammy
* drops nightly testing of `focal` without yet adding `noble` testing

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge
