### PR TITLE
Adding microk8s 1.34 strict for testing in our CI

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -31,6 +31,7 @@ def get_tracks(all=False):
         "1.33",
         "1.33-strict",
         "1.34",
+        "1.34-strict",
         "1.35",
     ]
 


### PR DESCRIPTION
Update the MicroK8s configbag to include 1.34-strict 