### PR TITLE
Build and Test against 1.34 Charmed Kubernetes

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -103,7 +103,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.30', '1.31', '1.32', '1.33']
+    version: ['1.31', '1.32', '1.33', '1.34']
     jobs:
       - 'build-release-cdk-addons-{version}'
 

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -134,7 +134,7 @@
     parameters:
       - string:
           name: channel
-          default: 1.33/edge
+          default: 1.34/edge
           description: channel for charmed-kubernetes bundle to deploy
 
 - parameter:
@@ -158,7 +158,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.33/edge
+          default: 1.34/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,9 +73,9 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.34/edge
             - 1.33/edge
             - 1.32/edge
-            - 1.31/edge
       - stable:
           snap_versions:
             - 1.33/stable
@@ -118,9 +118,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
             - 1.32/edge
-            - 1.31/edge
       - axis:
           type: user-defined
           name: series
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
       - axis:
           type: user-defined
           name: cloud
@@ -426,8 +426,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -469,8 +469,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -510,8 +510,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -550,8 +550,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -590,8 +590,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -631,8 +631,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
-            - 1.32/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -672,9 +672,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/edge
             - 1.33/edge
             - 1.32/edge
-            - 1.31/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"


### PR DESCRIPTION
Update Jenkins CI to run tests against 1.34 charmed-kubernetes