### PR TITLE
Stop testing Charmed Kubernetes against focal

### DIFF
--- a/jobs/build-charms/builder_local.py
+++ b/jobs/build-charms/builder_local.py
@@ -641,6 +641,7 @@ class Series(Enum):
     BIONIC = "18.04"
     FOCAL = "20.04"
     JAMMY = "22.04"
+    NOBLE = "24.04"
 
     @classmethod
     def from_value(cls, value: str) -> "Series":

--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -116,7 +116,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-easyrsa.git'
 - etcd:
-    builder: local
+    builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-etcd'
     docs: 'https://charmhub.io/etcd/docs'
     downstream: charmed-kubernetes/layer-etcd.git
@@ -128,7 +128,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-etcd.git'
 - flannel:
-    builder: local
+    builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-flannel'
     build-resources: 'cd {out_path}; bash {src_path}/build-flannel-resources.sh'
     docs: 'https://charmhub.io/flannel/docs'
@@ -455,7 +455,7 @@
     channel-range:
       min: '1.27'
 - openstack-integrator:
-    builder: local
+    builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-openstack-integrator'
     docs: 'https://charmhub.io/openstack-integrator/docs'
     downstream: charmed-kubernetes/charm-openstack-integrator

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
 [testenv]
 deps =
      {[base]deps}
+     pip
      -r {toxinidir}/requirements.txt
 setenv =
     PYTHONPATH = PYTHONPATH:{toxinidir}


### PR DESCRIPTION
Switch charms from reactive build to launchpad build:

* flannel - https://github.com/charmed-kubernetes/charm-flannel/pull/92
* openstack-integrator - https://github.com/charmed-kubernetes/charm-openstack-integrator/pull/15
* etcd - https://github.com/charmed-kubernetes/layer-etcd/pull/216