### PR TITLE
Make aws heavy tests run on demand rather than scheduled

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -274,8 +274,7 @@
       - block-on-infra
       - build-discarder:
           num-to-keep: 10
-    triggers:
-        - timed: "@weekly"
+    triggers: []
     parameters:
       - charms-edge
       - series-stable
@@ -534,8 +533,7 @@
       - block-on-infra
       - build-discarder:
           num-to-keep: 10
-    triggers:
-        - timed: "@monthly"
+    triggers: []
     parameters:
       - charms-edge
       - series-stable
@@ -575,8 +573,7 @@
       - block-on-infra
       - build-discarder:
           num-to-keep: 10
-    triggers:
-        - timed: "@monthly"
+    triggers: []
     parameters:
       - charms-edge
       - series-stable


### PR DESCRIPTION
The following tests were somewhat costly and are perpetually in a failed state
* validate-ck-aws-iam
* validate-localhost
* validate-nvidia


Jira cards have been created to address 2 of these tests going forward after which they can be re-enabled as schedule tests runs. 

For now, we can just disable the scheduled test runs