### PR TITLE
release: add 1.36 to CI version matrix

### DIFF
--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -150,7 +150,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.35/beta
+          default: 1.36/beta
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:
@@ -158,7 +158,7 @@
     parameters:
       - string:
           name: snap_version
-          default: 1.35/edge
+          default: 1.36/edge
           description: channel for charmed-kubernetes snap used in deployment
 
 - parameter:

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -21,7 +21,7 @@
       - juju-lts
       - string:
           name: CK_VERSION
-          default: '1.35'
+          default: '1.36'
           description: |
             CK version to deploy. This will be used to set the snap track
             and to identify what k8s version is associated with the results.

--- a/jobs/sync-oci-images.yaml
+++ b/jobs/sync-oci-images.yaml
@@ -16,7 +16,7 @@
           default: 'runner-amd64'
       - string:
           name: version
-          default: '1.35'
+          default: '1.36'
           description: |
             CK version. This job will clone the cdk-addons release-`version` branch if one
             exists (otherwise 'main'), then process the image list for this `version`.

--- a/jobs/validate.yaml
+++ b/jobs/validate.yaml
@@ -73,14 +73,14 @@
     charm-channel:
       - edge:
           snap_versions:
+            - 1.36/edge
             - 1.35/edge
             - 1.34/edge
-            - 1.33/edge
       - stable:
           snap_versions:
+            - 1.35/stable
             - 1.34/stable
             - 1.33/stable
-            - 1.32/stable
           dow: '0'      # Sunday
     jobs:
       - 'validate-ck-{charm-channel}-{series}'
@@ -118,9 +118,9 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
             - 1.34/edge
-            - 1.33/edge
       - axis:
           type: user-defined
           name: series
@@ -179,8 +179,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.34/stable
             - 1.33/stable
-            - 1.32/stable
       - axis:
           type: user-defined
           name: arch
@@ -291,8 +291,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -333,8 +333,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -374,8 +374,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
       - axis:
           type: user-defined
           name: cloud
@@ -426,8 +426,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
       - axis:
           type: user-defined
           name: routing_mode
@@ -469,8 +469,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -510,8 +510,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -550,8 +550,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -590,8 +590,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -631,8 +631,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"
@@ -672,8 +672,8 @@
           type: user-defined
           name: snap_version
           values:
+            - 1.36/edge
             - 1.35/edge
-            - 1.34/edge
     builders:
       - set-env:
           JOB_SPEC_DIR: "jobs/validate"


### PR DESCRIPTION
Updates CI job defaults and version matrices to include Charmed Kubernetes 1.36.

Changes:
- `jobs/ci-master.yaml`: bump `snap_version` defaults to `1.36/beta` and `1.36/edge`
- `jobs/validate.yaml`: add `1.36/edge` to edge matrix (drop `1.33/edge`); add `1.35/stable` to stable matrix (drop `1.32/stable`)
- `jobs/cncf-conformance.yaml`: bump `CK_VERSION` default to `1.36`
- `jobs/sync-oci-images.yaml`: bump `version` default to `1.36`

Reference: https://github.com/charmed-kubernetes/jenkins/pull/1463