### PR TITLE
Update tigera_aws.py

### DIFF
--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -455,7 +455,7 @@ def deploy_bgp_router():
 
     log("Enabling secondary network interfaces")
     num_expected_nics = len(subnets)
-    nic_pattern = re.compile("^enp.+s0$")
+    nic_pattern = re.compile("^enp\d+s\d+$")
     nic_matches = set()
     max_retries, current_nics = 10, set()
     while not len(nic_matches) == num_expected_nics and max_retries:

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -452,7 +452,7 @@ def deploy_bgp_router():
     juju_wait(timeout=15 * 60)
 
     log("Enabling secondary network interfaces")
-    expected_nics = {f"enp{i + 39}" for i in range(0, len(subnets))}
+    expected_nics = {f"enp{i + 39}s0" for i in range(0, len(subnets))}
     max_retries, current_nics = 10, set()
     while not expected_nics.issubset(current_nics) and max_retries:
         time.sleep(10 - max_retries)

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -452,7 +452,7 @@ def deploy_bgp_router():
     juju_wait(timeout=15 * 60)
 
     log("Enabling secondary network interfaces")
-    expected_nics = {f"ens{i + 5}" for i in range(1, len(subnets))}
+    expected_nics = {f"enp{i + 39}" for i in range(0, len(subnets))}
     max_retries, current_nics = 10, set()
     while not expected_nics.issubset(current_nics) and max_retries:
         time.sleep(10 - max_retries)

--- a/jobs/integration/tigera_aws.py
+++ b/jobs/integration/tigera_aws.py
@@ -477,7 +477,7 @@ def deploy_bgp_router():
         )
         raise TimeoutError()
 
-    for interface in expected_nics:
+    for interface in nic_matches:
         # Setting IF_METRIC=101 lowers the priority of the routes for this network
         # interface. We need the primary network's default route to be higher
         # priority so that the public/elastic IP, which is bound to the primary


### PR DESCRIPTION

---
Fixes
17:22:25 [validate-ck-calico-bgp-router-jammy-1.32-edge] Failed to find all nics
17:22:25 [validate-ck-calico-bgp-router-jammy-1.32-edge]   expected: ens6
17:22:25 [validate-ck-calico-bgp-router-jammy-1.32-edge]   current : lo, fan-252, ftun0, enp40s0, enp39s0
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
