### PR TITLE
Use python enums to create a map of series names to ubuntu LTS dates

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -34,8 +34,6 @@ K8S_CHARM_SUPPORT_ARCHES = ["amd64", "s390x", "arm64"]
 # Support series map
 @total_ordering
 class Series(Enum):
-    xenial = "16.04"
-    bionic = "18.04"
     focal = "20.04"
     jammy = "22.04"
     noble = "24.04"

--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -1,5 +1,6 @@
 """Contains all the concrete variables used throughout job processing code"""
 
+from enum import Enum
 from pathlib import Path
 import yaml
 
@@ -28,14 +29,17 @@ K8S_SUPPORT_ARCHES = ["amd64", "ppc64el", "s390x", "arm64"]
 # Supported charm arches
 K8S_CHARM_SUPPORT_ARCHES = ["amd64", "s390x", "arm64"]
 
+
 # Support series map
-K8S_SERIES_MAP = {
-    "xenial": "16.04",
-    "bionic": "18.04",
-    "focal": "20.04",
-    "jammy": "22.04",
-    "noble": "24.04",
-}
+class Series(Enum):
+    xenial = "16.04"
+    bionic = "18.04"
+    focal = "20.04"
+    jammy = "22.04"
+    noble = "24.04"
+
+
+SERIES_ORDER = list(Series)
 
 # Kubernetes CNI version
 K8S_CNI_SEMVER = "0.8"

--- a/jobs/integration/conftest.py
+++ b/jobs/integration/conftest.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager, asynccontextmanager
 from functools import cached_property
 
 from cilib.lp import Client as LPClient
+from cilib.enums import Series
 from datetime import datetime
 from juju.model import Model
 from pathlib import Path
@@ -51,7 +52,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--series",
         action="store",
-        default=os.environ.get("SERIES", "jammy"),
+        default=os.environ.get("SERIES", Series.jammy.name),
         help="Base series",
     )
     parser.addoption("--cloud", action="store", help="Juju cloud to use")
@@ -203,13 +204,7 @@ class Tools:
         """Retrieve juju 3.x base from series."""
         if self.juju_version < (3, 1):
             return f"--series={series}"
-        mapping = {
-            "bionic": "ubuntu@18.04",
-            "focal": "ubuntu@20.04",
-            "jammy": "ubuntu@22.04",
-            "noble": "ubuntu@24.04",
-        }
-        return f"--base={mapping[series]}"
+        return f"--base=ubuntu@{Series[series].value}"
 
     async def run(self, cmd: str, *args: str, stdin=None, _tee=False):
         """

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -24,6 +24,7 @@ from tempfile import TemporaryDirectory
 from subprocess import check_output, check_call
 from typing import List
 from cilib import log
+from cilib.enums import Series
 import click
 
 
@@ -556,60 +557,72 @@ async def wait_for_application_status(model, app_name, status="active"):
         raise AssertionError(f"Application has unexpected status: {app.status.status}")
 
 
-def _supported_series(charmhub_info, channel):
-    return {p["series"] for p in charmhub_info["channel-map"][channel]["platforms"]}
+class UnitMetadata:
+    def __init__(self, unit):
+        self._model = unit.machine.model
+        self._unit = unit
+        self._charm_info = None
+        self._app_info = None
+
+    async def charm_channel(self) -> str:
+        app_info = await self.app_info()
+        channel = "/".join((app_info["track"] or "latest", app_info["risk"]))
+        return channel
+
+    @property
+    def charm_url(self) -> str:
+        app = self._model.applications[self._unit.application]
+        return "-".join(app.data["charm-url"].split("/")[-1].split("-")[:-1])
+
+    async def app_info(self) -> dict:
+        if self._app_info is None:
+            app = self._model.applications[self._unit.application]
+            app_info = await app._facade().GetCharmURLOrigin(application=app.name)
+            self._app_info = app_info.charm_origin
+        return self._app_info
+
+    async def charm_info(self) -> dict:
+        if self._charm_info is None:
+            self._charm_info = await self._model.charmhub.info(self.charm_url)
+        return self._charm_info
+
+    async def supports_series(self, channel: str, series: Series) -> bool:
+        charm_info = await self.charm_info()
+        return series in {
+            Series(p["channel"])
+            for p in charm_info["channel-map"][channel]["revision"]["bases"]
+        }
 
 
-async def refresh_openstack_charms(machine, new_series, tools):
-    """Upgrade openstack charms to a channel that supports new_series
+async def supports_series_upgrade(machine, new_series: Series) -> bool:
+    """Confirm that this machine can be upgraded to the new series.
 
-    The openstack charms (ceph, hacluster, mysql) have to switch to a newer channel
-    before they can do a series upgrade. I.e. hacluster should be deployed on channel
-    2.0.3/stable when running focal. Before upgrading to jammy, you need to switch to
-    2.4/stable.
+    All the units on the machine must exist on a charm that supports the new series.
     """
     for unit in _units(machine):
