### PR TITLE
chore: Validate on noble as well

### DIFF
--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -67,6 +67,9 @@
       - jammy:
           hour: '0' # Midnight
           dow: '1,3,5'  # MWF
+      - noble:
+          hour: '0' # Midnight
+          dow: '1,3,5'  # MWF
     charm-channel:
       - edge:
           snap_versions:
@@ -123,6 +126,7 @@
           name: series
           values:
             - jammy
+            - noble
       - axis:
           type: user-defined
           name: arch

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -68,7 +68,7 @@
           hour: '0' # Midnight
           dow: '1,3,5'  # MWF
       - noble:
-          hour: '0' # Midnight
+          hour: '12' # Noon
           dow: '1,3,5'  # MWF
     charm-channel:
       - edge:


### PR DESCRIPTION
### Overview

This PR enables us to validate the charms on noble

Also ran the following to update the jobs:
```
$ tox -e py -- jenkins-jobs --conf jobs/jjb-conf.ini update jobs/ci-master.
yaml jobs/arc-conformance.yaml jobs/build-aws-iam-oci.yaml jobs/build-charms.yaml jobs/build-debs.yaml jobs/build-docs.yaml jobs/build-snaps.yaml jobs/ci-master.yaml jobs/cncf-conformance.yaml jobs/infra-ps5.yaml jobs/infra.yaml jobs/release-charm.yaml jobs/release-microk8s-capi.yaml jobs/release-microk8s.yaml jobs/release.yaml jobs/reports.yaml jobs/sync-oci-images.yaml jobs/sync-upstream.yaml jobs/validate-hacluster.yaml jobs/validate.yaml

py: commands[0]> jenkins-jobs --conf jobs/jjb-conf.ini update jobs/ci-master.yaml jobs/arc-conformance.yaml jobs/build-aws-iam-oci.yaml jobs/build-charms.yaml jobs/build-debs.yaml jobs/build-docs.yaml jobs/build-snaps.yaml jobs/ci-master.yaml jobs/cncf-conformance.yaml jobs/infra-ps5.yaml jobs/infra.yaml jobs/release-charm.yaml jobs/release-microk8s-capi.yaml jobs/release-microk8s.yaml jobs/release.yaml jobs/reports.yaml jobs/sync-oci-images.yaml jobs/sync-upstream.yaml jobs/validate-hacluster.yaml jobs/validate.yaml
INFO:jenkins_jobs.cli.subcommand.base:Updating jobs in [PosixPath('jobs/ci-master.yaml')] (['jobs/arc-conformance.yaml', 'jobs/build-aws-iam-oci.yaml', 'jobs/build-charms.yaml', 'jobs/build-debs.yaml', 'jobs/build-docs.yaml', 'jobs/build-snaps.yaml', 'jobs/ci-master.yaml', 'jobs/cncf-conformance.yaml', 'jobs/infra-ps5.yaml', 'jobs/infra.yaml', 'jobs/release-charm.yaml', 'jobs/release-microk8s-capi.yaml', 'jobs/release-microk8s.yaml', 'jobs/release.yaml', 'jobs/reports.yaml', 'jobs/sync-oci-images.yaml', 'jobs/sync-upstream.yaml', 'jobs/validate-hacluster.yaml', 'jobs/validate.yaml'])
INFO:jenkins_jobs.builder:Number of jobs generated:  0
INFO:jenkins_jobs.cli.subcommand.update:Number of jobs updated: 0
INFO:jenkins_jobs.builder:Number of views generated:  0
INFO:jenkins_jobs.cli.subcommand.update:Number of views updated: 0
  py: OK (40.89=setup[40.68]+cmd[0.21] seconds)
  congratulations :) (40.92 seconds)
```