### PR TITLE
feat: Add framework to supported charms matrix

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -1,5 +1,6 @@
 # -*- mode:yaml; -*-
 - calico:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-calico'
     build-resources: 'cd {out_path}; bash {src_path}/build-calico-resource.sh'
@@ -15,6 +16,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-calico.git'
 - calico-enterprise:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-calico-enterprise'
     docs: 'https://charmhub.io/calico-enterprise/docs'
@@ -31,6 +33,7 @@
     channel-range:
       min: '1.29'
 - canal:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-canal'
     build-resources: 'cd {out_path}; bash {src_path}/build-canal-resources.sh'
@@ -44,6 +47,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/layer-canal.git'
 - ceph-csi:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-ceph-csi'
     docs: 'https://charmhub.io/ceph-csi/docs'
@@ -60,6 +64,7 @@
     channel-range:
       min: '1.25'
 - cinder-csi:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-cinder-csi'
     docs: 'https://charmhub.io/cinder-csi/docs'
@@ -75,6 +80,7 @@
     channel-range:
       min: '1.28'
 - cilium:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-cilium'
     build-resources: 'cd {out_path}; bash {src_path}/fetch-resources.sh'
@@ -91,6 +97,7 @@
     channel-range:
       min: '1.27'
 - containerd:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-containerd'
     docs: 'https://charmhub.io/containerd/docs'
@@ -104,6 +111,7 @@
       - cri
     upstream: 'https://github.com/charmed-kubernetes/charm-containerd.git'
 - easyrsa:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-easyrsa'
     docs: 'https://charmhub.io/easyrsa/docs'
@@ -116,6 +124,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-easyrsa.git'
 - etcd:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-etcd'
     docs: 'https://charmhub.io/etcd/docs'
@@ -128,6 +137,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/layer-etcd.git'
 - flannel:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-flannel'
     build-resources: 'cd {out_path}; bash {src_path}/build-flannel-resources.sh'
@@ -141,6 +151,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-flannel.git'
 - kata:
+    framework: reactive
     builder: local
     bugs: 'https://bugs.launchpad.net/charm-kata'
     docs: 'https://charmhub.io/kata/docs'
@@ -154,6 +165,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kata.git'
 - keystone-k8s-auth:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/keystone-k8s-auth-operator'
     docs: 'https://charmhub.io/keystone-k8s-auth/docs'
@@ -164,6 +176,7 @@
     downstream: canonical/keystone-k8s-auth-operator.git
     upstream: 'https://github.com/canonical/keystone-k8s-auth-operator.git'
 - kube-ovn:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kube-ovn'
     docs: 'https://charmhub.io/kube-ovn/docs'
@@ -178,6 +191,7 @@
     channel-range:
       min: '1.25'
 - kubeapi-load-balancer:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubeapi-load-balancer'
     docs: 'https://charmhub.io/kubeapi-load-balancer/docs'
@@ -191,6 +205,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer.git'
 - kube-state-metrics:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/kube-state-metrics-operator'
     docs: 'https://charmhub.io/kube-state-metrics/docs'
@@ -203,6 +218,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/kube-state-metrics-operator.git'
 - kubernetes-autoscaler:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-autoscaler'
     docs: 'https://charmhub.io/kubernetes-autoscaler/docs'
@@ -214,6 +230,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-autoscaler.git'
 - kubernetes-e2e:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-e2e'
     docs: 'https://charmhub.io/kubernetes-e2e/docs'
@@ -226,6 +243,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-e2e.git'
 - kubernetes-control-plane:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-control-plane'
     build-resources: 'cd {out_path}; bash {src_path}/build-cni-resources.sh'
@@ -239,6 +257,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-control-plane.git'
 - kubernetes-metrics-server:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-metrics-server'
     docs: 'https://charmhub.io/kubernetes-metrics-server/docs'
@@ -252,6 +271,7 @@
     upstream: >-
       https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator.git
 - kubernetes-worker:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubernetes-worker'
     build-resources: 'cd {out_path}; bash {src_path}/build-cni-resources.sh'
@@ -265,6 +285,7 @@
       - core
     upstream: 'https://github.com/charmed-kubernetes/charm-kubernetes-worker.git'
 - kubevirt:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-kubevirt'
     docs: 'https://charmhub.io/kubevirt/docs'
@@ -279,6 +300,7 @@
     channel-range:
       min: '1.27'
 - openstack-cloud-controller:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-openstack-cloud-controller'
     docs: 'https://charmhub.io/openstack-cloud-controller/docs'
