### PR TITLE
fix: pin snapcraft channel for old microk8s LP build triggers

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -49,7 +49,7 @@ people_name = "microk8s-dev"
 # that still build on core20 (everything prior to 1.34). Snapcraft 9.x dropped
 # core20 support, and API-triggered builds ignore the recipe's pinned channel
 # unless it is passed explicitly.
-snapcraft_channel = "8.x/stable"
+legacy_snapcraft_channel = "8.x/stable"
 cachedir = os.getenv("WORKSPACE", default="/var/tmp/") + "/cache"
 creds = os.getenv("LPCREDS")
 github_repo = "github.com/canonical/microk8s"

--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -45,6 +45,11 @@ def get_tracks(all=False):
 
 snap_name = "microk8s"
 people_name = "microk8s-dev"
+# Snapcraft channel used when triggering Launchpad builds for MicroK8s tracks
+# that still build on core20 (everything prior to 1.34). Snapcraft 9.x dropped
+# core20 support, and API-triggered builds ignore the recipe's pinned channel
+# unless it is passed explicitly.
+snapcraft_channel = "8.x/stable"
 cachedir = os.getenv("WORKSPACE", default="/var/tmp/") + "/cache"
 creds = os.getenv("LPCREDS")
 github_repo = "github.com/canonical/microk8s"

--- a/jobs/microk8s/release-to-edge-on-new-upstream-release.py
+++ b/jobs/microk8s/release-to-edge-on-new-upstream-release.py
@@ -42,7 +42,7 @@ def trigger_lp_builders(track):
     if track_needs_legacy_snapcraft(track):
         # API-triggered builds ignore the recipe's pinned snapcraft channel
         # unless it is passed explicitly, so pin it for core20-based tracks.
-        build_kwargs["channels"] = {"snapcraft": configbag.snapcraft_channel}
+        build_kwargs["channels"] = {"snapcraft": configbag.legacy_snapcraft_channel}
     request = microk8s.requestBuilds(**build_kwargs)
     return request
 

--- a/jobs/microk8s/release-to-edge-on-new-upstream-release.py
+++ b/jobs/microk8s/release-to-edge-on-new-upstream-release.py
@@ -6,7 +6,7 @@ from snapstore import Microk8sSnap
 from launchpadlib.launchpad import Launchpad
 from lazr.restfulclient.errors import HTTPError
 from configbag import get_tracks
-from utils import upstream_release
+from utils import upstream_release, track_needs_legacy_snapcraft
 
 
 def trigger_lp_builders(track):
@@ -38,7 +38,12 @@ def trigger_lp_builders(track):
 
     # trigger build
     ubuntu = launchpad.distributions["ubuntu"]
-    request = microk8s.requestBuilds(archive=ubuntu.main_archive, pocket="Updates")
+    build_kwargs = {"archive": ubuntu.main_archive, "pocket": "Updates"}
+    if track_needs_legacy_snapcraft(track):
+        # API-triggered builds ignore the recipe's pinned snapcraft channel
+        # unless it is passed explicitly, so pin it for core20-based tracks.
+        build_kwargs["channels"] = {"snapcraft": configbag.snapcraft_channel}
+    request = microk8s.requestBuilds(**build_kwargs)
     return request
 
 

--- a/jobs/microk8s/utils.py
+++ b/jobs/microk8s/utils.py
@@ -3,6 +3,25 @@ import json
 import semver
 
 
+# Tracks prior to this MAJOR.MINOR build on core20, which is unsupported by
+# snapcraft 9.x, so they must pin to the legacy snapcraft channel.
+LEGACY_SNAPCRAFT_CEILING = (1, 34)
+
+
+def track_needs_legacy_snapcraft(track):
+    """Return True if the MicroK8s track must build with the legacy snapcraft.
+
+    Tracks prior to 1.34 build on core20, which is unsupported by snapcraft
+    9.x, so they must pin to the 8.x channel. The 'latest' track follows the
+    newest k8s release (>= 1.34) and uses the default snapcraft.
+    """
+    if track == "latest":
+        return False
+    major_minor = track.split("-")[0]  # strip '-strict' / '-eksd' suffix
+    major, minor = (int(part) for part in major_minor.split("."))
+    return (major, minor) < LEGACY_SNAPCRAFT_CEILING
+
+
 def upstream_release(release):
     if release.endswith("-eksd"):
         return upstream_eksd_release(release)


### PR DESCRIPTION
API-triggered Launchpad builds ignore the recipe's pinned snapcraft channel unless 'channels' is passed explicitly, so MicroK8s tracks prior to 1.34 (built on core20) were being built with snapcraft 9.x, which dropped core20 support and caused an endless build-failure loop.

Explicitly pass channels={"snapcraft": "8.x/stable"} when triggering builds for tracks prior to 1.34; 1.34+ and latest keep using the default snapcraft.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
