### PR TITLE
chore: build cdk-addons for 1.35 and 1.36

### DIFF
--- a/jobs/build-snaps.yaml
+++ b/jobs/build-snaps.yaml
@@ -103,7 +103,7 @@
 - project:
     name: build-release-snaps
     arch: 'amd64'
-    version: ['1.31', '1.32', '1.33', '1.34']
+    version: ['1.33', '1.34', '1.35', '1.36']
     jobs:
       - 'build-release-cdk-addons-{version}'
 


### PR DESCRIPTION
Updates the `build-release-snaps` job to add 1.35 and 1.36 and drop the now-EOL 1.31 and 1.32 versions.

```
version: ['1.33', '1.34', '1.35', '1.36']
```

Note: 1.35 was skipped in a previous bump, this catches it up alongside 1.36.