### PR TITLE
fix: rollback unsupported arguments for `hashlib`

### DIFF
--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -234,12 +234,12 @@ class LPBuildEntity(BuildEntity):
         with urllib.request.urlopen(dl_link) as src:
             buffer = src.read()
 
-        md5sum = hashlib.md5(buffer).hexdigest()
+        sha256sum = hashlib.sha256(buffer).hexdigest()
         target = dst_target / charm_file
         with target.open("wb") as dst:
             dst.write(buffer)
 
-        self.echo(f"Downloaded {build.title} md5sum={md5sum}")
+        self.echo(f"Downloaded {build.title} sha256sum={sha256sum}")
         return Artifact.from_charm(target)
 
     def _lp_amend_git_version(self):

--- a/jobs/build-charms/builder_launchpad.py
+++ b/jobs/build-charms/builder_launchpad.py
@@ -234,7 +234,7 @@ class LPBuildEntity(BuildEntity):
         with urllib.request.urlopen(dl_link) as src:
             buffer = src.read()
 
-        md5sum = hashlib.md5(buffer, usedforsecurity=False).hexdigest()
+        md5sum = hashlib.md5(buffer).hexdigest()
         target = dst_target / charm_file
         with target.open("wb") as dst:
             dst.write(buffer)


### PR DESCRIPTION
## Overview
Rollback unsupported `md5` API introduced in #1674 
---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
