### PR TITLE
Pause building a set of charms that have fallen out of test matrix

### DIFF
--- a/jobs/includes/charm-support-matrix.inc
+++ b/jobs/includes/charm-support-matrix.inc
@@ -590,6 +590,8 @@
       - multus
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-multus.git'
+    channel-range:
+      max: '1.32'
 - sriov-cni:
     framework: ops
     builder: launchpad
@@ -604,6 +606,8 @@
       - sriov-cni
       - cni
     upstream: 'https://github.com/charmed-kubernetes/charm-sriov-cni.git'
+    channel-range:
+      max: '1.32'
 - sriov-network-device-plugin:
     framework: ops
     builder: launchpad
@@ -619,6 +623,8 @@
       - cni
     upstream: >-
       https://github.com/charmed-kubernetes/charm-sriov-network-device-plugin.git
+    channel-range:
+      max: '1.32'
 - coredns:
     framework: ops
     builder: launchpad
@@ -646,6 +652,8 @@
       - gatekeeper-controller-manager
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
+    channel-range:
+      max: '1.32'
 - gatekeeper-audit:
     framework: ops
     builder: launchpad
@@ -660,6 +668,8 @@
       - gatekeeper-audit
       - docs-extra
     upstream: 'https://github.com/charmed-kubernetes/opa-gatekeeper-operators.git'
+    channel-range:
+      max: '1.32'
 - bird:
     framework: ops
     builder: launchpad


### PR DESCRIPTION
The following charms did not get a 1.33/stable release and we should likely pause their work since their test-coverage isn't functional.  

* multus
* sriov-cni
* sriov-network-device-plugin
* gatekeeper-controller-manager
* gatekeeper-audit
