### PR TITLE
fix: update juju base image to be run on aws

### DIFF
--- a/jobs/microk8s/release.sh
+++ b/jobs/microk8s/release.sh
@@ -27,7 +27,7 @@ export PROXY=${PROXY:-}
 export RELEASE_CHANNEL=${RELEASE_CHANNEL:-all}
 
 
-SERIES=focal
+SERIES=jammy
 JUJU_DEPLOY_BUNDLE="${WORKSPACE}/ubuntu.yaml"
 JUJU_DEPLOY_CHANNEL=stable
 JUJU_CLOUD=aws/us-east-1


### PR DESCRIPTION
Juju doesn't run `focal` on AWS anymore. 