### PR TITLE
feat: Add '1.33-strict' Microk8s to supported versions list

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -29,6 +29,7 @@ def get_tracks(all=False):
         "1.32",
         "1.32-strict",
         "1.33",
+        "1.33-strict",
         "1.34",
         "1.35",
     ]


### PR DESCRIPTION
### Overview

This PR adds 1.33-strict to Microk8s tracks list to be picked up by the `update-microk8s-gh-branches-and-lp-builders` job.