### PR TITLE
Bump stable release to 1.33

### DIFF
--- a/docs/releases/bugfix/index.md
+++ b/docs/releases/bugfix/index.md
@@ -175,7 +175,7 @@ Otherwise, you would end up promoting charms from the last candidate release
 overwriting the previous stable with an invalid charm.
 
 It can be wise to run first with the `--dry-run` flag to ensure the correct
-promotions are correct specifically for charms that require multiple promotions 
+promotions are correct specifically for charms that require multiple promotions
 because they support multiple arches with potentially different resources.
 
 **Note about `to_channel`**
@@ -259,7 +259,7 @@ Send an email to the `k8s-crew@lists.canonical.com` mailing list with something 
 ---
 
 **Subject: Announcing the Release of Charmed Kubernetes {VERSION}**
- 
+
 
 We are excited to announce the release of Charmed Kubernetes {VERSION} in the {CHANNEL} channel!
 This release includes several notable fixes and improvements across the Kubernetes charms, ensuring better stability, enhanced functionality, and improved security.

--- a/docs/releases/stable/index.md
+++ b/docs/releases/stable/index.md
@@ -293,6 +293,22 @@ to this release `1.xx`. For example, for the 1.29 GA:
 
 - https://github.com/charmed-kubernetes/jenkins/pull/1481
 
+If the snaps are not yet promoted (in the beta channel)
+
+```sh
+CHANNEL=1.xx
+for snap in kube-apiserver kube-controller-manager kube-proxy kube-scheduler kubectl kubeadm kubelet kubernetes-test; do
+  snapcraft promote ${snap} \
+      --from-channel="${CHANNEL}/beta" \
+      --to-channel="${CHANNEL}/stable"
+done
+for CHANNEL in 1.33 1.32 1.31; do
+  snapcraft promote cdk-addons \
+      --from-channel="${CHANNEL}/beta" \
+      --to-channel="${CHANNEL}/stable"
+done
+```
+
 > **Note**: Nightly charm and bundle builds will publish to both `latest/edge`
 and `K8S_STABLE_VERSION/edge` channels.
 

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -126,7 +126,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.32/stable
+          default: 1.33/stable
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -142,7 +142,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.32/stable
+          default: 1.33/stable
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/release.yaml
+++ b/jobs/release.yaml
@@ -65,7 +65,7 @@
       - string:
           name: charm_channel
           description: "The charm channel to validate"
-          default: "1.32/candidate"
+          default: "1.33/candidate"
           trim: true
       - string:
           name: cloud
@@ -85,8 +85,8 @@
             Stable snap channel offset behind the charm candidate channel.
 
             for example)
-            0 with charm_channel is 1.32/candidate, then prior_snap_version is 1.32/stable
-            1 with charm_channel is 1.30/candidate, then prior_snap_version is 1.29/stable
+            0 with charm_channel is 1.33/candidate, then prior_snap_version is 1.33/stable
+            1 with charm_channel is 1.33/candidate, then prior_snap_version is 1.32/stable
           values:
             - 0
             - 1
@@ -144,8 +144,8 @@
           type: user-defined
           name: deploy_snap
           values:
+            - 1.33/stable
             - 1.32/stable
-            - 1.31/stable
       - axis:
           type: user-defined
           name: series

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -78,9 +78,9 @@
             - 1.31/edge
       - stable:
           snap_versions:
+            - 1.33/stable
             - 1.32/stable
             - 1.31/stable
-            - 1.30/stable
           dow: '0'      # Sunday
     jobs:
       - 'validate-ck-{charm-channel}-{series}'
@@ -179,8 +179,8 @@
           type: user-defined
           name: snap_version
           values:
-            - 1.28/stable
-            - 1.27/stable
+            - 1.32/stable
+            - 1.31/stable
       - axis:
           type: user-defined
           name: arch


### PR DESCRIPTION
Includes changes to docs and validation/release testing now that 1.33 is the stable release.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [x ] Needs `jjb` after merge
