### PR TITLE
fix: resolve HIGH severity bandit findings

### DIFF
--- a/cilib/html.py
+++ b/cilib/html.py
@@ -9,6 +9,6 @@ from jinja2 import Environment, FileSystemLoader
 def template(name):
     """Returns a template from jobs/templates/<name>"""
     files_p = str(Path(os.environ.get("WORKSPACE")) / "jobs/templates")
-    env = Environment(loader=FileSystemLoader(files_p))
+    env = Environment(loader=FileSystemLoader(files_p), autoescape=True)
     _tmpl = env.get_template(name)
     return _tmpl

--- a/cilib/run.py
+++ b/cilib/run.py
@@ -31,7 +31,7 @@ def script(script_data, **kwargs):
     if is_single_command:
         process = subprocess.Popen(
             script_data.strip(),
-            shell=True,
+            shell=True,  # nosec B602 - intentional: runs CI script commands
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -234,7 +234,7 @@ class LPBuildEntity(BuildEntity):
         with urllib.request.urlopen(dl_link) as src:
             buffer = src.read()
 
-        md5sum = hashlib.md5(buffer).hexdigest()
+        md5sum = hashlib.md5(buffer, usedforsecurity=False).hexdigest()
         target = dst_target / charm_file
         with target.open("wb") as dst:
             dst.write(buffer)

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -50,7 +50,7 @@ class LocalExecutor(ExecutorInterface):
         if not arch:
             arch = configbag.get_arch()
         cmd = "mv microk8s/microk8s_*_{0}.snap microk8s_latest_{0}.snap".format(arch)
-        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)  # nosec B602 - glob expansion requires shell
+        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)  # nosec B602
 
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None

--- a/jobs/microk8s/executors/local.py
+++ b/jobs/microk8s/executors/local.py
@@ -50,7 +50,7 @@ class LocalExecutor(ExecutorInterface):
         if not arch:
             arch = configbag.get_arch()
         cmd = "mv microk8s/microk8s_*_{0}.snap microk8s_latest_{0}.snap".format(arch)
-        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
+        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)  # nosec B602 - glob expansion requires shell
 
     def test_distro(
         self, distro, track_channel_to_upgrade, testing_track_channel, proxy=None


### PR DESCRIPTION
## Summary

Fix all 4 HIGH severity findings from the bandit SAST scan added in #1673.

## Findings & Fixes

### 1. B701 — jinja2 autoescape disabled (`cilib/html.py:12`)
- **CWE-94**: Code injection via template rendering
- **Fix**: Add `autoescape=True` to `jinja2.Environment()`

### 2. B602 — subprocess with `shell=True` (`cilib/run.py:34`)
- **CWE-78**: OS command injection
- **Fix**: Mark with `# nosec B602` — this is a CI runner that intentionally executes script commands via shell

### 3. B324 — weak MD5 hash (`jobs/build-charms/builder_launchpad.py:237`)
- **CWE-327**: Use of broken cryptographic algorithm
- **Fix**: Add `usedforsecurity=False` — MD5 is used for download checksum display, not security

### 4. B602 — subprocess with `shell=True` (`jobs/microk8s/executors/local.py:53`)
- **CWE-78**: OS command injection
- **Fix**: Mark with `# nosec B602` — glob pattern in `mv` command requires shell expansion

## Context
Found by bandit SAST scan added in #1673.