@@ -293,6 +315,7 @@
     channel-range:
       min: '1.28'
 - tigera-secure-ee:
+    framework: reactive
     builder: local
     bugs: 'https://bugs.launchpad.net/charm-tigera-secure-ee'
     build-resources: 'cd {out_path}; bash {src_path}/build-resources.sh'
@@ -307,6 +330,7 @@
     channel-range:
       max: '1.28'
 - keepalived:
+    framework: reactive
     builder: local
     bugs: 'https://bugs.launchpad.net/charm-keepalived'
     docs: 'https://charmhub.io/keepalived/docs'
@@ -320,6 +344,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-keepalived.git'
 - docker-registry:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/layer-docker-registry'
     docs: 'https://charmhub.io/docker-registry/docs'
@@ -332,6 +357,7 @@
       - docker-registry
       - docs-extra
 - aws-iam:
+    framework: reactive
     builder: local
     bugs: 'https://bugs.launchpad.net/charm-aws-iam'
     docs: 'https://charmhub.io/aws-iam/docs'
@@ -344,6 +370,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-aws-iam.git'
 - azure-integrator:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-azure-integrator'
     docs: 'https://charmhub.io/azure-integrator/docs'
@@ -354,8 +381,9 @@
       - k8s
       - charm-azure-integrator
       - integrator
-    upstream: 'https://github.com/juju-solutions/charm-azure-integrator.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-azure-integrator.git'
 - azure-cloud-provider:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-azure-cloud-provider'
     docs: 'https://charmhub.io/azure-cloud-provider/docs'
@@ -370,6 +398,7 @@
     channel-range:
       min: '1.25'
 - gcp-integrator:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-gcp-integrator'
     docs: 'https://charmhub.io/gcp-integrator/docs'
@@ -380,8 +409,9 @@
       - k8s
       - charm-gcp-integrator
       - integrator
-    upstream: 'https://github.com/juju-solutions/charm-gcp-integrator.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-gcp-integrator.git'
 - gcp-k8s-storage:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-gcp-k8s-storage'
     docs: 'https://charmhub.io/gcp-k8s-storage/docs'
@@ -396,6 +426,7 @@
     channel-range:
       min: '1.25'
 - gcp-cloud-provider:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-gcp-cloud-provider'
     docs: 'https://charmhub.io/gcp-cloud-provider/docs'
@@ -410,11 +441,13 @@
     channel-range:
       min: '1.29'
 - github-runner:
+    framework: ops
     downstream: charmed-kubernetes/github-runner-operator
     tags:
       - github-runner
     upstream: 'https://github.com/charmed-kubernetes/github-runner-operator.git'
 - aws-integrator:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-aws-integrator'
     docs: 'https://charmhub.io/aws-integrator/docs'
@@ -425,8 +458,9 @@
       - k8s
       - charm-aws-integrator
       - integrator
-    upstream: 'https://github.com/juju-solutions/charm-aws-integrator.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-aws-integrator.git'
 - aws-k8s-storage:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-aws-k8s-storage'
     docs: 'https://charmhub.io/aws-k8s-storage/docs'
@@ -441,6 +475,7 @@
     channel-range:
       min: '1.25'
 - aws-cloud-provider:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-aws-cloud-provider'
     docs: 'https://charmhub.io/aws-cloud-provider/docs'
@@ -455,6 +490,7 @@
     channel-range:
       min: '1.27'
 - openstack-integrator:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-openstack-integrator'
     docs: 'https://charmhub.io/openstack-integrator/docs'
@@ -465,8 +501,9 @@
       - k8s
       - charm-openstack-integrator
       - integrator
-    upstream: 'https://github.com/juju-solutions/charm-openstack-integrator.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-openstack-integrator.git'
 - vsphere-integrator:
+    framework: reactive
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-vsphere-integrator'
     docs: 'https://charmhub.io/vsphere-integrator/docs'
@@ -477,8 +514,9 @@
       - k8s
       - charm-vsphere-integrator
       - integrator
-    upstream: 'https://github.com/juju-solutions/charm-vsphere-integrator.git'
+    upstream: 'https://github.com/charmed-kubernetes/charm-vsphere-integrator.git'
 - vsphere-cloud-provider:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-vsphere-cloud-provider'
     docs: 'https://charmhub.io/vsphere-cloud-provider/docs'
