### PR TITLE
Update tigera_aws.py

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -12,7 +12,7 @@ from subprocess import check_output, CalledProcessError
 
 VPC_CIDR = "172.30.0.0/16"
 SUBNET_CIDRS = ["172.30.0.0/24", "172.30.1.0/24"]
-REGION = os.environ.get("JUJU_CLOUD", "us-east-2").replace("aws/","")
+REGION = os.environ.get("JUJU_CLOUD", "us-east-2").replace("aws/", "")
 AVAILABILITY_ZONE = f"{REGION}a"
 OWNER = os.environ.get("JUJU_OWNER", "k8sci")
 

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -12,7 +12,7 @@ from subprocess import check_output, CalledProcessError
 
 VPC_CIDR = "172.30.0.0/16"
 SUBNET_CIDRS = ["172.30.0.0/24", "172.30.1.0/24"]
-REGION = os.environ.get("JUJU_CLOUD", "us-east-2")
+REGION = os.environ.get("JUJU_CLOUD", "us-east-2").replace("aws/","")
 AVAILABILITY_ZONE = f"{REGION}a"
 OWNER = os.environ.get("JUJU_OWNER", "k8sci")
 


### PR DESCRIPTION
Add .replace call to REGION. This is coupled to the cloud provider but I believe it's OK since the file is called _aws.py. Also, I did not change JUJU_CLOUD because aws/us-east-2 is valid for a JUJU_CLOUD.

I changed the REGION variable because aws/us-east-2 is not a valid region.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
