### PR TITLE
fix: pin snapcraft channel for CK snap LP build triggers

### DIFF
--- a/cilib/enums.py
+++ b/cilib/enums.py
@@ -28,6 +28,12 @@ K8S_STARTING_SEMVER = "1.28.0"
 # Supported arches
 K8S_SUPPORT_ARCHES = ["amd64", "ppc64el", "s390x", "arm64"]
 
+# Snapcraft channel used when building snaps based on legacy bases (e.g. core20).
+# The latest snapcraft (9.x) dropped core20 support, so Launchpad builds that
+# don't pin a snapcraft channel default to latest and fail endlessly. All current
+# CK snap tracks build on core20, so we pin every CK build to this channel.
+SNAPCRAFT_LEGACY_CHANNEL = "8.x/stable"
+
 # Supported charm arches
 K8S_CHARM_SUPPORT_ARCHES = ["amd64", "s390x", "arm64"]
 

--- a/cilib/lp.py
+++ b/cilib/lp.py
@@ -5,6 +5,7 @@ from retry.api import retry_call
 from lazr.restfulclient.errors import NotFound, PreconditionFailed
 from launchpadlib.launchpad import Launchpad
 from configparser import ConfigParser
+from cilib import enums
 import logging
 import os
 
@@ -114,6 +115,7 @@ class Client:
             snap.auto_build = True
             snap.auto_build_pocket = "Updates"
             snap.auto_build_archive = self.archive()
+            snap.auto_build_channels = {"snapcraft": enums.SNAPCRAFT_LEGACY_CHANNEL}
             snap.store_upload = True
             snap.store_name = name
             snap.store_series = self.snappy_series()
@@ -137,6 +139,7 @@ class Client:
                 auto_build=True,
                 auto_build_pocket="Updates",
                 auto_build_archive=self.archive(),
+                auto_build_channels={"snapcraft": enums.SNAPCRAFT_LEGACY_CHANNEL},
             )
         retry_call(
             snap.lp_save,

--- a/cilib/service/snap.py
+++ b/cilib/service/snap.py
@@ -310,4 +310,8 @@ class SnapService(DebugMixin):
         snap_recipe.completeAuthorization(
             discharge_macaroon=discharge_macaroon.serialize()
         )
-        snap_recipe.requestBuilds(archive=_client.archive(), pocket="Updates")
+        snap_recipe.requestBuilds(
+            archive=_client.archive(),
+            pocket="Updates",
+            channels={"snapcraft": enums.SNAPCRAFT_LEGACY_CHANNEL},
+        )


### PR DESCRIPTION
CK component snaps (kubectl, kube-apiserver, kubelet, etc.) build on the core20 base for all active tracks (1.31-1.37). The latest snapcraft (9.x) dropped core20 support, so Launchpad builds that don't pin a snapcraft channel default to latest and fail endlessly.

Pin every CK snap build to 8.x/stable in both code paths:
- requestBuilds() for explicitly API-triggered builds
- auto_build_channels on the recipe for Launchpad daily auto-builds

This mirrors the MicroK8s old-trigger fix, applied unconditionally since all current CK tracks are core20.

---
Mark below if this PR requires a job refresh (`jjb`) after merge:

- [ ] Needs `jjb` after merge

Please make sure to open PR's against the correct code:

- For integration tests, please make changes in `jobs/integration`
- For validation envs, `jobs/validate`
- For MicroK8s,`jobs/microk8s`
- For charm/bundle builds, `jobs/build-charms`