@@ -493,6 +531,7 @@
     channel-range:
       min: '1.25'
 - metallb:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb/docs'
@@ -507,6 +546,7 @@
     channel-range:
       min: '1.28'
 - metallb-controller:
+    framework: ops
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb-controller/docs'
     downstream: charmed-kubernetes/metallb-operator
@@ -520,6 +560,7 @@
     channel-range:
       max: '1.27'
 - metallb-speaker:
+    framework: ops
     bugs: 'https://bugs.launchpad.net/operator-metallb'
     docs: 'https://charmhub.io/metallb-speaker/docs'
     downstream: charmed-kubernetes/metallb-operator
@@ -533,6 +574,7 @@
     channel-range:
       max: '1.27'
 - multus:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-multus'
     docs: 'https://charmhub.io/multus/docs'
@@ -545,6 +587,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-multus.git'
 - sriov-cni:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-sriov-cni'
     docs: 'https://charmhub.io/sriov-cni/docs'
@@ -558,6 +601,7 @@
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-sriov-cni.git'
 - sriov-network-device-plugin:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-sriov-network-device-plugin'
     docs: 'https://charmhub.io/sriov-network-device-plugin/docs'
@@ -572,6 +616,7 @@
     upstream: >-
       https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin.git
 - coredns:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-coredns'
     docs: 'https://charmhub.io/coredns/docs'
@@ -584,6 +629,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/charm-coredns.git'
 - gatekeeper-controller-manager:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
     docs: 'https://charmhub.io/gatekeeper-controller-manager/docs'
@@ -597,6 +643,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - gatekeeper-audit:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/opa-gatekeeper-operator'
     docs: 'https://charmhub.io/gatekeeper-audit/docs'
@@ -610,6 +657,7 @@
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
 - bird:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-bird'
     docs: 'https://charmhub.io/bird/docs'
@@ -622,6 +670,7 @@
     channel-range:
       min: '999.0'
 - kubernetes-dashboard:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/kubernetes-dashboard-operator'
     docs: 'https://charmhub.io/kubernetes-dashboard/docs'
@@ -636,6 +685,7 @@
     channel-range:
       min: '1.28'
 - volcano-admission:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
@@ -652,6 +702,7 @@
     channel-range:
       min: '1.27'
 - volcano-controllers:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
@@ -668,6 +719,7 @@
     channel-range:
       min: '1.27'
 - volcano-scheduler:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/charm-volcano'
     docs: 'https://discourse.charmhub.io/t/volcano-docs-index/9600'
@@ -684,6 +736,7 @@
     channel-range:
       min: '1.27'
 - nvidia-gpu-operator:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/nvidia-operators'
     downstream: charmed-kubernetes/nvidia
@@ -697,6 +750,7 @@
     channel-range:
       min: '1.29'
 - nvidia-network-operator:
+    framework: ops
     builder: launchpad
     bugs: 'https://bugs.launchpad.net/nvidia-operators'
     downstream: charmed-kubernetes/nvidia
@@ -713,6 +767,7 @@
 
 # EOL in favor of operator charm: https://charmhub.io/kubernetes-dashboard
 # - k8s-dashboard:
+#     framework: ops 
 #     upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
 #     subdir: "charms/kubernetes-dashboard"
 #     namespace: "containers"
@@ -720,6 +775,7 @@
 #     tags: ["k8s", "k8s-dashboard"]
 #     branch: "main"
 # - dashboard-metrics-scraper:
+#     framework: ops
 #     upstream: "https://github.com/charmed-kubernetes/kubernetes-dashboard-operator"
 #     subdir: "charms/dashboard-metrics-scraper"
 #     namespace: "containers"
@@ -728,7 +784,8 @@
 #     branch: "main"
 
 # - nfs:
-#     upstream: "https://github.com/hyperbolic2346/nfs-charm.git"
+#     framework: reactive
+#     upstream: "https://github.com/charmed-kubernetes/nfs-charm.git"
 #     namespace: 'containers'
 #     downstream: 'charmed-kubernetes/nfs-charm'
 #     tags: ['k8s', 'nfs']


### PR DESCRIPTION
### Overview
This PR adds `framework` to the supported charms matrix.
It also replaces some archived repos with the new ones (`juju-solutions` -> `charmed-kubernetes`).

### Note to reviewer
Charms are considered ops-based if they're initialized using `ops.main`, otherwise they're considered reactive.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
