### PR TITLE
fix: update default test distribution to Ubuntu 22.04

### DIFF
--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -226,7 +226,7 @@ class Microk8sSnap:
         channel_to_upgrade=None,
         track_to_upgrade=None,
         tests_branch=None,
-        distributions=["ubuntu:20.04"],
+        distributions=["ubuntu:22.04"],
         proxy=None,
     ):
         """


### PR DESCRIPTION
## Summary

Update the default test distribution from Ubuntu 20.04 to Ubuntu 22.04 in the microk8s release CI.

## Problem

Kubernetes 1.36 ([KEP-5573](https://github.com/kubernetes/enhancements/issues/5573)) sets `failCgroupV1=true` by default, causing kubelet to fatally exit on cgroup v1 hosts with:

```
failed to validate kubelet configuration, error: kubelet is configured to not run
on a host using cgroup v1. cgroup v1 support is unsupported and will be removed
in a future release
```

Ubuntu 20.04 uses cgroup v1 (`tmpfs` at `/sys/fs/cgroup/`), so the microk8s 1.36 release CI times out waiting for pods that will never be scheduled (kubelet never starts → no node registers → hostpath-provisioner never deploys → 6h timeout).

## Fix

Change the default `distributions` parameter in `test_cross_distro()` from `ubuntu:20.04` to `ubuntu:22.04`. Ubuntu 22.04 uses cgroup v2 (`cgroup2fs`) and works correctly with Kubernetes >= 1.35.

## Verification

Reproduced locally:
- **Ubuntu 20.04 VM + microk8s 1.36**: kubelet crashes immediately with cgroup v1 error, zero nodes/pods
- **Ubuntu 22.04 VM + microk8s 1.36**: all pods reach Running state including hostpath-provisioner

## References

- [KEP-5573: Remove cgroup v1 support](https://github.com/kubernetes/enhancements/issues/5573)
- [kubernetes/kubernetes#134298](https://github.com/kubernetes/kubernetes/pull/134298) — Set failCgroupV1 to true
- [K8s 1.31 blog: Moving cgroup v1 to maintenance mode](https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/)