### PR TITLE
Improve regex for finding charm file names in build reports

### DIFF
--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -207,7 +207,9 @@ class LPBuildEntity(BuildEntity):
         """
 
         content = self._lp_build_log(build)
-        charm_file_matches = re.findall(r"([\w\-\.]+\.charm)", content, re.MULTILINE)
+        charm_file_matches = re.findall(
+            r"\s([\w\-\.]+\.charm)\s", content, re.MULTILINE
+        )
         uniq = set(charm_file_matches)
         if not uniq:
             err_msg = (


### PR DESCRIPTION
Resolving build errors like this when the build report has multiple matches on the regex.

```
04:07:26   File "jobs/build-charms/main.py", line 115, in build
04:07:26     entity.charm_build()
04:07:26   File "/var/lib/jenkins/slaves/jenkins-agent-focal-k8s-production-12/workspace/build-charms/jobs/build-charms/builder_launchpad.py", line 282, in charm_build
04:07:26     self.artifacts = [
04:07:26   File "/var/lib/jenkins/slaves/jenkins-agent-focal-k8s-production-12/workspace/build-charms/jobs/build-charms/builder_launchpad.py", line 283, in <listcomp>
04:07:26     self._lp_build_download(build, download_path) for build in builds
04:07:26   File "/var/lib/jenkins/slaves/jenkins-agent-focal-k8s-production-12/workspace/build-charms/jobs/build-charms/builder_launchpad.py", line 230, in _lp_build_download
04:07:26     charm_file = self._lp_charm_filename_from_build(build)
04:07:26   File "/var/lib/jenkins/slaves/jenkins-agent-focal-k8s-production-12/workspace/build-charms/jobs/build-charms/builder_launchpad.py", line 224, in _lp_charm_filename_from_build
04:07:26     raise BuildException(err_msg)
04:07:26 builder_local.BuildException: Failed launchpad build openstack-integrator due to not finding too many named packed charms.Found charm files: discourse.charm, openstack-integrator_ubuntu-22.04-amd64-arm64-s390x_ubuntu-24.04-amd64-arm64-s390x.charm
```