### PR TITLE
Bugfix-release-upgrade should have a configurable snap offices channels

### DIFF
--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -80,10 +80,16 @@
             - runner-validate
       - axis:
           type: user-defined
-          name: snap_version
+          name: prior_snap_offset
+          description: |
+            Stable snap channel offset behind the charm candidate channel.
+
+            for example)
+            0 with charm_channel is 1.32/candidate, then prior_snap_version is 1.32/stable
+            1 with charm_channel is 1.30/candidate, then prior_snap_version is 1.29/stable
           values:
-            - 1.30/stable
-            - 1.29/stable
+            - 0
+            - 1
       - axis:
           type: user-defined
           name: series
@@ -99,7 +105,7 @@
           JOB_SPEC_DIR: "jobs/release"
       - run-lxc:
           COMMAND: |
-           bash jobs/release/bugfix-upgrade-spec $snap_version $series $charm_channel $cloud
+           bash jobs/release/bugfix-upgrade-spec $prior_snap_offset $series $charm_channel $cloud
 
 - job:
     name: 'validate-charm-release-upgrade'

--- a/jobs/release/bugfix-upgrade-spec
+++ b/jobs/release/bugfix-upgrade-spec
@@ -41,12 +41,23 @@ function test::execute
 ###############################################################################
 # ENV
 ###############################################################################
+# This job deploys an existing stable charm and snap
+# then upgrades to a candidate channel
+# 
+# using the candidate channel (1.xx/candidate)
+#    derive the deploy charm-channel = 1.xx/stable
+#    derive the deploy snap-channel = 1.(xx-N)/stable  where N=0 or 1
 
-SNAP_VERSION=${1}
+PRIOR_SNAP_OFFSET=${1}    # Could be 0 or 1
 SERIES=${2}
 CANDIDATE_CHANNEL=${3}
+
+# replace 1.xx/(edge or candidate, or beta) with 1.xx/stable
+JUJU_DEPLOY_CHANNEL=$(echo "$CANDIDATE_CHANNEL" | sed -E 's#/.*#/stable#')
+PRIOR_TRACK=$(python3 $WORKSPACE/jobs/release/prior_track.py $CANDIDATE_CHANNEL $PRIOR_SNAP_OFFSET)
+SNAP_VERSION="$PRIOR_TRACK/stable"
+
 JUJU_DEPLOY_BUNDLE=charmed-kubernetes
-JUJU_DEPLOY_CHANNEL=stable
 JUJU_CLOUD=${4}
 JUJU_CONTROLLER=validate-$(identifier::short)
 JUJU_MODEL=validate-bugfix-upgrade
@@ -57,7 +68,7 @@ JOB_ID=$(identifier)
 
 
 # this job deploys with
-#   charm-channel=stable
+#   charm-channel=1.xx/stable
 #   snap-channel  at {K8S_STABLE_VERSION - 1}/stable or {K8S_STABLE_VERSION - 2}/stable
 # then upgrades charm-channel to candidate
 # and  upgrades snap-channel  to candidate

--- a/jobs/release/prior_track.py
+++ b/jobs/release/prior_track.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+"""Given a release track, calculate the prior release track.
+
+| step  | input           | output |
+| ---   | ---             | ---    |
+| 0     | 1.32/candidate  | 1.32   |
+| 1     | 1.32/edge       | 1.31   |
+| 2     | 1.32/beta       | 1.30   |
+"""
+
+import argparse
+
+
+parser = argparse.ArgumentParser(description="Release steps calculator")
+parser.add_argument(
+    "channel",
+    type=str,
+    help="Release channel in the format <track>/<risk>",
+)
+parser.add_argument(
+    "step",
+    type=int,
+    help="Release step",
+)
+
+args = parser.parse_args()
+channel = args.channel.split("/")
+if len(channel) != 2:
+    raise ValueError("Invalid channel format. Expected <track>/<risk>.")
+
+track = channel[0].split(".")
+if len(track) != 2:
+    raise ValueError("Invalid track format. Expected <major>.<minor>.")
+
+minor = int(track[1])
+print(f"{track[0]}.{minor - args.step}")


### PR DESCRIPTION
When running a bugfix-release-upgrade job, we can't just test two specific snap versions, we must calculate which snaps to deploy based on the candidate charm channel. 

We're trying to release 1.xx/candidate charm works with the following snap releases
* 1.(xx-0)/stable
* 1.(xx-1)/stable

The test must upgrade 
charm: `1.xx/stable` -> `1.xx/candidate`
snap: (`$snap_version`) -> `1.xx/candidate`

where the `snap_version` is calculated using the prior tracks

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

