### PR TITLE
Allow validation tests to parameterize the channel of etcd snap

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -101,6 +101,15 @@
             Set default series to use in test deployment
 
 - parameter:
+    name: etcd-channel
+    parameters:
+      - string:
+          name: etcd_channel
+          default: auto
+          description: |-
+            Specify the etcd snap channel to use
+
+- parameter:
     name: snap-params
     parameters:
       - string:

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -21,6 +21,7 @@
     parameters:
       - 'charms-{charm-channel}'
       - lxc-runner-params
+      - etcd-channel
     axes:
       - axis:
           type: slave  # wokeignore:rule=slave
@@ -59,7 +60,7 @@
           JOB_SPEC_DIR: "jobs/validate"
       - run-lxc:
           COMMAND: |
-            bash jobs/validate/spec $snap_version $series $channel $arch $cloud
+            bash jobs/validate/spec $snap_version $series $channel $arch $cloud $etcd_channel
 
 - project:
     name: validate-ck
@@ -102,6 +103,7 @@
         - timed: "@weekly"
     parameters:
       - charms-edge
+      - etcd-channel
       - lxc-runner-params
       - juju-lts
     axes:
@@ -138,7 +140,7 @@
           JOB_SPEC_DIR: "jobs/validate"
       - run-lxc:
           COMMAND: |
-            bash jobs/validate/spec $snap_version $series $channel $arch $cloud
+            bash jobs/validate/spec $snap_version $series $channel $arch $cloud $etcd_channel
 
 # UPGRADE --------------------------------------------------------------------------- #
 - job:

--- a/jobs/validate/spec
+++ b/jobs/validate/spec
@@ -30,6 +30,7 @@ JUJU_VERSION=$(juju --version | cut -f-2 -d.)
 CUSTOM_CLOUD=$(echo "$JUJU_CLOUD" | cut -f1 -d/)
 JOB_NAME_CUSTOM="validate-ck-$CUSTOM_CLOUD-$ARCH-$SERIES-$JUJU_VERSION-$SNAP_VERSION"
 JOB_ID=$(identifier)
+ETCD_VERSION=${6:-auto}
 
 ###############################################################################
 # START

--- a/juju.bash
+++ b/juju.bash
@@ -147,6 +147,9 @@ applications:
     constraints: $constraints
     options:
       channel: $SNAP_VERSION
+  etcd:
+    options:
+      channel: ${ETCD_VERSION:-auto}
 EOF
 }
 


### PR DESCRIPTION
Allows a jenkins test to parameterize the version of etcd snap

- [ ] Needs `jjb` after merge

