### PR TITLE
Add building of MicroK8s 1.34 and 1.35

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -29,6 +29,8 @@ def get_tracks(all=False):
         "1.32",
         "1.32-strict",
         "1.33",
+        "1.34",
+        "1.35",
     ]
 
 


### PR DESCRIPTION
We add the option for MicroK8s to build 1.34 and 1.35. The 1.35 will start building when the 1.35 is available from upstream.