### PR TITLE
chore: 1.33 GA readiness

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -13,11 +13,11 @@ K8S_STABLE_VERSION = "1.32"
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
 # Typically, this is K8S_STABLE_VERSION+1. However, when preparing the next
-# stable release, this will be +2. For example, 1.30 is currently stable and
-# we're working on the 1.31 GA. Set this value to '1.32' sometime between the
-# final RC and GA so we don't get pre-release builds (e.g. 1.31.1-alpha.0) in
-# our 1.31 tracks.
-K8S_NEXT_VERSION = "1.33"
+# stable release, this will be +2. For example, 1.32 is currently stable and
+# we're working on the 1.33 GA. Set this value to '1.34' sometime between the
+# final RC and GA so we don't get pre-release builds (e.g. 1.33.1-alpha.0) in
+# our 1.33 tracks.
+K8S_NEXT_VERSION = "1.34"
 
 # Lowest K8S SEMVER to process, this is usually K8S_STABLE_VERSION - 4
 K8S_STARTING_SEMVER = "1.28.0"
@@ -86,7 +86,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
     ("1.32", ["1.32/stable", "1.32/candidate", "1.32/beta", "1.32/edge"]),
-    ("1.33", ["1.33/edge"]),
+    ("1.33", ["1.33/stable", "1.33/candidate", "1.33/beta", "1.33/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -13,11 +13,11 @@ K8S_STABLE_VERSION = "1.32"
 # Next MAJOR.MINOR
 # This controls whether or not we publish pre-release snaps in our channels.
 # Typically, this is K8S_STABLE_VERSION+1. However, when preparing the next
-# stable release, this will be +2. For example, 1.32 is currently stable and
-# we're working on the 1.33 GA. Set this value to '1.34' sometime between the
-# final RC and GA so we don't get pre-release builds (e.g. 1.33.1-alpha.0) in
-# our 1.33 tracks.
-K8S_NEXT_VERSION = "1.34"
+# stable release, this will be +2. For example, 1.30 is currently stable and
+# we're working on the 1.31 GA. Set this value to '1.32' sometime between the
+# final RC and GA so we don't get pre-release builds (e.g. 1.31.1-alpha.0) in
+# our 1.31 tracks.
+K8S_NEXT_VERSION = "1.33"
 
 # Lowest K8S SEMVER to process, this is usually K8S_STABLE_VERSION - 4
 K8S_STARTING_SEMVER = "1.28.0"
@@ -86,7 +86,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.30", ["1.30/stable", "1.30/candidate", "1.30/beta", "1.30/edge"]),
     ("1.31", ["1.31/stable", "1.31/candidate", "1.31/beta", "1.31/edge"]),
     ("1.32", ["1.32/stable", "1.32/candidate", "1.32/beta", "1.32/edge"]),
-    ("1.33", ["1.33/stable", "1.33/candidate", "1.33/beta", "1.33/edge"]),
+    ("1.33", ["1.33/candidate", "1.33/beta", "1.33/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -43,6 +43,11 @@ between 1.29 RC and GA:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/1462
 
+**^ NOTE**: Only add `1.xx/stable` to the `SNAP_K8S_TRACK_LIST` in the `enums.py` file
+if the `1.xx.0` snaps are available. Otherwise, the snap stable channels would have
+an rc1 in them.
+
+
 Additionally, if not done already, CI should include 1.xx in the version matrix
 and config for relevant jobs. For example, see these updates where we adjusted
 tests for our 1.29 release:

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -150,7 +150,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.32/beta
+          default: 1.33/beta
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -21,7 +21,7 @@
       - juju-lts
       - string:
           name: CK_VERSION
-          default: '1.32'
+          default: '1.33'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.32'
+          default: '1.33'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.


### PR DESCRIPTION
### Overview
Updated the files according to the stable release doc.
Ran the following command, but it didn't result in any change:
```
$ tox -e py -- jenkins-jobs --conf jobs/jjb-conf.ini update jobs/ci-master.yaml jobs/arc-conformance.yaml jobs/build-aws-iam-oci.yaml jobs/build-charms.yaml jobs/build-debs.yaml jobs/build-docs.yaml jobs/build-snaps.yaml jobs/ci-master.yaml jobs/cncf-conformance.yaml jobs/infra-ps5.yaml jobs/infra.yaml jobs/release-charm.yaml jobs/release-microk8s-capi.yaml jobs/release-microk8s.yaml jobs/release.yaml jobs/reports.yaml jobs/sync-oci-images.yaml jobs/sync-upstream.yaml jobs/validate-hacluster.yaml jobs/validate.yaml

INFO:jenkins_jobs.cli.subcommand.base:Updating jobs in [PosixPath('jobs/ci-master.yaml')] (['jobs/arc-conformance.yaml', 'jobs/build-aws-iam-oci.yaml', 'jobs/build-charms.yaml', 'jobs/build-debs.yaml', 'jobs/build-docs.yaml', 'jobs/build-snaps.yaml', 'jobs/ci-master.yaml', 'jobs/cncf-conformance.yaml', 'jobs/infra-ps5.yaml', 'jobs/infra.yaml', 'jobs/release-charm.yaml', 'jobs/release-microk8s-capi.yaml', 'jobs/release-microk8s.yaml', 'jobs/release.yaml', 'jobs/reports.yaml', 'jobs/sync-oci-images.yaml', 'jobs/sync-upstream.yaml', 'jobs/validate-hacluster.yaml', 'jobs/validate.yaml'])
INFO:jenkins_jobs.builder:Number of jobs generated:  0
INFO:jenkins_jobs.cli.subcommand.update:Number of jobs updated: 0
INFO:jenkins_jobs.builder:Number of views generated:  0
INFO:jenkins_jobs.cli.subcommand.update:Number of views updated: 0
  py: OK (0.22=setup[0.03]+cmd[0.19] seconds)
  congratulations :) (0.25 seconds)
```

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