-        app = unit.machine.model.applications[unit.application]
-        charm_name = "-".join(app.data["charm-url"].split("/")[-1].split("-")[:-1])
-        charm_info = await unit.machine.model.charmhub.info(charm_name)
-        if charm_info["publisher"] != "OpenStack Charmers":
-            continue
-
-        app_info = await app._facade().GetCharmURLOrigin(application=app.name)
-        app_info = app_info.charm_origin
-        current_channel = "/".join((app_info["track"] or "latest", app_info["risk"]))
-        if new_series in _supported_series(charm_info, current_channel):
-            continue
-
-        for channel, channel_info in charm_info["channel-map"].items():
-            if (
-                app_info["risk"] == channel_info["risk"]
-                and new_series in _supported_series(charm_info, channel)
-                and app_info["series"] in _supported_series(charm_info, channel)
-            ):
-                new_channel = channel
-                break
-        else:
-            raise ValueError(
-                f"{app.name} on channel {current_channel} does not support {new_series}"
-                " and no channel is found to upgrade to."
+        metadata = UnitMetadata(unit)
+        current_channel = await metadata.charm_channel()
+        if await metadata.supports_series(current_channel, new_series):
+            log.info(
+                f"{unit.name} supports {new_series.name} upgrade on {current_channel}"
             )
+            continue
+        log.info(f"{unit.name} doesn't support {new_series.name} on {current_channel}")
+        return False
+    return True
 
-        log.info(f"Upgrading {app.name} to {new_channel} to suport {new_series}")
-        await app.refresh(channel=new_channel)
 
-
-async def prep_series_upgrade(machine, new_series, tools):
+async def prep_series_upgrade(machine, new_series: Series, tools):
     log.info(f"preparing series upgrade for machine {machine.id}")
     await tools.run(
         "juju",
-        "upgrade-series",
+        "upgrade-machine",
         "--yes",
         "-m",
         tools.connection,
         machine.id,
         "prepare",
-        new_series,
+        f"ubuntu@{new_series.value}",
     )
     try:
         await wait_for_status("blocked", _units(machine))
@@ -624,16 +637,17 @@ async def prep_series_upgrade(machine, new_series, tools):
 
 
 async def do_series_upgrade(machine):
+    await machine_reboot(machine, block=True)
+    log.info(f"Doing release upgrade for machine {machine.id}")
     file_name = "/etc/apt/apt.conf.d/50unattended-upgrades"
     option = "--force-confdef"
-    log.info(f"doing series upgrade for machine {machine.id}")
     await machine.ssh(
         f"""
-        if ! grep -q -- '{option}' {file_name}; then
-          echo 'DPkg::options {{ "{option}"; }};' | sudo tee -a {file_name}
-        fi
-        sudo DEBIAN_FRONTEND=noninteractive do-release-upgrade -f DistUpgradeViewNonInteractive
-    """
+if ! grep -q -- '{option}' {file_name}; then
+    echo 'DPkg::options {{ "{option}"; }};' | sudo tee -a {file_name}
+fi
+sudo DEBIAN_FRONTEND=noninteractive do-release-upgrade -f DistUpgradeViewNonInteractive
+"""
     )
     await machine_reboot(machine)
 
@@ -649,18 +663,18 @@ async def machine_reboot(machine, block=False):
 
     while block:
         try:
-            await machine.ssh("service jujud-machine-* status")
+            await machine.ssh("service jujud-machine-* status", timeout=30)
             block = False
         except JujuError:
             log.info("Waiting for machine to start up")
             await asyncio.sleep(5)
 
 
-async def finish_series_upgrade(machine, tools, new_series):
+async def finish_series_upgrade(machine, new_series: Series, tools):
     log.info(f"completing series upgrade for machine {machine.id}")
     await tools.run(
         "juju",
-        "upgrade-series",
+        "upgrade-machine",
         "--yes",
         "-m",
         tools.connection,
@@ -670,8 +684,8 @@ async def finish_series_upgrade(machine, tools, new_series):
     if _primary_unit(machine).application == "vault" and tools.vault_unseal_command:
         tools.run(shlex.split(tools.vault_unseal_command))
     await wait_for_status("active", _units(machine))
-    series = await machine.ssh("lsb_release -cs")
-    assert series.strip() == new_series
+    series = await machine.ssh("lsb_release -cs 2>/dev/null")
+    assert Series[series.strip()] == new_series
 
 
 class JujuRunError(AssertionError):

--- a/jobs/integration/utils.py
+++ b/jobs/integration/utils.py
@@ -27,10 +27,6 @@ from cilib import log
 import click
 
 
-# note: we can't upgrade to focal until after it's released
-SERIES_ORDER = ["bionic", "focal", "jammy", "noble"]
-
-
 def tracefunc(frame, event, arg):
     if event != "call":
         return

--- a/jobs/validate/series-upgrade-spec
+++ b/jobs/validate/series-upgrade-spec
@@ -19,7 +19,10 @@ function test::execute
     juju::pip::2.9
 
     declare -n is_pass=$1
-    timeout -s INT 3h pytest \
+    # The timeout command is used to limit the execution time of the pytest command.
+    # If the command exceeds the specified time limit, it will be terminated.
+    # a 9 machine cluster takes about 2hrs just to upgrade the series.
+    timeout -s INT 5h pytest \
                 --html="report.html" \
                 --json-report \
                 --json-report-summary \


### PR DESCRIPTION
### Overview
By using python's `Enum`, we should be able to map ubuntu series names into LTS releases. 

### Details
* replace the `K8S_SERIES_MAP` for a `Series` enum.  One can still index into an enum by name:
eg) `Series["jammy"] == Series.jammy `
* Drop existing references to `K8S_SERIES_MAP`
* Move `SERIES_ORDER` into `cilib.enums`
* Only deploy ceph-csi `v3.13.0` when running on `noble` or beyond
* charm builder defines its own `CharmSeries` not associated with the Enum `Series`
