### PR TITLE
Handle snap upgrade requirements across multiple ck releases

### DIFF
--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -333,7 +333,7 @@ async def model(request, tools):
         await tools.juju_wait()
         upgrade_snap_channel = request.config.getoption("--upgrade-snap-channel")
         upgrade_charm_channel = request.config.getoption("--upgrade-charm-channel")
-        if not upgrade_snap_channel and upgrade_charm_channel:
+        if not (upgrade_snap_channel and upgrade_charm_channel):
             raise Exception(
                 "Must have both snap and charm upgrade "
                 "channels set to perform upgrade prior to validation test."

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -94,6 +94,7 @@
           type: user-defined
           name: series
           values:
+            - focal
             - jammy
       - axis:
           type: user-defined

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -49,7 +49,7 @@
     name: 'validate-charm-bugfix-upgrade'
     node: runner-validate
     description: |
-      Validates CK upgrades from previous 2 stables to latest candidate
+      Validates CK upgrades from current stable, and previous 2 stables to latest candidate
     project-type: matrix
     scm:
       - k8s-jenkins-jenkaas
@@ -90,6 +90,7 @@
           values:
             - 0
             - 1
+            - 2
       - axis:
           type: user-defined
           name: series

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -34,7 +34,6 @@
           description: |-
             specify the juju channel to use
           values:
-            - 3.1/stable
             - 3/stable
       - axis:
           type: user-defined


### PR DESCRIPTION
### Overview
Resolves a few issues with Bugfix Upgrade testings across multiple releases (1.28 -> 1.32)

Starting in 1.29, changing snaps from `1.xx/stable` -> `1.xx/candidate` didn't actually block the charm, so logic was added to the tests to skip running the upgrade action. This is still a requirement for 1.28 however.  

So, lets just have the test run the action if the charm says it needs the action run. 

### Details
* fix logic bug on when to upgrade charms and snaps
* Reinstate focal testing for the time being on bugfix releases
* drop juju 3.1 for nightly tests runs

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x] Needs `jjb` after merge