### PR TITLE
chore: start building `1.36` snaps

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -20,7 +20,7 @@ K8S_STABLE_VERSION = "1.35"
 # we're working on the 1.31 GA. Set this value to '1.32' sometime between the
 # final RC and GA so we don't get pre-release builds (e.g. 1.31.1-alpha.0) in
 # our 1.31 tracks.
-K8S_NEXT_VERSION = "1.36"
+K8S_NEXT_VERSION = "1.37"
 
 # Lowest K8S SEMVER to process, this is usually K8S_STABLE_VERSION - 4
 K8S_STARTING_SEMVER = "1.28.0"
@@ -98,6 +98,7 @@ K8S_CRI_TOOLS_SEMVER = "1.19"
 
 # Kubernetes build source to go version map
 K8S_GO_MAP = {
+    "1.36": "go/1.26/stable",
     "1.35": "go/1.25/stable",
     "1.34": "go/1.24/stable",
     "1.33": "go/1.24/stable",
@@ -144,6 +145,7 @@ SNAP_K8S_TRACK_LIST = [
     ("1.33", ["1.33/stable", "1.33/candidate", "1.33/beta", "1.33/edge"]),
     ("1.34", ["1.34/stable", "1.34/candidate", "1.34/beta", "1.34/edge"]),
     ("1.35", ["1.35/stable", "1.35/candidate", "1.35/beta", "1.35/edge"]),
+    ("1.36", ["1.36/candidate", "1.36/beta", "1.36/edge"]),
 ]
 SNAP_K8S_TRACK_MAP = dict(SNAP_K8S_TRACK_LIST)
 


### PR DESCRIPTION
## Overview

Start building `1.36` snaps for Charmed Kubernetes

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
